### PR TITLE
chore(coderabbit): fix path filters

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en"
 early_access: false
 reviews:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,9 +7,9 @@ reviews:
     review_status: true
     collapse_walkthrough: true
     path_filters:
-        - "!api/"
-        - "!wardjs/src/codegen/"
-        - "!ts-client/"
+        - "!api/**"
+        - "!wardjs/src/codegen/**"
+        - "!ts-client/**"
     path_instructions:
         - path: "**/*.go"
           instructions: "Review the Golang code for conformity with the Uber Golang style guide, highlighting any deviations."


### PR DESCRIPTION
For some reasons the folders excluded in path-filters were not working (see #163, it commented `ts-client/` files).

I'm trying to follow more closely the examples from coderabbit docs: https://docs.coderabbit.ai/guides/configure-coderabbit/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated path filters in configuration to support recursive exclusion patterns, enhancing the review process by excluding all subdirectories under specified paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->