### PR TITLE
feat(x/warden): refactor and improve perf for SpacesByOwner query

### DIFF
--- a/warden/x/warden/keeper/genesis.go
+++ b/warden/x/warden/keeper/genesis.go
@@ -15,7 +15,7 @@ func (k *Keeper) ImportState(ctx sdk.Context, genState types.GenesisState) error
 		return fmt.Errorf("failed to import keychains: %w", err)
 	}
 
-	err = k.spaces.Import(ctx, genState.Spaces, func(k types.Space) uint64 {
+	err = k.SpacesKeeper.Coll().Import(ctx, genState.Spaces, func(k types.Space) uint64 {
 		return k.Id
 	})
 	if err != nil {
@@ -60,7 +60,7 @@ func (k *Keeper) ExportState(ctx sdk.Context, genState *types.GenesisState) erro
 	}
 	genState.Keychains = keychains
 
-	spaces, err := k.spaces.Export(ctx)
+	spaces, err := k.SpacesKeeper.Coll().Export(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to export spaces: %w", err)
 	}

--- a/warden/x/warden/keeper/keeper.go
+++ b/warden/x/warden/keeper/keeper.go
@@ -24,14 +24,14 @@ type (
 		// should be the x/gov module account.
 		authority string
 
-		spaces    repo.SeqCollection[v1beta2.Space]
 		keychains repo.SeqCollection[v1beta2.Keychain]
 
 		keyRequests             repo.SeqCollection[v1beta2.KeyRequest]
 		signatureRequests       repo.SeqCollection[v1beta2.SignRequest]
 		signTransactionRequests repo.SeqCollection[v1beta2.SignTransactionRequest]
 
-		KeysKeeper KeysKeeper
+		SpacesKeeper SpacesKeeper
+		KeysKeeper   KeysKeeper
 
 		bankKeeper   types.BankKeeper
 		intentKeeper types.IntentKeeper
@@ -52,6 +52,7 @@ var (
 	SignTransactionRequestSeqPrefix = collections.NewPrefix(10)
 	SignTransactionRequestsPrefix   = collections.NewPrefix(11)
 	KeysSpaceIndexPrefix            = collections.NewPrefix(12)
+	SpacesByOwnerPrefix             = collections.NewPrefix(13)
 )
 
 func NewKeeper(
@@ -68,9 +69,8 @@ func NewKeeper(
 	}
 
 	sb := collections.NewSchemaBuilder(storeService)
-	spaceSeq := collections.NewSequence(sb, SpaceSeqPrefix, "spaces sequence")
-	spacesColl := collections.NewMap(sb, SpacesPrefix, "spaces", collections.Uint64Key, codec.CollValue[v1beta2.Space](cdc))
-	spaces := repo.NewSeqCollection(spaceSeq, spacesColl, func(v *v1beta2.Space, u uint64) { v.Id = u })
+
+	spacesKeeper := NewSpacesKeeper(sb, cdc)
 
 	keychainSeq := collections.NewSequence(sb, KeychainSeqPrefix, "keychain sequence")
 	keychainColl := collections.NewMap(sb, KeychainsPrefix, "keychains", collections.Uint64Key, codec.CollValue[v1beta2.Keychain](cdc))
@@ -96,14 +96,14 @@ func NewKeeper(
 		authority:    authority,
 		logger:       logger,
 
-		spaces:    spaces,
 		keychains: keychains,
 
 		keyRequests:             keyRequests,
 		signatureRequests:       signatureRequests,
 		signTransactionRequests: signTransactionRequests,
 
-		KeysKeeper: keysKeeper,
+		SpacesKeeper: spacesKeeper,
+		KeysKeeper:   keysKeeper,
 
 		bankKeeper:   bankKeeper,
 		intentKeeper: intentKeeper,

--- a/warden/x/warden/keeper/msg_new_space.go
+++ b/warden/x/warden/keeper/msg_new_space.go
@@ -41,7 +41,7 @@ func (k msgServer) NewSpace(goCtx context.Context, msg *types.MsgNewSpace) (*typ
 		}
 	}
 
-	id, err := k.spaces.Append(ctx, space)
+	id, err := k.SpacesKeeper.New(ctx, space)
 	if err != nil {
 		return nil, err
 	}

--- a/warden/x/warden/keeper/msg_server_add_space_owner.go
+++ b/warden/x/warden/keeper/msg_server_add_space_owner.go
@@ -11,7 +11,7 @@ import (
 
 func (k msgServer) AddSpaceOwner(goCtx context.Context, msg *types.MsgAddSpaceOwner) (*intenttypes.MsgActionCreated, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	ws, err := k.spaces.Get(ctx, msg.SpaceId)
+	ws, err := k.SpacesKeeper.Get(ctx, msg.SpaceId)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (k msgServer) AddOwnerActionHandler(ctx sdk.Context, act intenttypes.Action
 		return nil, err
 	}
 
-	space, err := k.spaces.Get(ctx, msg.SpaceId)
+	space, err := k.SpacesKeeper.Get(ctx, msg.SpaceId)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func (k msgServer) AddOwnerActionHandler(ctx sdk.Context, act intenttypes.Action
 		return nil, err
 	}
 
-	if err := k.spaces.Set(ctx, space.Id, space); err != nil {
+	if err := k.SpacesKeeper.Set(ctx, space); err != nil {
 		return nil, err
 	}
 

--- a/warden/x/warden/keeper/msg_server_new_key_request.go
+++ b/warden/x/warden/keeper/msg_server_new_key_request.go
@@ -12,7 +12,7 @@ import (
 
 func (k msgServer) NewKeyRequest(goCtx context.Context, msg *types.MsgNewKeyRequest) (*intenttypes.MsgActionCreated, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	space, err := k.spaces.Get(ctx, msg.SpaceId)
+	space, err := k.SpacesKeeper.Get(ctx, msg.SpaceId)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (k msgServer) NewKeyRequestActionHandler(ctx sdk.Context, act intenttypes.A
 		return nil, err
 	}
 
-	if _, err := k.spaces.Get(ctx, msg.SpaceId); err != nil {
+	if _, err := k.SpacesKeeper.Get(ctx, msg.SpaceId); err != nil {
 		return nil, err
 	}
 

--- a/warden/x/warden/keeper/msg_server_new_sign_transaction_request.go
+++ b/warden/x/warden/keeper/msg_server_new_sign_transaction_request.go
@@ -19,7 +19,7 @@ func (k msgServer) NewSignTransactionRequest(goCtx context.Context, msg *v1beta2
 		return nil, err
 	}
 
-	space, err := k.spaces.Get(ctx, key.SpaceId)
+	space, err := k.SpacesKeeper.Get(ctx, key.SpaceId)
 	if err != nil {
 		return nil, err
 	}

--- a/warden/x/warden/keeper/msg_server_new_signature_request.go
+++ b/warden/x/warden/keeper/msg_server_new_signature_request.go
@@ -23,7 +23,7 @@ func (k msgServer) NewSignatureRequest(goCtx context.Context, msg *types.MsgNewS
 		return nil, fmt.Errorf("signed data is not 32 bytes. Length is: %d", len(msg.DataForSigning))
 	}
 
-	space, err := k.spaces.Get(ctx, key.SpaceId)
+	space, err := k.SpacesKeeper.Get(ctx, key.SpaceId)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (k msgServer) NewSignatureRequestActionHandler(ctx sdk.Context, act intentt
 		return nil, err
 	}
 
-	_, err = k.spaces.Get(ctx, key.SpaceId)
+	_, err = k.SpacesKeeper.Get(ctx, key.SpaceId)
 	if err != nil {
 		return nil, err
 	}

--- a/warden/x/warden/keeper/msg_server_remove_space_owner.go
+++ b/warden/x/warden/keeper/msg_server_remove_space_owner.go
@@ -28,7 +28,7 @@ import (
 
 func (k msgServer) RemoveSpaceOwner(goCtx context.Context, msg *types.MsgRemoveSpaceOwner) (*intenttypes.MsgActionCreated, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	space, err := k.spaces.Get(ctx, msg.SpaceId)
+	space, err := k.SpacesKeeper.Get(ctx, msg.SpaceId)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (k msgServer) RemoveOwnerActionHandler(ctx sdk.Context, act intenttypes.Act
 		return nil, err
 	}
 
-	space, err := k.spaces.Get(ctx, msg.SpaceId)
+	space, err := k.SpacesKeeper.Get(ctx, msg.SpaceId)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (k msgServer) RemoveOwnerActionHandler(ctx sdk.Context, act intenttypes.Act
 
 	space.RemoveOwner(msg.Owner)
 
-	if err := k.spaces.Set(ctx, space.Id, space); err != nil {
+	if err := k.SpacesKeeper.Set(ctx, space); err != nil {
 		return nil, err
 	}
 

--- a/warden/x/warden/keeper/msg_server_update_key.go
+++ b/warden/x/warden/keeper/msg_server_update_key.go
@@ -17,7 +17,7 @@ func (k msgServer) UpdateKey(goCtx context.Context, msg *types.MsgUpdateKey) (*i
 		return nil, err
 	}
 
-	space, err := k.spaces.Get(ctx, key.SpaceId)
+	space, err := k.SpacesKeeper.Get(ctx, key.SpaceId)
 	if err != nil {
 		return nil, err
 	}

--- a/warden/x/warden/keeper/msg_server_update_space.go
+++ b/warden/x/warden/keeper/msg_server_update_space.go
@@ -11,7 +11,7 @@ import (
 
 func (k msgServer) UpdateSpace(goCtx context.Context, msg *types.MsgUpdateSpace) (*intenttypes.MsgActionCreated, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	space, err := k.spaces.Get(ctx, msg.SpaceId)
+	space, err := k.SpacesKeeper.Get(ctx, msg.SpaceId)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (k msgServer) UpdateSpaceActionHandler(ctx sdk.Context, act intenttypes.Act
 		return nil, err
 	}
 
-	space, err := k.spaces.Get(ctx, msg.SpaceId)
+	space, err := k.SpacesKeeper.Get(ctx, msg.SpaceId)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (k msgServer) UpdateSpaceActionHandler(ctx sdk.Context, act intenttypes.Act
 		space.SignIntentId = msg.SignIntentId
 	}
 
-	if err := k.spaces.Set(ctx, space.Id, space); err != nil {
+	if err := k.SpacesKeeper.Set(ctx, space); err != nil {
 		return nil, err
 	}
 

--- a/warden/x/warden/keeper/query_space_by_address.go
+++ b/warden/x/warden/keeper/query_space_by_address.go
@@ -32,7 +32,7 @@ func (k Keeper) SpaceById(goCtx context.Context, req *types.QuerySpaceByIdReques
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	space, err := k.spaces.Get(ctx, req.Id)
+	space, err := k.SpacesKeeper.Get(ctx, req.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/warden/x/warden/keeper/query_spaces.go
+++ b/warden/x/warden/keeper/query_spaces.go
@@ -33,7 +33,7 @@ func (k Keeper) Spaces(goCtx context.Context, req *types.QuerySpacesRequest) (*t
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	spaces, pageRes, err := query.CollectionPaginate(ctx, k.spaces, req.Pagination, func(id uint64, space types.Space) (types.Space, error) {
+	spaces, pageRes, err := query.CollectionPaginate(ctx, k.SpacesKeeper.Coll(), req.Pagination, func(id uint64, space types.Space) (types.Space, error) {
 		return space, nil
 	})
 

--- a/warden/x/warden/keeper/query_spaces_by_owner.go
+++ b/warden/x/warden/keeper/query_spaces_by_owner.go
@@ -1,24 +1,9 @@
-// Copyright 2024
-//
-// This file includes work covered by the following copyright and permission notices:
-//
-// Copyright 2023 Qredo Ltd.
-// Licensed under the Apache License, Version 2.0;
-//
-// This file is part of the Warden Protocol library.
-//
-// The Warden Protocol library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the Warden Protocol library. If not, see https://github.com/warden-protocol/wardenprotocol/blob/main/LICENSE
 package keeper
 
 import (
 	"context"
 
+	"cosmossdk.io/collections"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
@@ -31,11 +16,22 @@ func (k Keeper) SpacesByOwner(goCtx context.Context, req *types.QuerySpacesByOwn
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
+	ownerAddr, err := sdk.AccAddressFromBech32(req.Owner)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid owner address")
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	spaces, pageRes, err := query.CollectionFilteredPaginate(ctx, k.spaces, req.Pagination, func(id uint64, value types.Space) (bool, error) {
-		return value.IsOwner(req.Owner), nil
-	}, func(id uint64, s types.Space) (types.Space, error) { return s, nil })
+	spaces, pageRes, err := query.CollectionPaginate(
+		ctx,
+		k.SpacesKeeper.ByOwner(),
+		req.Pagination,
+		func(key collections.Pair[sdk.AccAddress, uint64], value collections.NoValue) (types.Space, error) {
+			return k.SpacesKeeper.Get(ctx, key.K2())
+		},
+		query.WithCollectionPaginationPairPrefix[sdk.AccAddress, uint64](ownerAddr),
+	)
 
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/warden/x/warden/keeper/spaces.go
+++ b/warden/x/warden/keeper/spaces.go
@@ -1,0 +1,67 @@
+package keeper
+
+import (
+	"cosmossdk.io/collections"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/warden-protocol/wardenprotocol/warden/repo"
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
+)
+
+type SpacesKeeper struct {
+	spaces        repo.SeqCollection[types.Space]
+	spacesByOwner collections.KeySet[collections.Pair[sdk.AccAddress, uint64]]
+}
+
+func NewSpacesKeeper(sb *collections.SchemaBuilder, cdc codec.BinaryCodec) SpacesKeeper {
+	spaceSeq := collections.NewSequence(sb, SpaceSeqPrefix, "spaces sequence")
+	spacesColl := collections.NewMap(sb, SpacesPrefix, "spaces", collections.Uint64Key, codec.CollValue[types.Space](cdc))
+	spaces := repo.NewSeqCollection(spaceSeq, spacesColl, func(v *types.Space, u uint64) { v.Id = u })
+	spacesByOwner := collections.NewKeySet(sb, SpacesByOwnerPrefix, "spaces_by_owner", collections.PairKeyCodec(sdk.AccAddressKey, collections.Uint64Key))
+
+	return SpacesKeeper{
+		spaces:        spaces,
+		spacesByOwner: spacesByOwner,
+	}
+}
+
+func (k SpacesKeeper) Get(ctx sdk.Context, id uint64) (types.Space, error) {
+	return k.spaces.Get(ctx, id)
+}
+
+func (k SpacesKeeper) New(ctx sdk.Context, space *types.Space) (uint64, error) {
+	if err := k.updateSpaceOwners(ctx, *space); err != nil {
+		return 0, err
+	}
+	return k.spaces.Append(ctx, space)
+}
+
+func (k SpacesKeeper) Set(ctx sdk.Context, space types.Space) error {
+	if err := k.updateSpaceOwners(ctx, space); err != nil {
+		return err
+	}
+	return k.spaces.Set(ctx, space.Id, space)
+}
+
+func (k SpacesKeeper) updateSpaceOwners(ctx sdk.Context, space types.Space) error {
+	for _, owner := range space.Owners {
+		ownerAddr, err := sdk.AccAddressFromBech32(owner)
+		if err != nil {
+			return err
+		}
+
+		if err := k.spacesByOwner.Set(ctx, collections.Join(ownerAddr, space.Id)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (k SpacesKeeper) Coll() repo.SeqCollection[types.Space] {
+	return k.spaces
+}
+
+func (k SpacesKeeper) ByOwner() collections.KeySet[collections.Pair[sdk.AccAddress, uint64]] {
+	return k.spacesByOwner
+}


### PR DESCRIPTION
Following my last couple PRs, I'm continuing to improve slow queries. SpacesByOwner is one of the most hit endpoints, so I followed the same pattern of extracting the SpaceKeeper from the base Keeper of the x/warden module.

Note: during the v2 migration all the invalid (i.e. invalid bech32 format) Space owners addresses will be dropped.