### PR TITLE
feat(docs): add delegation program documentation

### DIFF
--- a/docs/.spelling
+++ b/docs/.spelling
@@ -202,3 +202,5 @@ reentrancy
 Node.js
 homebrew
 macOS
+undelegation
+tombstoned

--- a/docs/docs/validate/delegation-program.md
+++ b/docs/docs/validate/delegation-program.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 1
+---
+
+# Delegation Program
+
+The primary objective of this delegation plan is to promote a robust, secure,
+and decentralized blockchain network by carefully selecting validators based
+on performance, reliability, community involvement,
+and additional services they provide to the network.
+
+## What are the criteria for this delegation?
+
+Validators are evaluated based on a combination of positive and negative metrics.
+Each metric contributes to the validator's overall score, determining their eligibility and priority in the delegation process. This ensures that only the most reliable and active validators are chosen to maintain and secure the network.
+
+These metrics are, to name a few:
+
+- Activity, Community engagement, blog posts
+- Uptime
+- Services provided
+- Buenavista performance
+
+### Buenavista Performance
+
+During Buenavista, Warden Protocol team will be running a series of exercises with validators.
+The aim of these exercises is to test and prepare for a future mainnet event where
+Warden Protocol team will be delegating a portion of its token supply to qualifying validators.
+
+## What is the total number of tokens delegated to validators?
+
+At mainnet, Warden Protocol team intends to delegate 10% of its token supply to validators.
+
+## What number of validators will receive a delegation?
+
+Validators will be categorized into four different tiers.
+Each of these tiers will get a percentage of the delegation pool allocated during the mainnet launch.
+
+| Tiers | Amount    | Number of Validators | % / Validator | % Total | Total Delegation |
+| ----- | --------- | -------------------- | ------------- | ------- | ---------------- |
+| 1     | 1 Million | 5                    | 4%            | 20%     | 5 Million        |
+| 2     | 750,000   | 5                    | 3%            | 15%     | 3,75 Million     |
+| 3     | 625,000   | 10                   | 2,5%          | 25%     | 6,25 Million     |
+| 4     | 250,000   | 40                   | 1%            | 40%     | 10 Million       |
+
+Amounts are expressed in WARD tokens.
+
+## Commitment to Basic Validator Requirements
+
+Validators who want to attract delegations must comply with essential network support standards
+to sustain their delegations.
+If they fail to meet these standards, they may lose their delegations.
+
+These standards include:
+
+- Commission Rate up to: 10%
+- Uptime at least 95%
+- Governance participation of at least 80%
+- Minimal slashing rate
+- Timely upgrades and responsiveness to protocol release
+
+## Undelegation criteria
+
+- Getting slashed/tombstoned (cannot apply for 1 year afterward)
+- Getting jailed more than once during the quarter-applicable delegation period
+- Failing to upgrade your node in a timely manner (24 hours or less)
+- For any other reason, at Warden Protocol team's discretion
+- Failed to meet the commitments set by Warden Protocol team
+
+## Token reallocation program
+
+The Warden Protocol team will periodically reallocate tokens to balance the network and review the Validators' commitments.
+
+## Feedback process
+
+Validators in the program will receive a feedback form every quarter, so the program can be continually improved.


### PR DESCRIPTION
This will add Wardens delegation program for the docs site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the spelling list with new terms: "undelegation" and "tombstoned."
	- Added detailed documentation on the delegation program for blockchain validators, including criteria for selection, undelegation, and feedback processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->