### PR TITLE
fix(spaceward): tons of duplicate Plausible events on page change

### DIFF
--- a/spaceward/src/pages/Root.tsx
+++ b/spaceward/src/pages/Root.tsx
@@ -22,6 +22,9 @@ storyblokInit({
 	use: [apiPlugin],
 });
 
+const { enableAutoPageviews } = Plausible();
+enableAutoPageviews();
+
 interface SpacesQueryResult {
 	pageParam: number;
 	pagination?:
@@ -59,9 +62,6 @@ export function Root() {
 	if (status === "Disconnected" && address) {
 		signOut();
 	}
-
-	const { enableAutoPageviews } = Plausible();
-	enableAutoPageviews();
 
 	const { QuerySpacesByOwner } = useWardenWardenV1Beta2();
 	const { data: spacesQuery } = QuerySpacesByOwner(


### PR DESCRIPTION
Right now, Plausible get re-initialized everytime the Root component is re-rendered by React, which is...a lot.

I moved the initialization at the root level of the script so it gets initialized only once when the app is loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled automatic pageview tracking for analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->