### PR TITLE
docs: change license for SpaceWard

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ out the documentation website at: https://docs.wardenprotocol.org/.
 
 ## License
 
-This project is released under the terms of the Apache 2.0 License - see
-[LICENSE](./LICENSE) for details.
+With the exception of the SpaceWard folder, this project is released under the
+terms of the Apache 2.0 License - see [LICENSE](./LICENSE) for details.
 
-This project is based on the work made by Qredo on [Fusion
-Chain](https://github.com/qredo/fusionchain) and released under the Apache 2
-license. See [NOTICE](./NOTICE) for more details.
+Elements of this project are based on the work made by Qredo Ltd on [Fusion
+Chain](https://github.com/qredo/fusionchain) and were released under the Apache
+2 license. See [NOTICE](./NOTICE) for more details.
 

--- a/spaceward/LICENSE
+++ b/spaceward/LICENSE
@@ -1,0 +1,68 @@
+SpaceWard Non-Commercial License
+
+V.1 dated 01 March 2023
+
+This license contains the terms and conditions under which Warden Labs (the
+"Company") makes available its Software. Your use of the Software is subject to
+these terms and conditions.
+
+Company grants you (the "Licensee") a license to use, modify, and redistribute
+the Software, but only (a) for Non-Commercial Use, or (b) for Commercial Use
+only on the Designated Blockchains.
+
+If the Licensee makes available a copy of the Software to any third party, the
+Software must be subject to the terms of this license only, and the Licensee
+must provide a copy of this license to that third party. All restrictions and
+conditions of this license apply to the Software or any portion or modification
+of the Software made under this license and any previous versions of the
+Software.
+
+The Licensee must ensure that any third party who gets a copy of any part of
+the Software from the Licensee also gets a copy of the terms of this license or
+the respective license URL, as well as copies of any plain-text lines beginning
+with Required Notice that the licensor provided with the software. For example:
+"Required Notice: Copyright Warden Labs".
+
+These terms do not allow the Licensee to sublicense or transfer any of the
+Licensee's rights to anyone else. These terms do not imply any other licenses
+not expressly granted in this license.
+
+If the Licensee violates any of these terms or uses the Software in a way not
+authorized under this license, the license granted to the Licensee ends
+immediately. If the Licensee makes, or authorizes any other person to make, any
+written claim that the Software, or any other Warden Labs Product (as defined
+below), infringes or contributes to the infringement of any patent, all rights
+granted to the Licensee under this license end immediately.
+
+In accordance with applicable law, the Software is provided AS IS, without any
+warranty or condition, and Company will not be liable to the Licensee for any
+damages arising out of these terms or the use or nature of the Software, under
+any kind of legal claim.
+
+Terms in this license are used, and shall be interpreted, as follows:
+
+"Software" means the software developed by the Company, which is the
+implementation of the SpaceWard application available at
+https://github.com/warden-protocol/wardenprotocol/tree/main/spaceward as may be
+updated from time to time.
+
+"Designated Blockchains" refer to the version of the digital blockchain ledger
+that, at any given time, is recognized as canonical in accordance with the
+blockchain consensus. The initial Designated Blockchains shall be the Warden
+Protocol only, with reference to
+https://github.com/warden-protocol/wardenprotocol/tree/main as may be updated
+from time to time.
+
+"Non-Commercial Use" means academic, scientific, or research and development
+use, or evaluating the Software (such as through auditing), but does not
+include the creation of an application that facilitates any transaction of
+economic value.
+
+"Commercial Use" is any use that is not a Non-Commercial Use.
+
+To "use" means any use, modification, distribution or other exploitation of the
+Software or any part of it.
+
+A "Warden Labs Product" is any product or service offered by the Company or its
+affiliates.
+


### PR DESCRIPTION
We are moving SpaceWard to a non-commercial license.