### PR TITLE
build: fix goreleaser after CosmWasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+dist-linux-amd64
 
 # Editor directories and files
 .tmp

--- a/.goreleaser-amd64.yaml
+++ b/.goreleaser-amd64.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 1
+
+project_name: wardend
+
+dist: dist-linux-amd64
+
+before:
+  hooks:
+    # setup musl
+    - apk add gcc musl-dev
+
+    # setup libwasmvm
+    - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.a
+
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+env:
+  - CGO_ENABLED=1
+
+builds:
+  - id: wardend-linux-amd64
+    main: ./cmd/wardend
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/cosmos/cosmos-sdk/version.Name=warden
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=wardend
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+      - -linkmode=external
+      - -extldflags '-static'
+    tags:
+      - netgo
+      - muslc
+
+archives:
+  - format: zip
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,21 +11,69 @@ before:
     - go mod tidy
     # you may remove this if you don't need go generate
     - go generate ./...
+    # setup musl
+    - apt update && apt install musl-dev=1.2.2-1
+env:
+  - CGO_ENABLED=1
 
 builds:
-  - env:
-      - CGO_ENABLED=0
+  - id: wardend-linux-arm64
+    main: ./cmd/wardend
     goos:
       - linux
-      - windows
-      - darwin
-    main: ./cmd/wardend
+    goarch:
+      - arm64
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm_muslc.aarch64.a -O /lib/libwasmvm_muslc.a
+    flags:
+      - -mod=readonly
+      - -trimpath
     ldflags:
       - -s -w
       - -X github.com/cosmos/cosmos-sdk/version.Name=warden
       - -X github.com/cosmos/cosmos-sdk/version.AppName=wardend
       - -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}}
       - -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+      - -linkmode=external
+      - -extldflags '-static'
+    tags:
+      - netgo
+      - muslc
+
+  - id: wardend-darwin-arm64
+    main: ./cmd/wardend
+    env:
+      - CC=oa64-clang
+      - CGO_LDFLAGS=-L/lib
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/cosmos/cosmos-sdk/version.Name=warden
+      - -X github.com/cosmos/cosmos-sdk/version.AppName=wardend
+      - -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+      - -X github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger,static_wasm
+      - -linkmode=external
+    tags:
+      - netgo
+      - ledger
+      - static_wasm
+
+release:
+  mode: append
 
 archives:
   - format: zip
@@ -39,8 +87,4 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  disable: true

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PWD=$(shell pwd)
 VERSION=$(shell git describe --tags --always)
 COMMIT=$(shell git rev-parse HEAD)
 DIRTY=$(shell git diff --quiet || echo "-dirty")
@@ -5,6 +6,7 @@ FULL_VERSION=$(VERSION)$(DIRTY)
 CHAIN_ID=wardenprotocol
 OUTPUT_DIR=./build
 LDFLAGS=-ldflags "-s -w -X github.com/cosmos/cosmos-sdk/version.Name=warden -X github.com/cosmos/cosmos-sdk/version.AppName=wardend -X github.com/cosmos/cosmos-sdk/version.Version=$(FULL_VERSION) -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) -X github.com/warden-protocol/wardenprotocol/cmd/wardenprotocold/cmd.ChainID=$(CHAIN_ID)"
+TAG=$(shell git tag --points-at HEAD)
 
 build-all: build-wardend build-faucet build-wardenkms
 
@@ -23,5 +25,31 @@ build-faucet:
 
 build-wardenkms:
 	go build $(LDFLAGS) -o $(OUTPUT_DIR)/wardenkms ./cmd/wardenkms
+
+release-wardend-cross-arm64:
+	@docker run \
+		--rm \
+		-e CGO_ENABLED=1 \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(PWD):/go/src/wardend \
+		-w /go/src/wardend \
+		ghcr.io/goreleaser/goreleaser-cross:v1.22 \
+		--clean --skip=validate --skip=publish
+
+release-wardend-linux-amd64:
+	@docker run \
+		--platform linux/amd64 \
+		--rm \
+		-e CGO_ENABLED=1 \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(PWD):/go/src/wardend \
+		-w /go/src/wardend \
+		ghcr.io/goreleaser/goreleaser:v1.25.1 \
+		--clean --skip=publish -f ./.goreleaser-amd64.yaml
+
+release-wardend: release-wardend-linux-amd64 release-wardend-cross-arm64
+	cat dist-linux-amd64/wardend_*_checksums.txt dist/wardend_*_checksums.txt > dist/checksums.txt
+	@if [ -z "$(TAG)" ] || [ -n "$(DIRTY)" ]; then echo "No tag found for the current commit. Won't proceed with GitHub release."; exit 1; fi
+	gh release create $(TAG) --title $(TAG) --verify-tag dist-linux-amd64/wardend_Linux_x86_64.zip dist/wardend_*.zip dist/checksums.txt
 
 .PHONY: build-all build install build-wardend install-wardend build-faucet build-wardenkms


### PR DESCRIPTION
Since we're now shipping CosmWasm (that requires CGO), cross-compilation is no longer trivial.

The current solution is to build three binaries:

- Linux amd64: built in an Alpine Linux container using musl, statically compiled
- Linux arm64 and Darwin arm64: build using goreleaser-cross in a Debian image using musl

I also added a utility target to Makefile for running the two steps above and upload the artifacts as a GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced cross-compiling and release targets for ARM64 and Linux AMD64 platforms in the build process.
  - Enhanced release verification for GitHub releases.
  
- **Chores**
  - Updated build configurations to support multiple platforms and architectures.
  - Improved build automation and environment setup for releases.

- **Documentation**
  - Updated `.gitignore` to exclude specific build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->