### PR TITLE
fix(spaceward): restore Osmosis support for WalletConnect

### DIFF
--- a/spaceward/src/features/home/HomeAssets.tsx
+++ b/spaceward/src/features/home/HomeAssets.tsx
@@ -85,6 +85,12 @@ export function HomeAssets() {
 	);
 }
 
+const isCosmosWallet = (type?: AddressType) =>
+	type &&
+	[AddressType.ADDRESS_TYPE_OSMOSIS].includes(
+		type,
+	);
+
 function Address({
 	address,
 	type,
@@ -120,7 +126,14 @@ function Address({
 			</div>
 			<div>
 				<div className="space-y-4">
-					<Sepolia address={address} keyId={keyId} />
+					{type === AddressType.ADDRESS_TYPE_ETHEREUM ? (
+						<Sepolia
+							address={address}
+							keyId={keyId}
+						/>
+					) : isCosmosWallet(type) ? (
+						<CosmosLike />
+					) : null}
 				</div>
 			</div>
 		</div>
@@ -184,4 +197,8 @@ function Sepolia({ address, keyId }: { address: string; keyId: Long }) {
 			</div>
 		</div>
 	);
+}
+
+function CosmosLike() {
+	return null
 }


### PR DESCRIPTION
Osmosis support was added in #167 but for a mistake was removed during my changes in #173.

Apart from that, it was slightly bugged (i.e. the response to `cosmos_getAccounts` was missing a couple fields, `algo` and `pubkey`). There were some leftovers of console.log and a `debugger` statement. I took the chance to clean up all of this.

I personally tested the integration with https://app.osmosis.zone and it works. I couldn't test on testnet (https://testnet.osmosis.zone/) because I couldn't find a working faucet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to check if a wallet is a Cosmos wallet in the Home section.
	- Introduced new components for different blockchain types, enhancing the user interface.
	- Enhanced the Wallet Connect feature with support for additional wallet types and functionalities including session keepalive, and QR code image pasting.
	- Implemented event handling for session and proposal expirations in Wallet Connect, improving session management.

- **Enhancements**
	- Improved user interactions and UI in Wallet Connect for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->