### PR TITLE
ci: update docker build command

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -12,12 +12,8 @@ jobs:
     if: |
        startsWith(github.ref_name, 'faucet@') ||
        startsWith(github.ref_name, 'wardend@') ||
-       startsWith(github.ref_name, 'web@') ||
-       startsWith(github.ref_name, 'wardenkms@') ||
-       startsWith(github.ref_name, 'fwardenmodel@') ||
-       startsWith(github.ref_name, 'mpcwardenmodel@') ||
-       startsWith(github.ref_name, 'mpc-relayer@') ||
-       startsWith(github.ref_name, 'relayer-eth@')
+       startsWith(github.ref_name, 'spaceward@') ||
+       startsWith(github.ref_name, 'wardenkms@')
     permissions:
       id-token: write
       contents: read
@@ -40,12 +36,29 @@ jobs:
           echo "ECR_REPO=${{ vars.ECR_REGISTRY }}.dkr.ecr.eu-west-1.amazonaws.com/wardenprotocol/production/$(echo ${{ github.ref_name }} | awk -F'@' '{print $1}')" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Build and Push (SpaceWard)
+        if: ${{ env.REF == 'spaceward' }}
+        uses: docker/build-push-action@v4
+        with:
+          context: ./spaceward
+          build-args: |
+             SERVICE=${{ env.REF }}
+             GIT_SHA=${{ env.COMMIT_SHA }}
+             BUILD_DATE=${{ env.BUILD_DATE }}
+          push: true
+          tags: |
+            ${{ env.ECR_REPO }}:${{ env.SHORT_SHA }}
+            ${{ env.ECR_REPO }}:${{ env.TAG }}
+            ${{ env.ECR_REPO }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Build and Push
         id: image
+        if: ${{ env.REF != 'spaceward' }}
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ./docker/Dockerfile-${{ env.REF }}
+          target: ${{ env.REF }}
           build-args: |
              SERVICE=${{ env.REF }}
              GIT_SHA=${{ env.COMMIT_SHA }}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "blockchain",
     "keychain",
     "wardenmodel",
-    "web"
+    "spaceward"
   ],
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",


### PR DESCRIPTION
After my latest refactorings, we now have a single Dockerfile (with separate `target`s inside). This PR updates the github action that builds and pushes the image to reflect that.

The notable exception is the SpaceWard app, which I decided to keep separate and has its own Dockerfile in `spaceward/Dockerfile`, since it doesn't require the full repo as context. In the future this might change, but I want to discuss pro/cons with the frontend team first.