### PR TITLE
chore(spaceward): replace Infura Ethereum RPC endpoint with PublicNode's

### DIFF
--- a/spaceward/src/routes/ethereum.tsx
+++ b/spaceward/src/routes/ethereum.tsx
@@ -12,7 +12,7 @@ import useWardenWarden from "@/hooks/useWardenWarden";
 import { Key, WalletType } from "wardenprotocol-warden-client-ts/lib/warden.warden/rest";
 import { useClient } from "@/hooks/useClient";
 
-const url = "https://sepolia.infura.io/v3/6484e0cc3e0447e386fb42ce19ea7155";
+const url = "https://ethereum-sepolia-rpc.publicnode.com";
 
 const provider = new ethers.JsonRpcProvider(url);
 

--- a/spaceward/src/routes/walletconnect.tsx
+++ b/spaceward/src/routes/walletconnect.tsx
@@ -197,7 +197,7 @@ async function approveSession(w: IWeb3Wallet, spaceAddr: string, proposal: any) 
   }
 }
 
-const url = "https://sepolia.infura.io/v3/6484e0cc3e0447e386fb42ce19ea7155";
+const url = "https://ethereum-sepolia-rpc.publicnode.com";
 
 const provider = new ethers.JsonRpcProvider(url);
 


### PR DESCRIPTION
We're going to use publicnode.com for the time being.