### PR TITLE
build(wardenkms): add wasmvm dynamic library to Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN --mount=type=bind,source=.,target=.,readonly\
 
 FROM debian:bookworm-slim AS wardenkms
 COPY --from=wardenkms-build /build/wardenkms /
+ADD --checksum=sha256:b0c3b761e5f00e45bdafebcfe9c03bd703b88b3f535c944ca8e27ef9b891cd10 https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
 ENTRYPOINT ["/wardenkms"]
 
 ## snap


### PR DESCRIPTION
Without this, the binary doesn't work unfortunately.

We'll need to think if it's possible for wardenkms to be built without `wasmvm`, since it doesn't really use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated new library support within the application container for enhanced performance and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->