### PR TITLE
feat(spaceward): show toast indicators when using faucet

### DIFF
--- a/spaceward/src/components/FaucetButton.tsx
+++ b/spaceward/src/components/FaucetButton.tsx
@@ -39,6 +39,7 @@ function FaucetButton() {
 					"Please wait a few seconds for the tokens to arrive.",
 				duration: 5000,
 			});
+			trackEvent("Get WARD");
 		} catch (err) {
 			update({
 				id,
@@ -57,15 +58,7 @@ function FaucetButton() {
 	return (
 		<Button
 			disabled={loading}
-			onClick={() => {
-				getTokens(),
-					trackEvent("Get WARD", {
-						callback: () => console.log("Plausible event"),
-						props: {
-							variation: "button A",
-						},
-					});
-			}}
+			onClick={() => getTokens()}
 			className="w-full h-12 gap-2"
 			size={"sm"}
 		>

--- a/spaceward/src/components/FaucetButton.tsx
+++ b/spaceward/src/components/FaucetButton.tsx
@@ -3,25 +3,55 @@ import { env } from "@/env";
 import { useAddressContext } from "@/hooks/useAddressContext";
 import { Button } from "@/components/ui/button";
 import Plausible from "plausible-tracker";
-import { PlusCircleIcon } from "lucide-react";
+import { PlusCircleIcon, RefreshCwIcon } from "lucide-react";
+import { useToast } from "./ui/use-toast";
 
 async function getFaucetTokens(addr: string) {
-	await fetch(env.faucetURL, {
+	const res = await fetch(env.faucetURL, {
 		method: "POST",
 		body: JSON.stringify({ address: addr }),
 	});
+	if (!res.ok) {
+		const data = await res.json();
+		throw new Error(data.message);
+	}
 }
 
 function FaucetButton() {
 	const [loading, setLoading] = useState(false);
 	const { address } = useAddressContext();
+	const { toast } = useToast();
 
 	const { trackEvent } = Plausible();
 
 	const getTokens = async () => {
 		setLoading(true);
-		await getFaucetTokens(address);
-		setLoading(false);
+		const { id, update } = toast({
+			title: "Requesting tokens",
+			duration: 5000,
+		});
+		try {
+			await getFaucetTokens(address);
+			update({
+				id,
+				title: "Tokens requested",
+				description:
+					"Please wait a few seconds for the tokens to arrive.",
+				duration: 5000,
+			});
+		} catch (err) {
+			update({
+				id,
+				title: "Error getting tokens",
+				description:
+					"If you already requested tokens recently, please wait a few hours before trying again.",
+				duration: 5000,
+			});
+		} finally {
+			setTimeout(() => {
+				setLoading(false);
+			}, 5000);
+		}
 	};
 
 	return (
@@ -39,8 +69,20 @@ function FaucetButton() {
 			className="w-full h-12 gap-2"
 			size={"sm"}
 		>
-			<PlusCircleIcon strokeWidth={1} className="h-6 w-6" />
-			Get WARD
+			{loading ? (
+				<>
+					<RefreshCwIcon
+						strokeWidth={1}
+						className="h-6 w-6 animate-spin"
+					/>
+					Please wait
+				</>
+			) : (
+				<>
+					<PlusCircleIcon strokeWidth={1} className="h-6 w-6" />
+					Get WARD
+				</>
+			)}
 		</Button>
 	);
 }


### PR DESCRIPTION
Many users reports indicate that it's not clear why the faucet is not working, making them think that something is broken on our side. These toasts make it clear that something *is* happening, and suggest that they might have to wait a few hours before trying again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced `FaucetButton` to display toast notifications for different states during the token request process, improving user feedback and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->