### PR TITLE
docs: missing quote in JSON example

### DIFF
--- a/docs/docs/validate/creating-validator.md
+++ b/docs/docs/validate/creating-validator.md
@@ -76,7 +76,7 @@ Then, create a file named `validator.json` with the following content:
 ```
 {    
     "pubkey": {"@type":"/cosmos.crypto.ed25519.PubKey","key":"lR1d7YBVK5jYijOfWVKRFoWCsS4dg3kagT7LB9GnG8I="},
-    "amount": "1000000uward,
+    "amount": "1000000uward",
     "moniker": "your-node-moniker",
     "identity": "eqlab testnet validator",
     "website": "optional website for your validator",


### PR DESCRIPTION
Typo line 79 (") missing