### PR TITLE
feat(wardend): add cli commands for approving/rejecting key requests

### DIFF
--- a/warden/x/warden/client/cli/tx.go
+++ b/warden/x/warden/client/cli/tx.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/version"
+	"github.com/spf13/cobra"
+
+	"github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
+)
+
+// NewTxCmd returns a root CLI command handler for x/warden transaction commands.
+func NewTxCmd() *cobra.Command {
+	txCmd := &cobra.Command{
+		Use:                        v1beta2.ModuleName,
+		Short:                      "Warden transaction subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	txCmd.AddCommand(
+		FulfillKeyRequestTxCmd(),
+		RejectKeyRequestTxCmd(),
+	)
+
+	return txCmd
+}
+
+func FulfillKeyRequestTxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fulfill-key-request [request-id] [public-key-data]",
+		Short: "Fulfill a key request providing the public key.",
+		Long: `Fulfill a key request providing the public key.
+The sender of this transaction must be a party of the Keychain for the request.
+The public key must be a base64 encoded string.`,
+		Example: fmt.Sprintf("%s tx warden fulfill-key-request 1234 aGV5dGhlcmU=", version.AppName),
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			reqId, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				return err
+			}
+
+			pk, err := base64.StdEncoding.DecodeString(args[1])
+			if err != nil {
+				return err
+			}
+
+			msg := &v1beta2.MsgUpdateKeyRequest{
+				Creator:   clientCtx.GetFromAddress().String(),
+				Status:    v1beta2.KeyRequestStatus_KEY_REQUEST_STATUS_FULFILLED,
+				RequestId: reqId,
+				Result:    v1beta2.NewMsgUpdateKeyRequestKey(pk),
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func RejectKeyRequestTxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reject-key-request [request-id] [reason]",
+		Short: "Reject a key request providing the reason.",
+		Long: `Reject a key request providing a reason.
+The sender of this transaction must be a party of the Keychain for the request.`,
+		Example: fmt.Sprintf("%s tx warden reject-key-request 1234 'something happened'", version.AppName),
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			reqId, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				return err
+			}
+
+			msg := &v1beta2.MsgUpdateKeyRequest{
+				Creator:   clientCtx.GetFromAddress().String(),
+				Status:    v1beta2.KeyRequestStatus_KEY_REQUEST_STATUS_REJECTED,
+				RequestId: reqId,
+				Result:    v1beta2.NewMsgUpdateKeyRequestReject(args[1]),
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/warden/x/warden/module/autocli.go
+++ b/warden/x/warden/module/autocli.go
@@ -28,6 +28,10 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateParams",
 					Skip:      true, // skipped because authority gated
 				},
+				{
+					RpcMethod: "UpdateKeyRequest",
+					Skip:      true, // skipped in favor of the two separate commands for fulfilling or rejecting the request
+				},
 				// this line is used by ignite scaffolding # autocli/tx
 			},
 		},

--- a/warden/x/warden/module/module.go
+++ b/warden/x/warden/module/module.go
@@ -17,10 +17,12 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
 
 	// this line is used by starport scaffolding # 1
 
 	modulev1 "github.com/warden-protocol/wardenprotocol/api/warden/warden/module"
+	"github.com/warden-protocol/wardenprotocol/warden/x/warden/client/cli"
 	"github.com/warden-protocol/wardenprotocol/warden/x/warden/keeper"
 	"github.com/warden-protocol/wardenprotocol/warden/x/warden/types"
 	"github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
@@ -128,6 +130,11 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 
 // RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value, the InvariantRegistry triggers appropriate logic (most often the chain will be halted)
 func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+
+// GetTxCmd returns the root tx command for the gov module.
+func (am AppModule) GetTxCmd() *cobra.Command {
+	return cli.NewTxCmd()
+}
 
 // InitGenesis performs the module's genesis initialization. It returns no validator updates.
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {


### PR DESCRIPTION
Adds 

```
wardend tx warden fulfill-key-request 1 aGV5dGhlcmU=
```

and

```
wardend tx warden reject-key-request 1 'some reason'
```

The previous autogenerated command was not working because of the `oneof` in Protobuf. (I think it was trying to fill both the fields.)