### PR TITLE
fix(x/warden): prevent adding invalid addresses as keychain parties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (x/intent) [#139](https://github.com/warden-protocol/wardenprotocol/pull/139) Ability for modules to dynamically resolve variables on Action creation
     * x/warden can now resolve `warden.space.owners` in Intent definitions into the list of owners of the space
 * (x/intent) [#151](https://github.com/warden-protocol/wardenprotocol/pull/151) Store Intents' AST, instead of the raw string
+* (x/warden) [#152](https://github.com/warden-protocol/wardenprotocol/pull/152) Prevent adding invalid addresses as Keychain parties
 
 ### Features
 

--- a/warden/x/warden/keeper/msg_server_add_keychain_party.go
+++ b/warden/x/warden/keeper/msg_server_add_keychain_party.go
@@ -27,6 +27,11 @@ import (
 func (k msgServer) AddKeychainParty(goCtx context.Context, msg *types.MsgAddKeychainParty) (*types.MsgAddKeychainPartyResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	_, err := sdk.AccAddressFromBech32(msg.Party)
+	if err != nil {
+		return nil, fmt.Errorf("invalid party address: %s", err)
+	}
+
 	kr, err := k.keychains.Get(ctx, msg.KeychainId)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
You shouldn't be allowed to add any string as a Keychain party, this error message makes it clearer for users.