### PR TITLE
build: add `make build` and `make install` aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ LDFLAGS=-ldflags "-s -w -X github.com/cosmos/cosmos-sdk/version.Name=warden -X g
 
 build-all: build-wardend build-faucet build-wardenkms
 
+build: build-wardend
+
+install: install-wardend
+
 build-wardend:
 	go build $(LDFLAGS) -o $(OUTPUT_DIR)/wardend ./cmd/wardend
 
@@ -20,4 +24,4 @@ build-faucet:
 build-wardenkms:
 	go build $(LDFLAGS) -o $(OUTPUT_DIR)/wardenkms ./cmd/wardenkms
 
-.PHONY: build-all build-wardend install-wardend build-faucet build-wardenkms
+.PHONY: build-all build install build-wardend install-wardend build-faucet build-wardenkms


### PR DESCRIPTION
As requested by the community multiple times on Discord, `make build` and `make install` will build the `wardend` binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Makefile to include new `build` and `install` targets for improved project build and installation processes.
	- Modified the `build-all` target for enhanced dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->