### PR TITLE
docs: fix typos and rerun spellcheck

### DIFF
--- a/docs/.spelling
+++ b/docs/.spelling
@@ -180,3 +180,7 @@ whitelisted
 whitepaper
 x86
 xDefi
+gamification
+leaderboard
+swappable
+warp-usdc

--- a/docs/docs/warp.md
+++ b/docs/docs/warp.md
@@ -54,8 +54,8 @@ The Phases will be split into:
 
 
 1. LBP Phase: Get early access to WARP and start to accumulate points (WARP) ahead of Warden Protocol Mainnet. The more WARP, the more WARD! Link to access the LBP Phase (starting 30/04/2024): https://app.v2.fjordfoundry.com/pools/0xb1cC5aE9f94032e4Ce168C3A4Bc191b7923e7585
-2. Farming Phase: Accumulate WARP through on-chain and off-chain activies, as well as providing liquidity for WARP-USDC LP tokens.
-3. Reedeming Phase: Get WARD tokens based on your WARP amount - and join Warden Mainnet.
+2. Farming Phase: Accumulate WARP through on-chain and off-chain activities, as well as providing liquidity for WARP-USDC LP tokens.
+3. Redeeming Phase: Get WARD tokens based on your WARP amount - and join Warden Mainnet.
 
 
 


### PR DESCRIPTION
For some reason, the GitHub action didn't run in #226 so we missed these couple spellcheck errors.