### PR TITLE
build: use `just` instead of `make` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ ENTRYPOINT ["/wardenkms"]
 
 ## node-builder
 FROM node:lts-alpine as node-build-env
+RUN apk add --no-cache python3 build-base
 RUN npm install -g pnpm@9
 
 ## snap

--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ shulgin := "warden10kmgv5gzygnecf46x092ecfe5xcvvv9r870rq4"
 shulgin_mnemonic := "exclude try nephew main caught favorite tone degree lottery device tissue tent ugly mouse pelican gasp lava flush pen river noise remind balcony emerge"
 
 # run a single-node chain locally, a custom path to "wardend" can be configured
-localnet bin="wardend": install
+localnet bin="wardend":
     #!/usr/bin/env bash
     set -euxo pipefail
     rm -rf ~/.warden


### PR DESCRIPTION
The current Docker build is broken, fix it to use `just` instead of the old `make` commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Replaced `make` commands with `just` for building components like `wardend`, `faucet`, and `wardenkms`.
	- Improved the `wardend-debug` setup for easier local development by utilizing `just` commands.
	- Removed the `install` directive for the `localnet` command in the `justfile`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->