### PR TITLE
fix(faucet): install certificates to faucet container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ FROM debian:bookworm-slim AS faucet
 COPY --from=wardend-build /build/wardend /usr/bin/wardend
 COPY --from=wardend-build /build/faucet /usr/bin/faucet
 ADD --checksum=sha256:b0c3b761e5f00e45bdafebcfe9c03bd703b88b3f535c944ca8e27ef9b891cd10 https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 EXPOSE 8000
 CMD ["/usr/bin/faucet"]
 


### PR DESCRIPTION
Container is complaining about missing certificates when trying to communicate with RPC clients.
This change will fix that error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Enhanced Docker image security and reliability by updating packages and installing necessary certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->