### PR TITLE
fix(warden): ID not being set correctly for some entities

### DIFF
--- a/warden/repo/seqcollection.go
+++ b/warden/repo/seqcollection.go
@@ -1,8 +1,14 @@
 package repo
 
 import (
+	"fmt"
+
 	"cosmossdk.io/collections"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var (
+	ErrInvalidID = fmt.Errorf("invalid ID")
 )
 
 // SeqCollection is an opinionated collection built on top of Cosmos SDK's Collections that uses a Sequence as ID for the Map.
@@ -28,16 +34,19 @@ func (c SeqCollection[V]) Get(ctx sdk.Context, id uint64) (V, error) {
 }
 
 func (c SeqCollection[V]) Set(ctx sdk.Context, id uint64, obj V) error {
+	if id == 0 {
+		return ErrInvalidID
+	}
 	return c.Map.Set(ctx, id, obj)
 }
 
-func (c SeqCollection[V]) Append(ctx sdk.Context, obj V) (uint64, error) {
+func (c SeqCollection[V]) Append(ctx sdk.Context, obj *V) (uint64, error) {
 	id, err := c.next(ctx)
 	if err != nil {
 		return 0, err
 	}
-	c.setId(&obj, id)
-	return id, c.Map.Set(ctx, id, obj)
+	c.setId(obj, id)
+	return id, c.Map.Set(ctx, id, *obj)
 }
 
 func (c SeqCollection[V]) next(ctx sdk.Context) (uint64, error) {

--- a/warden/x/intent/keeper/actions.go
+++ b/warden/x/intent/keeper/actions.go
@@ -125,7 +125,7 @@ func (k Keeper) AddAction(ctx sdk.Context, creator string, msg sdk.Msg, intentID
 
 	// create action object
 	timestamp := k.getBlockTime(ctx)
-	act := types.Action{
+	act := &types.Action{
 		Status:    types.ActionStatus_ACTION_STATUS_PENDING,
 		Approvers: nil,
 		IntentId:  intentID,
@@ -137,7 +137,7 @@ func (k Keeper) AddAction(ctx sdk.Context, creator string, msg sdk.Msg, intentID
 	}
 
 	// add initial approver
-	pol, err := k.IntentForAction(ctx, act)
+	pol, err := k.IntentForAction(ctx, *act)
 	if err != nil {
 		return nil, err
 	}
@@ -156,5 +156,5 @@ func (k Keeper) AddAction(ctx sdk.Context, creator string, msg sdk.Msg, intentID
 		return nil, err
 	}
 
-	return &act, nil
+	return act, nil
 }

--- a/warden/x/intent/keeper/msg_server_new_intent.go
+++ b/warden/x/intent/keeper/msg_server_new_intent.go
@@ -39,7 +39,7 @@ func (k msgServer) NewIntent(goCtx context.Context, msg *types.MsgNewIntent) (*t
 		Name:   msg.Name,
 		Intent: msg.Intent,
 	}
-	id, err := k.intents.Append(ctx, intentPb)
+	id, err := k.intents.Append(ctx, &intentPb)
 	if err != nil {
 		return nil, err
 	}

--- a/warden/x/warden/keeper/msg_server_add_space_owner.go
+++ b/warden/x/warden/keeper/msg_server_add_space_owner.go
@@ -39,6 +39,10 @@ func (k msgServer) AddSpaceOwner(goCtx context.Context, msg *types.MsgAddSpaceOw
 	}
 
 	res, err := k.AddOwnerActionHandler(ctx, *act, &cdctypes.Any{})
+	if err != nil {
+		return nil, err
+	}
+
 	return res.(*types.MsgAddSpaceOwnerResponse), err
 }
 

--- a/warden/x/warden/keeper/msg_server_new_key_request.go
+++ b/warden/x/warden/keeper/msg_server_new_key_request.go
@@ -91,7 +91,7 @@ func (k msgServer) NewKeyRequestActionHandler(ctx sdk.Context, act intenttypes.A
 		}
 	}
 
-	req := types.KeyRequest{
+	req := &types.KeyRequest{
 		Creator:      msg.Creator,
 		SpaceAddr:    msg.SpaceAddr,
 		KeychainAddr: msg.KeychainAddr,

--- a/warden/x/warden/keeper/msg_server_new_sign_transaction_request.go
+++ b/warden/x/warden/keeper/msg_server_new_sign_transaction_request.go
@@ -106,7 +106,7 @@ func (k msgServer) NewSignTransactionRequestActionHandler(ctx sdk.Context, act i
 	ctx.Logger().Debug("parsed layer 1 tx", "wallet", w, "tx", tx)
 
 	// generate signature request
-	signatureRequest := types.SignRequest{
+	signatureRequest := &types.SignRequest{
 		Creator:        msg.Creator,
 		KeyId:          msg.KeyId,
 		KeyType:        key.Type,
@@ -118,7 +118,7 @@ func (k msgServer) NewSignTransactionRequestActionHandler(ctx sdk.Context, act i
 		return nil, err
 	}
 
-	id, err := k.signTransactionRequests.Append(ctx, types.SignTransactionRequest{
+	id, err := k.signTransactionRequests.Append(ctx, &types.SignTransactionRequest{
 		Creator:             msg.Creator,
 		SignRequestId:       signRequestID,
 		KeyId:               msg.KeyId,

--- a/warden/x/warden/keeper/msg_server_new_signature_request.go
+++ b/warden/x/warden/keeper/msg_server_new_signature_request.go
@@ -109,7 +109,7 @@ func (k msgServer) NewSignatureRequestActionHandler(ctx sdk.Context, act intentt
 		}
 	}
 
-	req := types.SignRequest{
+	req := &types.SignRequest{
 		Creator:        msg.Creator,
 		KeyId:          msg.KeyId,
 		KeyType:        key.Type,


### PR DESCRIPTION
`SeqCollection[V].Append()` tries to change the ID of the passed object, but it was bugged as it was taking the object passed by value, effectively not changing it also for the caller.

So, in the db the entity was stored correctly, but if the caller tried to use the ID right after calling Append(), it was unset.

This PR fixes this bug that manifested in some cases during Action execution.