### PR TITLE
fix(x/warden): continue query if one key fails to derive an address

### DIFF
--- a/warden/x/warden/keeper/query_keys.go
+++ b/warden/x/warden/keeper/query_keys.go
@@ -62,7 +62,8 @@ func (k Keeper) Keys(goCtx context.Context, req *types.QueryKeysRequest) (*types
 					walletType = types.WalletType_WALLET_TYPE_CELESTIA
 				}
 				if err != nil {
-					return nil, err
+					ctx.Logger().Warn("failed to derive address for key %d: %w", value.Id, err)
+					continue
 				}
 				response.Wallets = append(response.Wallets, &types.WalletKeyResponse{
 					Address: address,
@@ -100,7 +101,8 @@ func (k Keeper) Keys(goCtx context.Context, req *types.QueryKeysRequest) (*types
 				// 	walletType = types.WalletType_WALLET_TYPE_SUI
 				// }
 				if err != nil {
-					return nil, err
+					ctx.Logger().Warn("failed to derive address for key %d: %w", value.Id, err)
+					continue
 				}
 				response.Wallets = append(response.Wallets, &types.WalletKeyResponse{
 					Address: address,


### PR DESCRIPTION
If someone committed a "bad" public key, the entire Keys query started to fail.

I decided to not put safety checks when the Key is written, because I think different keychains will be able to use different formats, but only formats we recognized and support will be able to be derived into addresses.