### PR TITLE
perf(x/warden): add benchmarks for most used queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * (docs) [#127](https://github.com/warden-protocol/wardenprotocol/pull/127) Add CHANGELOG.md
 * (ci) [#137](https://github.com/warden-protocol/wardenprotocol/pull/137) Add CodeRabbit configuration file, copied from Cosmos SDK's repo
+* (perf) [#138](https://github.com/warden-protocol/wardenprotocol/pull/138) Add benchmarks for most hit queries in `x/warden` and `x/intent` (ActionsByAddress, AllKeys, KeysBySpaceId)
 
 
 ## [v0.2.0](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.2.0) - 2024-03-26

--- a/warden/x/intent/keeper/query_actions_by_address_test.go
+++ b/warden/x/intent/keeper/query_actions_by_address_test.go
@@ -1,0 +1,57 @@
+package keeper_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/warden-protocol/wardenprotocol/warden/testutil/keeper"
+	"github.com/warden-protocol/wardenprotocol/warden/x/intent/types"
+)
+
+func init() {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount("warden", "wardenpub")
+}
+
+func Benchmark_QueryActionsByAddress(b *testing.B) {
+	k, ctx := keepertest.IntentKeeper(b)
+
+	// create many actions, each with a unique address
+	for i := 0; i < 100_000; i++ {
+		addr := sdk.MustBech32ifyAddressBytes(sdk.GetConfig().GetBech32AccountAddrPrefix(), []byte(fmt.Sprintf("address-%d", i)))
+
+		_, err := k.ActionKeeper.New(
+			ctx,
+			&types.Action{
+				Intent: types.Intent{
+					Id: uint64(i),
+					Addresses: []string{
+						addr,
+					},
+				},
+			},
+		)
+		require.NoError(b, err)
+	}
+
+	// query actions by a single address
+	address := sdk.MustBech32ifyAddressBytes(sdk.GetConfig().GetBech32AccountAddrPrefix(), []byte(fmt.Sprintf("address-%d", 100)))
+	req := &types.QueryActionsByAddressRequest{
+		Address: address,
+		Pagination: &query.PageRequest{
+			// CountTotal helps investigate the performance of the pagination
+			CountTotal: true,
+			Limit:      1,
+		},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := k.ActionsByAddress(ctx, req)
+		require.NoError(b, err)
+		require.NotNil(b, res)
+	}
+}

--- a/warden/x/warden/keeper/query_all_keys_test.go
+++ b/warden/x/warden/keeper/query_all_keys_test.go
@@ -1,0 +1,50 @@
+package keeper_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/warden-protocol/wardenprotocol/warden/testutil/keeper"
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
+)
+
+func Benchmark_QueryAllKeys(b *testing.B) {
+	k, ctx := keepertest.WardenKeeper(b)
+
+	pk, err := base64.StdEncoding.DecodeString("A8Ijpl1mphVgurSqcDfS4mVVSqgXVLubol7+Kgjay1I+")
+	require.NoError(b, err)
+
+	for i := 0; i < 1_000_000; i++ {
+		err = k.KeysKeeper.New(
+			ctx,
+			types.Key{
+				Type:      types.KeyType_KEY_TYPE_ECDSA_SECP256K1,
+				PublicKey: pk,
+			},
+			types.KeyRequest{
+				Id: uint64(i),
+			},
+		)
+		require.NoError(b, err)
+	}
+
+	req := &types.QueryAllKeysRequest{
+		Pagination: &query.PageRequest{
+			CountTotal: true,
+			Limit:      1,
+		},
+		DeriveWallets: []types.WalletType{
+			types.WalletType_WALLET_TYPE_ETH,
+			types.WalletType_WALLET_TYPE_CELESTIA,
+		},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := k.AllKeys(ctx, req)
+		require.NoError(b, err)
+		require.NotNil(b, res)
+	}
+}

--- a/warden/x/warden/keeper/query_keys_by_space_id_test.go
+++ b/warden/x/warden/keeper/query_keys_by_space_id_test.go
@@ -1,0 +1,52 @@
+package keeper_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/stretchr/testify/require"
+
+	keepertest "github.com/warden-protocol/wardenprotocol/warden/testutil/keeper"
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
+)
+
+func Benchmark_QueryKeysBySpaceId(b *testing.B) {
+	k, ctx := keepertest.WardenKeeper(b)
+
+	pk, err := base64.StdEncoding.DecodeString("A8Ijpl1mphVgurSqcDfS4mVVSqgXVLubol7+Kgjay1I+")
+	require.NoError(b, err)
+
+	for i := 0; i < 100_000; i++ {
+		err = k.KeysKeeper.New(
+			ctx,
+			types.Key{
+				Type:      types.KeyType_KEY_TYPE_ECDSA_SECP256K1,
+				PublicKey: pk,
+				SpaceId:   uint64(i),
+			},
+			types.KeyRequest{
+				Id: uint64(i),
+			},
+		)
+		require.NoError(b, err)
+	}
+
+	req := &types.QueryKeysBySpaceIdRequest{
+		SpaceId: 9999,
+		DeriveWallets: []types.WalletType{
+			types.WalletType_WALLET_TYPE_ETH,
+			types.WalletType_WALLET_TYPE_CELESTIA,
+		},
+		Pagination: &query.PageRequest{
+			CountTotal: true,
+			Limit:      1,
+		},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := k.KeysBySpaceId(ctx, req)
+		require.NoError(b, err)
+		require.NotNil(b, res)
+	}
+}


### PR DESCRIPTION
Not much but at least we have some reference data to improve upon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced benchmarking functionality to evaluate the performance of querying actions by address and keys within the system.
	- Added benchmark tests for querying all keys with pagination and specific wallet types.
	- Implemented benchmark tests for querying keys by space ID, enhancing performance evaluation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->