### PR TITLE
feat: prepare local devnet environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@
 # Each target is a separate image that can be built specifying the --target
 # flag when using `docker build`.
 
-FROM --platform=linux/amd64 golang:1.21-alpine3.18 AS build-env
-RUN apk add --update git build-base linux-headers
+FROM golang:1.21-alpine3.18 AS build-env
 WORKDIR /build
+ENV CGO_ENABLED=0
 
 ## wardend
 FROM build-env AS wardend-build
@@ -21,15 +21,13 @@ RUN --mount=type=bind,source=.,target=.,readonly\
     go build -o /build/faucet ./warden/cmd/faucet
 
 
-FROM alpine:3.18.0 AS wardend
-RUN apk add --update ca-certificates jq
-WORKDIR /
+FROM alpine:3.18 AS wardend
 COPY --from=wardend-build /build/wardend /usr/bin/wardend
 CMD ["wardend", "start"]
 
 
 ## faucet
-FROM alpine:3.18.0 AS faucet
+FROM alpine:3.18 AS faucet
 COPY --from=wardend-build /build/wardend /usr/bin/wardend
 COPY --from=wardend-build /build/faucet /usr/bin/faucet
 EXPOSE 8000
@@ -45,11 +43,8 @@ RUN --mount=type=bind,source=.,target=.,readonly\
     go build -o /build/wardenkms ./keychain/cmd/wardenkms
 
 
-FROM scratch AS wardenkms
-COPY --from=wardenkms-build /build/wardenkms .
-COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-USER svcuser
-EXPOSE 8080
+FROM alpine:3.18 AS wardenkms
+COPY --from=wardenkms-build /build/wardenkms /
 ENTRYPOINT ["/wardenkms"]
 
 ## spaceward

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ FROM alpine:3.18 AS wardend
 COPY --from=wardend-build /build/wardend /usr/bin/wardend
 CMD ["wardend", "start"]
 
+FROM wardend AS wardend-debug
+WORKDIR /root/.warden
+ADD --checksum=sha256:25c62530d273b7bc5218b62c1eaa42fdd17639189baf767505580169a33489c5 https://github.com/warden-protocol/snapshots/raw/main/devnet.tar.gz .
+RUN tar -xf devnet.tar.gz && rm devnet.tar.gz
 
 ## faucet
 FROM alpine:3.18 AS faucet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  validator-1:
+    build:
+      context: .
+      target: wardend-debug
+    ports:
+      - "0.0.0.0:26656:26656"
+      - "0.0.0.0:26657:26657"
+      - "0.0.0.0:9090:9090"
+      - "0.0.0.0:1317:1317"
+    environment:
+      WARDEND_API_ENABLE: true
+      WARDEND_API_ADDRESS: tcp://0.0.0.0:1317
+      WARDEND_API_ENABLED_UNSAFE_CORS: true
+      WARDEND_GRPC_ADDRESS: 0.0.0.0:9090
+      WARDEND_RPC_LADDR: tcp://0.0.0.0:26657
+      WARDEND_RPC_CORS_ALLOWED_ORIGINS: "*"
+      WARDEND_MINIMUM_GAS_PRICES: "0uward"
+
+  faucet:
+    build:
+      context: .
+      target: faucet
+    ports:
+      - "8000:8000"
+    environment:
+      NODE: http://host.docker.internal:26657
+      MNEMONIC: exclude try nephew main caught favorite tone degree lottery device tissue tent ugly mouse pelican gasp lava flush pen river noise remind balcony emerge
+
+  wardenkms:
+    build:
+      context: .
+      target: wardenkms
+    environment:
+      WARDENKMS_KEYCHAIN: wardenkeychain14a2hpadpsy9h55wuja0
+      WARDENKMS_CHAINID: wardenprotocol
+      WARDENKMS_MNEMONIC: exclude try nephew main caught favorite tone degree lottery device tissue tent ugly mouse pelican gasp lava flush pen river noise remind balcony emerge
+      WARDENKMS_WARDENURL: host.docker.internal:9090
+
+  spaceward:
+    build:
+      context: .
+      target: spaceward
+    ports:
+      - "8080:8080"
+    environment:
+      FAUCET_URL: http://127.0.0.1:8000
+      WARDEN_RPC_URL: http://127.0.0.1:26657
+      WARDEN_REST_URL: http://127.0.0.1:1317
+      WARDEN_CHAIN_NAME: Warden Protocol (local)

--- a/warden/cmd/faucet/faucet.go
+++ b/warden/cmd/faucet/faucet.go
@@ -95,37 +95,19 @@ func NewClient(ctx context.Context, cfg Config) (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) baseCmd() string {
-	// Build a string like this:
-	// wardend --node tcp://localhost:26657 --fees 20nward
-	return strings.Join([]string{
-		c.cfg.CliName,
-		"--node",
-		c.cfg.Node,
-		"--gas-prices",
-		c.cfg.Fees,
-		"--from",
-		c.cfg.AccountName,
-		"--keyring-backend",
-		c.cfg.KeyringBackend,
-		"--chain-id",
-		c.cfg.ChainID,
-	}, " ")
-}
-
 func (c *Client) setupNewAccount(ctx context.Context) (Out, error) {
 	// echo $mnemonic | $baseCmd keys add $SK1 --recover
 	cmd := strings.Join([]string{
 		"echo",
 		c.cfg.Mnemonic,
 		"|",
-		c.baseCmd(),
+		c.cfg.CliName,
 		"keys",
+		"--keyring-backend",
+		c.cfg.KeyringBackend,
 		"add",
 		c.cfg.AccountName,
 		"--recover",
-		"--keyring-backend",
-		c.cfg.KeyringBackend,
 	}, " ")
 	return e(ctx, cmd)
 }
@@ -134,7 +116,7 @@ func (c *Client) Send(ctx context.Context, dest string) (Out, error) {
 	// $baseCmd tx bank send shulgin warden1f6zkpwezlw58mssh0qat8d0dvwu3qpw67p83za 100000000nward --yes
 	log.Printf("sending %s to %s", c.cfg.SendDenom, dest)
 	cmd := strings.Join([]string{
-		c.baseCmd(),
+		c.cfg.CliName,
 		"tx",
 		"bank",
 		"send",
@@ -148,6 +130,8 @@ func (c *Client) Send(ctx context.Context, dest string) (Out, error) {
 		c.cfg.ChainID,
 		"--node",
 		c.cfg.Node,
+		"--gas-prices",
+		c.cfg.Fees,
 		"-o",
 		"json",
 	}, " ")


### PR DESCRIPTION
This PR:
- fixes some leftovers in the faucet that made it incompatible with the new `wardend` binary, I didn't notice before as I had two `wardend` binaries in my computer and it was using the older one
- updated all docker images to be alpine and cleaned a bit things up, this makes it easier to build images both for arm and amd64 cpus
- introduce a `docker-compose.yml`, so anyone can spin up an entire local devnet by just `docker compose up`. It's also possible to spin up *some* of the services (i.e. I can run the entire stack but wardenkms if I'm debugging it and I  want to run it outside of docker).

The local devnet is based on the devnet snapshot published at: https://github.com/warden-protocol/snapshots. This snapshot includes a validator account and an initial keychain that must match the environment variables of `docker-compose.yml`.