### PR TITLE
fix(warden): prevent common invalid intents definitions

### DIFF
--- a/warden/x/intent/types/intent.go
+++ b/warden/x/intent/types/intent.go
@@ -37,8 +37,23 @@ func UnpackIntent(cdc codec.BinaryCodec, intentPb *Intent) (intent.Intent, error
 
 var _ (intent.Intent) = (*BoolparserIntent)(nil)
 
-func (*BoolparserIntent) Validate() error {
-	// TODO validate definition syntax, and that all participants are in the intent
+func (p *BoolparserIntent) Validate() error {
+	if p.Definition == "" {
+		return fmt.Errorf("definition is empty")
+	}
+
+	for _, participant := range p.Participants {
+		if participant.Address == "" {
+			return fmt.Errorf("participant address is empty")
+		}
+	}
+
+	for _, participant := range p.Participants {
+		if !strings.Contains(p.Definition, participant.Abbreviation) {
+			return fmt.Errorf("participant abbreviation not found in definition")
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds some basic validation for Boolparser intents.

Note: this validation doesn't exclude *all* possible invalid definitions, just some of them.