### PR TITLE
fix(snap): redirect url when approving requests

### DIFF
--- a/snap/src/keyring.ts
+++ b/snap/src/keyring.ts
@@ -39,11 +39,7 @@ export class WardenKeyring implements Keyring {
       id,
       address: options?.address?.valueOf() as string,
       options: options ?? {},
-      methods: [
-        'personal_sign',
-        'eth_signTransaction',
-        'eth_signTypedData_v4',
-      ],
+      methods: ['personal_sign', 'eth_signTransaction', 'eth_signTypedData_v4'],
     };
     this.state.accounts[id] = account;
     await emitSnapKeyringEvent(snap, KeyringEvent.AccountCreated, { account });
@@ -78,11 +74,13 @@ export class WardenKeyring implements Keyring {
     this.state.pendingRequests[request.id] = request;
     await this.saveState();
 
+    const url = account.options.url?.toString() ?? 'http://localhost:5173/';
+
     return {
       pending: true,
       redirect: {
         message: 'Proceed in SpaceWard to approve this request',
-        url: 'http://localhost:5173/metamask',
+        url,
       },
     };
   }

--- a/spaceward/src/features/metamask/AddToMetaMaskButton.tsx
+++ b/spaceward/src/features/metamask/AddToMetaMaskButton.tsx
@@ -55,6 +55,7 @@ export function AddToMetaMaskButton({
 
 		try {
 			await keyringSnapClient.createAccount({
+				origin: window.location.origin,
 				keyId: keyId.toString(),
 				address,
 			});


### PR DESCRIPTION
I added the origin url to each MetaMask account.

The snap will use this information to show the proper redirect when user is required to approve the signature in SpaceWard.

In short: Alfama accounts will redirect to Alfama SpaceWard, Buenavista accounts will redirect to Buenavista SpaceWard, ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved handling of method listings and URL settings in key management.
- **New Features**
	- Enhanced the account creation process in the MetaMask integration by including an origin parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->