### PR TITLE
ci: add a button to deploy services to alfama

### DIFF
--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -1,0 +1,65 @@
+name: Deploy image
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: 'Env to deploy to'
+        required: true
+        type: choice
+        options:
+          - alfama
+      service_name:
+        description: 'Service'
+        required: true
+        type: choice
+        options:
+          - spaceward
+      image_tag:
+        description: 'Docker image tag (e.g the short commit SHA on main)'
+        required: true
+
+env:
+  env: ${{ github.event.inputs.env }}
+  service_name: ${{ github.event.inputs.service_name }}
+  image_tag: ${{ github.event.inputs.image_tag }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: 'Clone Helm repository'
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ vars.HELM_REPOSITORY }}
+          ref: 'main'
+          token: ${{ secrets.PAT }}
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Update kube config
+        run: aws eks update-kubeconfig --name $EKS_CLUSTER_NAME --region $AWS_REGION
+      - uses: azure/setup-helm@v3
+        with:
+          version: 'v3.12.0'
+      - name: Update Helm image.tag
+        run: |
+          helm upgrade \
+           ${{ env.service_name }} \
+           -n ${{ env.env }} \
+           --reuse-values \
+           --set image.tag=${{ env.image_tag }} \
+           ./charts/${{ env.service_name }}/
+      - name: send telegram message on push
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          message: |
+            ✅ Deployed to ${{ env.env }} environment
+            Service: ${{ env.service_name }}
+            Image tag: ${{ env.image_tag }}


### PR DESCRIPTION
I'd like to have "on click deployments" on testnets. For now, specifically for SpaceWard on Alfama.

In draft because it requires some work on helm charts.