### PR TITLE
fix(spaceward): prevent initial HTTP broken requests

### DIFF
--- a/spaceward/src/def-hooks/useAsset.ts
+++ b/spaceward/src/def-hooks/useAsset.ts
@@ -4,6 +4,8 @@ import { useAddressContext } from "./useAddressContext";
 export const useAsset = (denom: string) => {
   const { address } = useAddressContext();
   const { QueryBalance } = useCosmosBankV1Beta1();
-  const query = QueryBalance(address, { denom }, {});
+  const query = QueryBalance(address, { denom }, {
+    enabled: !!address,
+  });
   return { balance: query.data?.balance, isLoading: query.isLoading };
 };

--- a/spaceward/src/routes/root.tsx
+++ b/spaceward/src/routes/root.tsx
@@ -30,7 +30,7 @@ export default function Root() {
 	const { QuerySpacesByOwner } = useWardenWarden();
 	const { data: spacesQuery } = QuerySpacesByOwner(
 		{ owner: address },
-		{},
+		{ enabled: !!address },
 		10
 	);
 	const spacecount = spacesQuery?.pages[0].spaces?.length || 0;


### PR DESCRIPTION
When the app was launched for the first time, it was making a bunch of HTTP requests with a broken query because the address of the user wasn't known yet (it hadn't connected the wallet yet).

This fix prevents these useless HTTP requests.