### PR TITLE
fix(x/warden): resolve `space.owners` for SignIntents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * (shield) [#148](https://github.com/warden-protocol/wardenprotocol/pull/148) Use protobufs for defining the AST
 * (x/intent) [#155](https://github.com/warden-protocol/wardenprotocol/pull/155) Add MsgUpdateIntent, creators of an Intent can use it to change name and definition of their Intents.
+* (x/warden) [#159](https://github.com/warden-protocol/wardenprotocol/pull/159) Resolve `warden.space.owners` in Intent definitions for MsgNewSignatureRequest and MsgNewSignTransactionRequest
 
 ### Bug Fixes
 

--- a/warden/x/warden/keeper/keys.go
+++ b/warden/x/warden/keeper/keys.go
@@ -1,9 +1,10 @@
 package keeper
 
 import (
+	"context"
+
 	"cosmossdk.io/collections"
 	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
 	v1beta2 "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
@@ -26,16 +27,16 @@ func NewKeysKeeper(sb *collections.SchemaBuilder, cdc codec.BinaryCodec) KeysKee
 	}
 }
 
-func (k KeysKeeper) New(ctx sdk.Context, key types.Key, keyRequest types.KeyRequest) error {
+func (k KeysKeeper) New(ctx context.Context, key types.Key, keyRequest types.KeyRequest) error {
 	key.Id = keyRequest.Id
 	return k.Set(ctx, key)
 }
 
-func (k KeysKeeper) Get(ctx sdk.Context, id uint64) (types.Key, error) {
+func (k KeysKeeper) Get(ctx context.Context, id uint64) (types.Key, error) {
 	return k.keys.Get(ctx, id)
 }
 
-func (k KeysKeeper) Set(ctx sdk.Context, key types.Key) error {
+func (k KeysKeeper) Set(ctx context.Context, key types.Key) error {
 	if err := k.keysBySpace.Set(ctx, collections.Join(key.SpaceId, key.Id)); err != nil {
 		return err
 	}

--- a/warden/x/warden/keeper/shield.go
+++ b/warden/x/warden/keeper/shield.go
@@ -54,18 +54,19 @@ type getKeyIder interface {
 }
 
 func (w WardenShieldExpander) extractSpaceID(ctx context.Context, msg sdk.Msg) (uint64, error) {
-	if msg, ok := msg.(getSpaceIder); ok {
+	switch msg := msg.(type) {
+	case getSpaceIder:
 		return msg.GetSpaceId(), nil
-	}
-	if msg, ok := msg.(getKeyIder); ok {
+	case getKeyIder:
 		keyID := msg.GetKeyId()
 		key, err := w.keeper.KeysKeeper.Get(ctx, keyID)
 		if err != nil {
 			return 0, err
 		}
 		return key.SpaceId, nil
+	default:
+		return 0, fmt.Errorf("message does not have a SpaceId or KeyId field")
 	}
-	return 0, fmt.Errorf("message does not have a SpaceId field")
 }
 
 func (k Keeper) ShieldExpander() ast.Expander {

--- a/warden/x/warden/keeper/shield.go
+++ b/warden/x/warden/keeper/shield.go
@@ -20,7 +20,7 @@ func (w WardenShieldExpander) Expand(goCtx context.Context, ident *ast.Identifie
 		ctx := cosmoshield.UnwrapContext(goCtx)
 		msg := ctx.Msg()
 
-		spaceID, err := extractSpaceID(msg)
+		spaceID, err := w.extractSpaceID(ctx, msg)
 		if err != nil {
 			return nil, err
 		}
@@ -49,9 +49,21 @@ type getSpaceIder interface {
 	GetSpaceId() uint64
 }
 
-func extractSpaceID(msg sdk.Msg) (uint64, error) {
+type getKeyIder interface {
+	GetKeyId() uint64
+}
+
+func (w WardenShieldExpander) extractSpaceID(ctx context.Context, msg sdk.Msg) (uint64, error) {
 	if msg, ok := msg.(getSpaceIder); ok {
 		return msg.GetSpaceId(), nil
+	}
+	if msg, ok := msg.(getKeyIder); ok {
+		keyID := msg.GetKeyId()
+		key, err := w.keeper.KeysKeeper.Get(ctx, keyID)
+		if err != nil {
+			return 0, err
+		}
+		return key.SpaceId, nil
 	}
 	return 0, fmt.Errorf("message does not have a SpaceId field")
 }


### PR DESCRIPTION
Intents referencing `warden.space.owners` were only working when used for Actions that had a `SpaceId` field in the message, this is not the case for `NewSignatureRequest` and `NewSignTransactionRequest` that only have a `KeyId` field instead.

From the Key it's possible to go back to its Space, which is what PR adds to `x/warden` intent's expander.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Updated context handling in key management functions for improved alignment with Go standards.
    - Enhanced the shield expansion logic to support additional key identification methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->