### PR TITLE
feat(keychain-sdk): batch multiple requests into a single transaction

### DIFF
--- a/go-client/tx_client.go
+++ b/go-client/tx_client.go
@@ -23,14 +23,12 @@ import (
 // TxClient can read/write transactions to wardend and endpoints provided by the treasury module.
 type TxClient struct {
 	*RawTxClient
-	*WardenTxClient
 }
 
 // NewTxClient returns a TxClient.
 func NewTxClient(id Identity, chainID string, c *grpc.ClientConn, accountFetcher AccountFetcher) *TxClient {
 	raw := NewRawTxClient(id, chainID, c, accountFetcher)
 	return &TxClient{
-		RawTxClient:    raw,
-		WardenTxClient: NewWardenTxClient(raw),
+		RawTxClient: raw,
 	}
 }

--- a/go-client/tx_identity.go
+++ b/go-client/tx_identity.go
@@ -60,9 +60,6 @@ func NewIdentityFromSeed(derivationPath, seedPhrase string) (Identity, error) {
 
 	// Generate a private key object from the bytes
 	privKey, _ := btcec.PrivKeyFromBytes(derivedKey)
-	if err != nil {
-		return Identity{}, fmt.Errorf("failed to generate private key: %w", err)
-	}
 
 	// Convert the public key to a Cosmos secp256k1.PublicKey
 	cosmosPrivKey := &secp256k1.PrivKey{

--- a/go-client/tx_warden.go
+++ b/go-client/tx_warden.go
@@ -1,137 +1,68 @@
-// Copyright 2024
-//
-// This file includes work covered by the following copyright and permission notices:
-//
-// Copyright 2023 Qredo Ltd.
-// Licensed under the Apache License, Version 2.0;
-//
-// This file is part of the Warden Protocol library.
-//
-// The Warden Protocol library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the Warden Protocol library. If not, see https://github.com/warden-protocol/wardenprotocol/blob/main/LICENSE
 package client
 
 import (
-	"context"
-	"fmt"
-
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/warden-protocol/wardenprotocol/warden/x/warden/types"
 )
 
-// WardenTxClient contains a raw tx client.
-type WardenTxClient struct {
-	c *RawTxClient
+type KeyRequestFulfilment struct {
+	RequestID uint64
+	PublicKey []byte
 }
 
-// NewWardenTxClient returns a WardenTxClient.
-func NewWardenTxClient(c *RawTxClient) *WardenTxClient {
-	return &WardenTxClient{c: c}
+func (r KeyRequestFulfilment) Msg(creator string) sdk.Msg {
+	return &types.MsgUpdateKeyRequest{
+		Creator:   creator,
+		RequestId: r.RequestID,
+		Status:    types.KeyRequestStatus_KEY_REQUEST_STATUS_FULFILLED,
+		Result:    types.NewMsgUpdateKeyRequestKey(r.PublicKey),
+	}
 }
 
-// FulfilKeyRequest completes a key request writing the public key bytes to wardend. Note that the sender must be authorized to submit transactions
-// for the keychain corresponding to the requestID. The transaction will be rejected if the WardenTxClient does not have the correct identity address.
-func (c *WardenTxClient) FulfilKeyRequest(ctx context.Context, requestID uint64, publicKey []byte) error {
-	status := types.KeyRequestStatus_KEY_REQUEST_STATUS_FULFILLED
-	result := types.NewMsgUpdateKeyRequestKey(publicKey)
-
-	msg := &types.MsgUpdateKeyRequest{
-		Creator:   c.c.Identity.Address.String(),
-		RequestId: requestID,
-		Status:    status,
-		Result:    result,
-	}
-
-	txBytes, err := c.c.BuildTx(ctx, DefaultGasLimit, DefaultFees, msg)
-	if err != nil {
-		return fmt.Errorf("build tx: %w", err)
-	}
-
-	if err = c.c.SendWaitTx(ctx, txBytes); err != nil {
-		return fmt.Errorf("send wait tx: %w", err)
-	}
-
-	return nil
+type KeyRequestRejection struct {
+	RequestID uint64
+	Reason    string
 }
 
-// RejectKeyRequest is similar to FulfilKeyRequest, but instead rejects the key request with the provided reason.
-func (c *WardenTxClient) RejectKeyRequest(ctx context.Context, requestID uint64, reason string) error {
-	status := types.KeyRequestStatus_KEY_REQUEST_STATUS_REJECTED
-	result := types.NewMsgUpdateKeyRequestReject(reason)
-
-	msg := &types.MsgUpdateKeyRequest{
-		Creator:   c.c.Identity.Address.String(),
-		RequestId: requestID,
-		Status:    status,
-		Result:    result,
+func (r KeyRequestRejection) Msg(creator string) sdk.Msg {
+	return &types.MsgUpdateKeyRequest{
+		Creator:   creator,
+		RequestId: r.RequestID,
+		Status:    types.KeyRequestStatus_KEY_REQUEST_STATUS_REJECTED,
+		Result:    types.NewMsgUpdateKeyRequestReject(r.Reason),
 	}
-
-	txBytes, err := c.c.BuildTx(ctx, DefaultGasLimit, DefaultFees, msg)
-	if err != nil {
-		return fmt.Errorf("build tx: %w", err)
-	}
-
-	if err = c.c.SendWaitTx(ctx, txBytes); err != nil {
-		return fmt.Errorf("send wait tx: %w", err)
-	}
-
-	return nil
 }
 
-// FulfilSignatureRequest completes a signature request writing the signature bytes to wardend. The sender must be authorized to submit transactions
-// for the keychain corresponding to the requestID. The transaction will be rejected if the WardenTxClient does not have the correct identity address.
-func (c *WardenTxClient) FulfilSignatureRequest(ctx context.Context, requestID uint64, sig []byte) error {
-	status := types.SignRequestStatus_SIGN_REQUEST_STATUS_FULFILLED
-	result := &types.MsgFulfilSignatureRequest_Payload{
-		Payload: &types.MsgSignedData{
-			SignedData: sig,
+type SignRequestFulfilment struct {
+	RequestID uint64
+	Signature []byte
+}
+
+func (r SignRequestFulfilment) Msg(creator string) sdk.Msg {
+	return &types.MsgFulfilSignatureRequest{
+		Creator:   creator,
+		RequestId: r.RequestID,
+		Status:    types.SignRequestStatus_SIGN_REQUEST_STATUS_FULFILLED,
+		Result: &types.MsgFulfilSignatureRequest_Payload{
+			Payload: &types.MsgSignedData{
+				SignedData: r.Signature,
+			},
 		},
 	}
-
-	msg := &types.MsgFulfilSignatureRequest{
-		Creator:   c.c.Identity.Address.String(),
-		RequestId: requestID,
-		Status:    status,
-		Result:    result,
-	}
-
-	txBytes, err := c.c.BuildTx(ctx, DefaultGasLimit, DefaultFees, msg)
-	if err != nil {
-		return err
-	}
-
-	if err = c.c.SendWaitTx(ctx, txBytes); err != nil {
-		return err
-	}
-
-	return nil
 }
 
-// RejectSignatureRequest notifies wardend that a signature request has been rejected. The sender must be authorized to submit transactions
-// for the keychain corresponding to the requestID. The transaction will be rejected if the WardenTxClient does not have the correct identity address.
-func (c *WardenTxClient) RejectSignatureRequest(ctx context.Context, requestID uint64, reason string) error {
-	status := types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED
-	result := &types.MsgFulfilSignatureRequest_RejectReason{RejectReason: reason}
+type SignRequestRejection struct {
+	RequestID uint64
+	Reason    string
+}
 
-	msg := &types.MsgFulfilSignatureRequest{
-		Creator:   c.c.Identity.Address.String(),
-		RequestId: requestID,
-		Status:    status,
-		Result:    result,
+func (r SignRequestRejection) Msg(creator string) sdk.Msg {
+	return &types.MsgFulfilSignatureRequest{
+		Creator:   creator,
+		RequestId: r.RequestID,
+		Status:    types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED,
+		Result: &types.MsgFulfilSignatureRequest_RejectReason{
+			RejectReason: r.Reason,
+		},
 	}
-
-	txBytes, err := c.c.BuildTx(ctx, DefaultGasLimit, DefaultFees, msg)
-	if err != nil {
-		return err
-	}
-
-	if err = c.c.SendWaitTx(ctx, txBytes); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/keychain-sdk/requests_tracker.go
+++ b/keychain-sdk/requests_tracker.go
@@ -1,0 +1,35 @@
+package keychain
+
+import (
+	"sync"
+)
+
+type RequestTracker struct {
+	rw       sync.RWMutex
+	ingested map[uint64]struct{}
+}
+
+func NewRequestTracker() *RequestTracker {
+	return &RequestTracker{
+		ingested: make(map[uint64]struct{}),
+	}
+}
+
+func (t *RequestTracker) IsNew(id uint64) bool {
+	t.rw.RLock()
+	defer t.rw.RUnlock()
+	_, ok := t.ingested[id]
+	return !ok
+}
+
+func (t *RequestTracker) Ingested(id uint64) {
+	t.rw.Lock()
+	defer t.rw.Unlock()
+	t.ingested[id] = struct{}{}
+}
+
+func (t *RequestTracker) Done(id uint64) {
+	t.rw.Lock()
+	defer t.rw.Unlock()
+	delete(t.ingested, id)
+}

--- a/keychain-sdk/writer.go
+++ b/keychain-sdk/writer.go
@@ -1,0 +1,157 @@
+package keychain
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/warden-protocol/wardenprotocol/go-client"
+)
+
+type TxWriter struct {
+	// Limit is the maximum number of messages to batch together. When the limit is reached, the batch is sent.
+	Limit int
+
+	// BatchTimeout is the maximum time to wait before sending a batch of messages.
+	BatchTimeout time.Duration
+
+	// Client is the client used to send transactions to the chain.
+	Client *client.TxClient
+
+	Logger *slog.Logger
+
+	// Lock to prevent trying to send multiple transactions at once.
+	// Sending transactions is slow and we can hit the Limit and/or BatchTimeout multiple times in quick succession.
+	// Only one transaction can be sent at a time (i.e. due to Account and Sequence numbers).
+	sendTxLock sync.Mutex
+
+	batch Batch
+}
+
+func NewTxWriter(client *client.TxClient, limit int, batchTimeout time.Duration, logger *slog.Logger) *TxWriter {
+	return &TxWriter{
+		Client:       client,
+		Limit:        limit,
+		BatchTimeout: batchTimeout,
+		Logger:       logger,
+		batch:        Batch{messages: make(chan BatchItem, limit)},
+	}
+}
+
+func (w *TxWriter) Start(ctx context.Context, flushErrors chan error) error {
+	w.Logger.Info("starting tx writer")
+	ticker := time.NewTicker(w.BatchTimeout)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := w.Flush(ctx); err != nil {
+				flushErrors <- err
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (w *TxWriter) Write(ctx context.Context, msg client.Msger) error {
+	item := BatchItem{
+		Msger: msg,
+		Done:  make(chan error),
+	}
+	count := w.batch.Append(item)
+
+	w.Logger.Info("adding to batch", "count", count)
+
+	return <-item.Done
+}
+
+func (w *TxWriter) GasLimit() uint64 {
+	return client.DefaultGasLimit
+}
+
+func (w *TxWriter) Fees() sdk.Coins {
+	return client.DefaultFees
+}
+
+func (w *TxWriter) Flush(ctx context.Context) error {
+	msgs := w.batch.Clear()
+	if len(msgs) == 0 {
+		w.Logger.Debug("flushing batch", "empty", true)
+		return nil
+	}
+
+	defer func() {
+		for _, item := range msgs {
+			close(item.Done)
+		}
+	}()
+
+	msgers := make([]client.Msger, len(msgs))
+	for i, item := range msgs {
+		msgers[i] = item.Msger
+	}
+
+	if err := w.sendWaitTx(ctx, msgers...); err != nil {
+		for _, item := range msgs {
+			item.Done <- err
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (w *TxWriter) sendWaitTx(ctx context.Context, msgs ...client.Msger) error {
+	w.sendTxLock.Lock()
+	defer w.sendTxLock.Unlock()
+
+	w.Logger.Info("flushing batch", "count", len(msgs))
+
+	tx, err := w.Client.BuildTx(ctx, w.GasLimit(), w.Fees(), msgs...)
+	if err != nil {
+		return err
+	}
+
+	if err = w.Client.SendWaitTx(ctx, tx); err != nil {
+		return err
+	}
+
+	w.Logger.Info("flush complete")
+
+	return nil
+}
+
+type Batch struct {
+	clearMutex sync.Mutex
+	messages   chan BatchItem
+}
+
+type BatchItem struct {
+	client.Msger
+	Done chan error
+}
+
+func (b *Batch) Append(item BatchItem) int {
+	b.messages <- item
+	return len(b.messages)
+}
+
+func (b *Batch) Len() int {
+	return len(b.messages)
+}
+
+func (b *Batch) Clear() []BatchItem {
+	b.clearMutex.Lock()
+	defer b.clearMutex.Unlock()
+
+	items := make([]BatchItem, len(b.messages))
+	for i := 0; i < len(items); i++ {
+		items[i] = <-b.messages
+	}
+
+	return items
+}


### PR DESCRIPTION
This PR improves keychain performance a lot by batching multiple requests together into a single transaction.

I simplified the go-client APIs by introducing the Msger type and making it easier for users to build transactions with multiple messages. I took advantage of that in the keychain-sdk by bundling multiple responses into a single tx.

The keychain-sdk has been changed to
- keep track of requests statuses (i.e. to de-duplicate requests that have been seen/ingested before, but are still pending)
- instead of trying to write back the response immediately, we write it into a buffered channel that gets periodically flushed

It also fixed some annoying concurrency problems we were having.

The parameters to tune are:
- the rate of flushing (it doesn't make sense to be higher than our block rate)
- the size of the buffered channel, aka the limit of messages per transaction. If we put a number too high here, the entire tx will ran out of gas and fail. Local tests suggested that 20 msgs for 300.000 gas limit works. So this is easily a 20x improvement on the overall throughput.