### PR TITLE
chore(snap): allow snap to be used from buenavista

### DIFF
--- a/snap/package-lock.json
+++ b/snap/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "wardenprotocol-snap",
-  "version": "0.1.2",
+  "name": "@wardenprotocol/snap",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wardenprotocol-snap",
-      "version": "0.1.2",
+      "name": "@wardenprotocol/snap",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@metamask/keyring-api": "^4.0.1",

--- a/snap/package.json
+++ b/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wardenprotocol/snap",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Warden Protocol MetaMask snap",
   "repository": {
     "type": "git",

--- a/snap/snap.manifest.json
+++ b/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "Warden Protocol MetaMask snap",
   "proposedName": "Warden Protocol",
   "repository": {
@@ -7,12 +7,12 @@
     "url": "https://github.com/warden-protocol/wardenprotocol.git"
   },
   "source": {
-    "shasum": "cpF5XwEp9Ig+WEtetD4/kyavpckHq8KGab7ZJKjbd50=",
+    "shasum": "oXmhIo16D0V1TjximbU49cUdUtlgyvkKjnRCV5pdU4w=",
     "location": {
       "npm": {
         "filePath": "dist/wardenprotocol-snap.bundle.js",
         "iconPath": "images/icon.svg",
-        "packageName": "wardenprotocol-snap",
+        "packageName": "@wardenprotocol/snap",
         "registry": "https://registry.npmjs.org/"
       }
     }
@@ -23,7 +23,8 @@
         "http://localhost:5173",
         "http://localhost:5174",
         "https://spaceward.devnet.wardenprotocol.org",
-        "https://spaceward.alfama.wardenprotocol.org"
+        "https://spaceward.alfama.wardenprotocol.org",
+        "https://spaceward.buenavista.wardenprotocol.org"
       ]
     },
     "endowment:rpc": {


### PR DESCRIPTION
Added buenavista to allowed origins, sync-ed and rebuilt manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the app version to 0.1.3.
- **Documentation**
	- Updated manifest details including security enhancements and allowed origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->