### PR TITLE
test(wardend): fix app initialization

### DIFF
--- a/warden/app/sim_bench_test.go
+++ b/warden/app/sim_bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
-	bApp, err := app.New(logger, db, nil, true, appOptions, interBlockCacheOpt())
+	bApp, err := app.New(logger, db, nil, true, appOptions, nil, interBlockCacheOpt())
 	require.NoError(b, err)
 	require.Equal(b, app.Name, bApp.Name())
 
@@ -100,7 +100,7 @@ func BenchmarkInvariants(b *testing.B) {
 	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
-	bApp, err := app.New(logger, db, nil, true, appOptions, interBlockCacheOpt())
+	bApp, err := app.New(logger, db, nil, true, appOptions, nil, interBlockCacheOpt())
 	require.NoError(b, err)
 	require.Equal(b, app.Name, bApp.Name())
 

--- a/warden/app/sim_test.go
+++ b/warden/app/sim_test.go
@@ -87,7 +87,7 @@ func BenchmarkSimulation(b *testing.B) {
 	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
-	bApp, err := app.New(logger, db, nil, true, appOptions, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	bApp, err := app.New(logger, db, nil, true, appOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.NoError(b, err)
 	require.Equal(b, app.Name, bApp.Name())
 
@@ -133,7 +133,7 @@ func TestAppImportExport(t *testing.T) {
 	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
-	bApp, err := app.New(logger, db, nil, true, appOptions, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	bApp, err := app.New(logger, db, nil, true, appOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.NoError(t, err)
 	require.Equal(t, app.Name, bApp.Name())
 
@@ -174,7 +174,7 @@ func TestAppImportExport(t *testing.T) {
 		require.NoError(t, os.RemoveAll(newDir))
 	}()
 
-	newApp, err := app.New(log.NewNopLogger(), newDB, nil, true, appOptions, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	newApp, err := app.New(log.NewNopLogger(), newDB, nil, true, appOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.NoError(t, err)
 	require.Equal(t, app.Name, newApp.Name())
 
@@ -253,7 +253,7 @@ func TestAppSimulationAfterImport(t *testing.T) {
 	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
-	bApp, err := app.New(logger, db, nil, true, appOptions, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	bApp, err := app.New(logger, db, nil, true, appOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.NoError(t, err)
 	require.Equal(t, app.Name, bApp.Name())
 
@@ -299,7 +299,7 @@ func TestAppSimulationAfterImport(t *testing.T) {
 		require.NoError(t, os.RemoveAll(newDir))
 	}()
 
-	newApp, err := app.New(log.NewNopLogger(), newDB, nil, true, appOptions, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	newApp, err := app.New(log.NewNopLogger(), newDB, nil, true, appOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.NoError(t, err)
 	require.Equal(t, app.Name, newApp.Name())
 
@@ -382,6 +382,7 @@ func TestAppStateDeterminism(t *testing.T) {
 				nil,
 				true,
 				appOptions,
+				nil,
 				interBlockCacheOpt(),
 				baseapp.SetChainID(chainID),
 			)

--- a/warden/x/warden/types/v1beta2/sign_method_handler_ethereum_test.go
+++ b/warden/x/warden/types/v1beta2/sign_method_handler_ethereum_test.go
@@ -8,18 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ethereumWallet(t *testing.T) *EthereumSignMethodHandler {
-	t.Helper()
-	k := &Key{
-		Type:      KeyType_KEY_TYPE_ECDSA_SECP256K1,
-		PublicKey: hexutil.MustDecode("0x025cd45a6614df5348692ea4d0f7c16255b75a6b6f67bea5013621fe84af8031f0"),
-	}
-
-	wallet, err := NewEthereumSignMethodHandler(k)
-	require.NoError(t, err)
-	return wallet
-}
-
 func Test_ParseEthereumTransaction(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
After #156, the `app.New()` constructor has a new param for wasm opts. I fix the Go build in this PR by just passing `nil` (empty options).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Updated initialization parameters in various test and benchmark functions to enhance testing accuracy and coverage.
- **Refactor**
	- Removed the `ethereumWallet` function responsible for creating an Ethereum sign method handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->