### PR TITLE
ci: enable Docker builds on push to release/* branches

### DIFF
--- a/.github/workflows/spaceward.yml
+++ b/.github/workflows/spaceward.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: 'spaceward/'
 
   build-and-push:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
     needs: [build]
     uses: ./.github/workflows/build_push.yml
     with:

--- a/.github/workflows/wardend.yml
+++ b/.github/workflows/wardend.yml
@@ -41,7 +41,7 @@ jobs:
         run: go test -race -v ${{ env.modules }}
 
   build-and-push:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
     needs: [lint, unit-test]
     uses: ./.github/workflows/build_push.yml
     with:
@@ -49,7 +49,7 @@ jobs:
     secrets: inherit
 
   build-and-push-faucet:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
     needs: [lint, unit-test]
     uses: ./.github/workflows/build_push.yml
     with:

--- a/.github/workflows/wardenkms.yml
+++ b/.github/workflows/wardenkms.yml
@@ -38,7 +38,7 @@ jobs:
         run: go test -race -v ./cmd/wardenkms/...
 
   build-and-push:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
     needs: [lint, unit-test]
     uses: ./.github/workflows/build_push.yml
     with:


### PR DESCRIPTION
Build docker images from release/* branches as well, not just from main.

We'll maintain a **short-lived** release/v0.1.x branch for the current Alfama testnet that is currently live. Main development with breaking changes will continue on the main branch.