### PR TITLE
fix(spaceward): wrong Any value serialization when creating a new Intent

### DIFF
--- a/spaceward/src/components/new-intent-button.tsx
+++ b/spaceward/src/components/new-intent-button.tsx
@@ -15,7 +15,7 @@ import { monitorTx } from "@/hooks/keplr";
 import { useAddressContext } from "@/def-hooks/useAddressContext";
 import { useClient } from "@/hooks/useClient";
 import { useToast } from "./ui/use-toast";
-import { IntentParticipant } from "wardenprotocol-warden-client-ts/lib/warden.intent/types/warden/intent/intent";
+import { BoolparserIntent, IntentParticipant } from "wardenprotocol-warden-client-ts/lib/warden.intent/types/warden/intent/intent";
 
 function NewIntentButton() {
 	const { address } = useAddressContext();
@@ -47,19 +47,18 @@ function NewIntentButton() {
 			});
 		});
 
-		const client = useClient();
-
 		await monitorTx(
 			sendMsgNewIntent({
 				value: {
 					creator,
 					name,
-					intent: client.WardenIntent.tx.boolparserIntent({
-						value: {
+					intent: {
+						typeUrl: "/warden.intent.BoolparserIntent",
+						value: BoolparserIntent.encode({
 							definition,
 							participants: participantsList,
-						},
-					}),
+						}).finish(),
+					},
 				},
 			}),
 			toast


### PR DESCRIPTION
I was mixing two different ways of handling `Any` values (the fact that I had to use `client.something.tx` was a hint).

I found this other way of doing it while maintaining the type safety, there's a little boilerplate around it (you need to manually specify `typeUrl`, and manually call `YourType.encode(..).finish()`) but I think it's reasonable. We don't want to use `Any` too much anyway.

Closes [SWA-37]

[SWA-37]: https://warden-dev.atlassian.net/browse/SWA-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ