### PR TITLE
fix(faucet): add missing libwasmvm to the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN tar -xf devnet.tar.gz && rm devnet.tar.gz
 FROM debian:bookworm-slim AS faucet
 COPY --from=wardend-build /build/wardend /usr/bin/wardend
 COPY --from=wardend-build /build/faucet /usr/bin/faucet
+ADD --checksum=sha256:b0c3b761e5f00e45bdafebcfe9c03bd703b88b3f535c944ca8e27ef9b891cd10 https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
 EXPOSE 8000
 CMD ["/usr/bin/faucet"]
 


### PR DESCRIPTION
When trying to launch faucet you'll get:
```
stderr: wardend: error while loading shared libraries: libwasmvm.x86_64.so: cannot open shared object file: No such file or directory

panic: couldn't setup client: exit status 127
```

This PR will add the missing `libwasmvm` library to faucet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced application security by verifying and including a new library file through checksum verification in the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->