### PR TITLE
ci: copy .coderabbit.yml from cosmos-sdk repo

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,32 @@
+language: "en"
+early_access: false
+reviews:
+    request_changes_workflow: false
+    high_level_summary: true
+    poem: false
+    review_status: true
+    collapse_walkthrough: true
+    path_filters:
+        - "!api/"
+    path_instructions:
+        - path: "**/*.go"
+          instructions: "Review the Golang code for conformity with the Uber Golang style guide, highlighting any deviations."
+        - path: "tests/**/*"
+          instructions: |
+              "Assess the integration and e2e test code assessing sufficient code coverage for the changes associated in the pull request"
+        - path: "**/*_test.go"
+          instructions: |
+              "Assess the unit test code assessing sufficient code coverage for the changes associated in the pull request"
+        - path: "**/*.md"
+          instructions: |
+              "Assess the documentation for misspellings, grammatical errors, missing documentation and correctness"
+    auto_review:
+        enabled: true
+        ignore_title_keywords:
+            - "WIP"
+            - "DO NOT MERGE"
+        drafts: false
+        base_branches:
+            - "main"
+chat:
+    auto_reply: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Misc
 
 * (docs) [#127](https://github.com/warden-protocol/wardenprotocol/pull/127) Add CHANGELOG.md
+* (ci) [#137](https://github.com/warden-protocol/wardenprotocol/pull/137) Add CodeRabbit configuration file, copied from Cosmos SDK's repo
 
 
 ## [v0.2.0](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.2.0) - 2024-03-26


### PR DESCRIPTION
I'm setting up CodeRabbit so we can test it. I copied over the .coderabbit.yml file from https://github.com/cosmos/cosmos-sdk/blob/main/.coderabbit.yml.