### PR TITLE
Update flag in creating-validator.md for reuqesting tokens from faucet

### DIFF
--- a/docs/docs/validate/creating-validator.md
+++ b/docs/docs/validate/creating-validator.md
@@ -44,7 +44,7 @@ created address from the first step beforehand.
 You can obtain testnet tokens to fund your address from our WARD faucet:
 
 ```
-curl --json '{"address": "<your-address>"}' https://faucet.alfama.wardenprotocol.org
+curl --data '{"address": "<your-address>"}' https://faucet.alfama.wardenprotocol.org
 ```
 
 You can verify your balance with this command:


### PR DESCRIPTION
Added data flag in while creating the validator

Previous, while creating validator and requesting tokens from faucet with below command

```curl --json '{"address": "<your-address>"}' https://f
<img width="1437" alt="Screenshot 2024-03-12 at 12 55 30 AM" src="https://github.com/warden-protocol/wardenprotocol/assets/61224737/44ef7f76-8e65-41d3-ad86-eed511c17aa3">
aucet.alfama.wardenprotocol.org

``` 
was not working as --json should be replaced with --data 

Expected command: 

curl --data '{"address":"<your address>"}' https://faucet.alfama.wardenprotocol.org/

