### PR TITLE
Replace "ignite serve" with "just localnet"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+* (wardend) Add `wardend genesis add-genesis-space` and `wardend genesis add-genesis-keychain` commands to prepare the genesis file
+
 ### Bug Fixes
 
 ### Misc
+
+* (build) Add `just localnet` command to replace `ignite chain serve`
 
 ## [v0.3.0](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.3.0) - 2024-03-16
 

--- a/cmd/justfile
+++ b/cmd/justfile
@@ -17,6 +17,6 @@ build binary="wardend":
 
 # install (wardend|faucet|wardenkms|clichain). Eg. "just install wardend".
 install binary="wardend":
-    go build \
+    go install \
         {{ ldflags }} \
         ./cmd/{{ binary }}

--- a/cmd/wardend/cmd/commands.go
+++ b/cmd/wardend/cmd/commands.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"errors"
+	"io"
+
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cast"
-	"io"
 
 	"cosmossdk.io/log"
 	confixcmd "cosmossdk.io/tools/confix/cmd"
@@ -51,7 +52,11 @@ func initRootCmd(
 	// add keybase, auxiliary RPC, query, genesis, and tx child commands
 	rootCmd.AddCommand(
 		server.StatusCommand(),
-		genesisCommand(txConfig, basicManager),
+		genesisCommand(
+			txConfig,
+			basicManager,
+			AddGenesisSpaceCmd(app.DefaultNodeHome),
+		),
 		queryCommand(),
 		txCommand(),
 		keys.Commands(),

--- a/cmd/wardend/cmd/commands.go
+++ b/cmd/wardend/cmd/commands.go
@@ -56,6 +56,7 @@ func initRootCmd(
 			txConfig,
 			basicManager,
 			AddGenesisSpaceCmd(app.DefaultNodeHome),
+			AddGenesisKeychainCmd(app.DefaultNodeHome),
 		),
 		queryCommand(),
 		txCommand(),

--- a/cmd/wardend/cmd/gen-commands.go
+++ b/cmd/wardend/cmd/gen-commands.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/spf13/cobra"
+)
+
+func setupGenCommand(cmd *cobra.Command) (codec.Codec, string) {
+	clientCtx := client.GetClientContextFromCmd(cmd)
+	serverCtx := server.GetServerContextFromCmd(cmd)
+	config := serverCtx.Config
+	config.SetRoot(clientCtx.HomeDir)
+	return clientCtx.Codec, config.GenesisFile()
+}
+
+func updateGenesisState(genesisFileURL string, fn func(appState map[string]json.RawMessage) error) error {
+	appState, appGenesis, err := genutiltypes.GenesisStateFromGenFile(genesisFileURL)
+	if err != nil {
+		return fmt.Errorf("unmarshalling genesis state: %w", err)
+	}
+
+	if err := fn(appState); err != nil {
+		return fmt.Errorf("updating genesis: %w", err)
+	}
+
+	appStateJSON, err := json.Marshal(appState)
+	if err != nil {
+		return fmt.Errorf("marshalling application genesis state: %w", err)
+	}
+
+	appGenesis.AppState = appStateJSON
+	return genutil.ExportGenesisFile(appGenesis, genesisFileURL)
+}

--- a/cmd/wardend/cmd/gen-keychains.go
+++ b/cmd/wardend/cmd/gen-keychains.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+
+	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
+)
+
+func AddGenesisKeychainCmd(defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-genesis-keychain <creator> <description>",
+		Short: "Add a Keychain to the genesis file",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cdc, genesisFileURL := setupGenCommand(cmd)
+
+			creator := args[0]
+			description := args[1]
+
+			return updateGenesisState(
+				genesisFileURL,
+				func(appState map[string]json.RawMessage) error {
+					wardenGenState := wardentypes.GetGenesisStateFromAppState(cdc, appState)
+
+					wardenGenState.Keychains = append(wardenGenState.Keychains, wardentypes.Keychain{
+						Id:            1 + uint64(len(wardenGenState.Keychains)),
+						Creator:       creator,
+						Description:   description,
+						Admins:        []string{creator},
+						Parties:       []string{creator},
+						AdminIntentId: 0,
+						Fees:          nil,
+						IsActive:      true,
+					})
+
+					wardenGenStateBz, err := cdc.MarshalJSON(wardenGenState)
+					if err != nil {
+						return fmt.Errorf("marshalling warden genesis state: %w", err)
+					}
+					appState[wardentypes.ModuleName] = wardenGenStateBz
+
+					return nil
+				},
+			)
+		},
+	}
+
+	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/cmd/wardend/cmd/gen-spaces.go
+++ b/cmd/wardend/cmd/gen-spaces.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+
+	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
+)
+
+func AddGenesisSpaceCmd(defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-genesis-space <creator>",
+		Short: "Add a Space to the genesis file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cdc, genesisFileURL := setupGenCommand(cmd)
+
+			creator := args[0]
+
+			return updateGenesisState(
+				genesisFileURL,
+				func(appState map[string]json.RawMessage) error {
+					wardenGenState := wardentypes.GetGenesisStateFromAppState(cdc, appState)
+
+					wardenGenState.Spaces = append(wardenGenState.Spaces, wardentypes.Space{
+						Id:            1 + uint64(len(wardenGenState.Spaces)),
+						Creator:       creator,
+						Owners:        []string{creator},
+						AdminIntentId: 0,
+						SignIntentId:  0,
+					})
+
+					wardenGenStateBz, err := cdc.MarshalJSON(wardenGenState)
+					if err != nil {
+						return fmt.Errorf("marshalling warden genesis state: %w", err)
+					}
+					appState[wardentypes.ModuleName] = wardenGenStateBz
+
+					return nil
+				},
+			)
+		},
+	}
+
+	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/justfile
+++ b/justfile
@@ -56,6 +56,7 @@ localnet bin="wardend": install
     {{bin}} genesis add-genesis-account val 10000000000000000000000000uward
     {{bin}} genesis add-genesis-account shulgin 10000000000000000000000000uward
     {{bin}} genesis add-genesis-space {{shulgin}}
+    {{bin}} genesis add-genesis-keychain {{shulgin}} "WardenKMS"
     {{bin}} genesis gentx val 1000000000uward
     {{bin}} genesis collect-gentxs
     {{bin}} start --x-crisis-skip-assert-invariants

--- a/justfile
+++ b/justfile
@@ -55,6 +55,7 @@ localnet bin="wardend": install
     echo -n '{{shulgin_mnemonic}}' | {{bin}} keys add shulgin --recover > /dev/null
     {{bin}} genesis add-genesis-account val 10000000000000000000000000uward
     {{bin}} genesis add-genesis-account shulgin 10000000000000000000000000uward
+    {{bin}} genesis add-genesis-space {{shulgin}}
     {{bin}} genesis gentx val 1000000000uward
     {{bin}} genesis collect-gentxs
     {{bin}} start --x-crisis-skip-assert-invariants

--- a/justfile
+++ b/justfile
@@ -36,3 +36,25 @@ release-wardend: #_release-wardend-linux-amd64 _release-wardend-cross-arm64
     cat dist-linux-amd64/wardend_*_checksums.txt dist/wardend_*_checksums.txt > dist/checksums.txt
     if ! git diff-index --quiet HEAD -- || [ -z "{{release_tag}}" ]; then echo "Git working directory is dirty or current commit is not tagged"; exit 1; fi
     gh release create {{release_tag}} --title {{release_tag}} --verify-tag dist-linux-amd64/wardend_Linux_x86_64.zip dist/wardend_*.zip dist/checksums.txt
+
+
+shulgin := "warden10kmgv5gzygnecf46x092ecfe5xcvvv9r870rq4"
+shulgin_mnemonic := "exclude try nephew main caught favorite tone degree lottery device tissue tent ugly mouse pelican gasp lava flush pen river noise remind balcony emerge"
+
+# run a single-node chain locally, a custom path to "wardend" can be configured
+localnet bin="wardend": install
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    rm -rf ~/.warden
+    {{bin}} init localnet --chain-id {{chain_id}} --default-denom uward > /dev/null
+    {{bin}} config set client chain-id {{chain_id}}
+    {{bin}} config set client keyring-backend test
+    {{bin}} config set app minimum-gas-prices 0uward
+    {{bin}} config set config consensus.timeout_commit 1s -s
+    {{bin}} keys add val > /dev/null
+    echo -n '{{shulgin_mnemonic}}' | {{bin}} keys add shulgin --recover > /dev/null
+    {{bin}} genesis add-genesis-account val 10000000000000000000000000uward
+    {{bin}} genesis add-genesis-account shulgin 10000000000000000000000000uward
+    {{bin}} genesis gentx val 1000000000uward
+    {{bin}} genesis collect-gentxs
+    {{bin}} start --x-crisis-skip-assert-invariants

--- a/warden/x/warden/types/v1beta2/genesis.go
+++ b/warden/x/warden/types/v1beta2/genesis.go
@@ -1,7 +1,9 @@
 package v1beta2
 
 import (
-// this line is used by starport scaffolding # genesis/types/import
+	"encoding/json"
+
+	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 // DefaultIndex is the default global index
@@ -13,6 +15,18 @@ func DefaultGenesis() *GenesisState {
 		// this line is used by starport scaffolding # genesis/types/default
 		Params: DefaultParams(),
 	}
+}
+
+// GetGenesisStateFromAppState returns GenesisState given raw application
+// genesis state.
+func GetGenesisStateFromAppState(cdc codec.JSONCodec, appState map[string]json.RawMessage) *GenesisState {
+	var genesisState GenesisState
+
+	if appState[ModuleName] != nil {
+		cdc.MustUnmarshalJSON(appState[ModuleName], &genesisState)
+	}
+
+	return &genesisState
 }
 
 // Validate performs basic genesis state validation returning an error upon any


### PR DESCRIPTION
simplify our build and development process by replacing ignite with a justfile command

When working locally, I used to run this command:
```
ignite chain serve -p warden --home ~/.warden -v -r --skip-proto
```

The only good thing about it was the `config.yml` used to configure the genesis file automatically, but I replaced all the features by introducing two new `wardend genesis add-xxx` commands.

So I wrote this simpler `just localnet` command that does pretty much the same thing, it's more transparent (as you see exactly what commands are being executed), and it's also faster. Plus, we won't require other people to install an additional tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Improved the installation process by switching to `go install` for building binaries, enhancing build efficiency.
    - Introduced commands in `wardend` for creating and managing genesis keychains and spaces.
    - Added a script for setting up a local single-node chain using `wardend` to simplify local development and testing.

- **Enhancements**
    - Updated `genesisCommand` to support additional functionalities for genesis space and keychain management.

- **Bug Fixes**
    - Implemented a new function to accurately retrieve `GenesisState` from raw application genesis state, ensuring correct state initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->