### PR TITLE
fix(x/intent): v0.2 migration broke ActionsByAddress query

### DIFF
--- a/warden/x/intent/keeper/query_actions_by_address.go
+++ b/warden/x/intent/keeper/query_actions_by_address.go
@@ -46,14 +46,15 @@ func (k Keeper) ActionsByAddress(goCtx context.Context, req *types.QueryActionsB
 
 		intn, err := k.IntentForAction(ctx, value)
 		if err != nil {
-			return false, err
+			ctx.Logger().Debug("failed to get intent for action", "action_id", value.Id, "error", err)
+			return false, nil
 		}
 
 		return strings.Contains(intn.Definition, req.Address), nil
 	}, func(k uint64, a types.Action) (*types.Action, error) { return &a, nil })
 
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	return &types.QueryActionsByAddressResponse{

--- a/warden/x/intent/migrations/v2/store.go
+++ b/warden/x/intent/migrations/v2/store.go
@@ -74,8 +74,8 @@ func MigrateStore(ctx sdk.Context, storeService store.KVStoreService, cdc codec.
 }
 
 func clearAction(act *types.Action) {
-	act.Msg = nil
 	act.IntentId = 0
+
 	if act.Status == types.ActionStatus_ACTION_STATUS_PENDING {
 		act.Status = types.ActionStatus_ACTION_STATUS_TIMEOUT
 	}


### PR DESCRIPTION
The Action created in v0.1 references messages such as `warden.warden.MsgFoo` that no longer exist. For that, when calling `IntentForAction(...)` passing a v0.1 Action, an error is returned.

I changed the query `ActionsByAddress` to ignore actions whose intent can no longer be accessed, instead of returning an error.