### PR TITLE
fix(shield): grouped expressions not being handled at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Consensus Breaking Changes
 
+* (shield) [#225](https://github.com/warden-protocol/wardenprotocol/225) Fix shield to handle grouped expression
+
 ### Features
 
 ### Bug Fixes

--- a/shield/ast/stringify.go
+++ b/shield/ast/stringify.go
@@ -21,7 +21,7 @@ func Stringify(exp *Expression) string {
 	case *Expression_ArrayLiteral:
 		return fmt.Sprintf("[%s]", stringifyExpressions(n.ArrayLiteral.Elements))
 	case *Expression_CallExpression:
-		return fmt.Sprintf("%s(%s)", n.CallExpression.Function, stringifyExpressions(n.CallExpression.Arguments))
+		return fmt.Sprintf("%s(%s)", n.CallExpression.Function.Value, stringifyExpressions(n.CallExpression.Arguments))
 	case *Expression_InfixExpression:
 		return fmt.Sprintf("(%s %s %s)", Stringify(n.InfixExpression.Left), n.InfixExpression.Operator, Stringify(n.InfixExpression.Right))
 	default:

--- a/shield/ast/stringify.go
+++ b/shield/ast/stringify.go
@@ -7,6 +7,10 @@ import (
 )
 
 func Stringify(exp *Expression) string {
+	if exp == nil {
+		return "{ERR:nil expression}"
+	}
+
 	switch n := exp.Value.(type) {
 	case *Expression_Identifier:
 		return n.Identifier.Value
@@ -18,6 +22,8 @@ func Stringify(exp *Expression) string {
 		return fmt.Sprintf("[%s]", stringifyExpressions(n.ArrayLiteral.Elements))
 	case *Expression_CallExpression:
 		return fmt.Sprintf("%s(%s)", n.CallExpression.Function, stringifyExpressions(n.CallExpression.Arguments))
+	case *Expression_InfixExpression:
+		return fmt.Sprintf("(%s %s %s)", Stringify(n.InfixExpression.Left), n.InfixExpression.Operator, Stringify(n.InfixExpression.Right))
 	default:
 		return ""
 	}

--- a/shield/internal/parser/parser.go
+++ b/shield/internal/parser/parser.go
@@ -51,6 +51,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.Type_TRUE, p.parseBooleanLiteral)
 	p.registerPrefix(token.Type_FALSE, p.parseBooleanLiteral)
 	p.registerPrefix(token.Type_LBRACKET, p.parseArrayLiteral)
+	p.registerPrefix(token.Type_LPAREN, p.parseGroupedExpression)
 
 	p.registerInfix(token.Type_AND, p.parseInfixExpression)
 	p.registerInfix(token.Type_OR, p.parseInfixExpression)
@@ -137,6 +138,17 @@ func (p *Parser) parseArrayLiteral() *ast.Expression {
 	al := &ast.ArrayLiteral{Token: p.curToken}
 	al.Elements = p.parseExpressionList(token.Type_RBRACKET)
 	return ast.NewArrayLiteral(al)
+}
+
+func (p *Parser) parseGroupedExpression() *ast.Expression {
+	p.nextToken()
+
+	exp := p.parseExpression(LOWEST)
+	if !p.expectPeek(token.Type_RPAREN) {
+		return nil
+	}
+
+	return exp
 }
 
 func (p *Parser) parseInfixExpression(left *ast.Expression) *ast.Expression {

--- a/shield/internal/parser/parser_test.go
+++ b/shield/internal/parser/parser_test.go
@@ -96,3 +96,53 @@ func TestBooleanOperations(t *testing.T) {
 	require.True(t, ok, "expression is not *ast.InfixExpression. got=%T", and.Left)
 	require.Equal(t, "&&", and.Operator)
 }
+
+func TestParser(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			`5`,
+			"5",
+		},
+		{
+			`true`,
+			"true",
+		},
+		{
+			`false`,
+			"false",
+		},
+		{
+			`warden1234`,
+			"warden1234",
+		},
+		{
+			`true || true && false`,
+			"(true || (true && false))",
+		},
+		{
+			`(true && false)`,
+			"(true && false)",
+		},
+		{
+			`true || (true && false)`,
+			"(true || (true && false))",
+		},
+		{
+			`((true || (address) || ((any(2, true) || false) && true)))`,
+			"((true || address) || ((any(2, true) || false) && true))",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			l := lexer.New(tt.input)
+			p := New(l)
+			expression := p.Parse()
+			require.NotNil(t, expression)
+			require.Equal(t, tt.expected, ast.Stringify(expression))
+		})
+	}
+}


### PR DESCRIPTION
We were completely ignoring grouped expressions (e.g. expressions wrapped between parentheses such as `(true || false)`).

This PR adds proper support and tests for this cases.