### PR TITLE
chore(snap): bump release version

### DIFF
--- a/snap/package.json
+++ b/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wardenprotocol/snap",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Warden Protocol MetaMask snap",
   "repository": {
     "type": "git",

--- a/snap/snap.manifest.json
+++ b/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Warden Protocol MetaMask snap",
   "proposedName": "Warden Protocol",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/warden-protocol/wardenprotocol.git"
   },
   "source": {
-    "shasum": "oXmhIo16D0V1TjximbU49cUdUtlgyvkKjnRCV5pdU4w=",
+    "shasum": "jq/UFAP9Pm3j1EF2A8r0FEQcrBY++F3Cfr9yiJxDEEs=",
     "location": {
       "npm": {
         "filePath": "dist/wardenprotocol-snap.bundle.js",


### PR DESCRIPTION
I forgot to re-release the Snap on npm after #201.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Warden Protocol MetaMask snap to version 0.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->