### PR TITLE
Fix wardenjs ESM in Node.js

### DIFF
--- a/spaceward/src/components/SendEth.tsx
+++ b/spaceward/src/components/SendEth.tsx
@@ -7,7 +7,7 @@ import SignatureRequestDialog from "@/components/SignatureRequestDialog";
 import { MetadataEthereum } from "warden-protocol-wardenprotocol-client-ts/lib/warden.warden.v1beta2/module";
 import { SignMethod } from "warden-protocol-wardenprotocol-client-ts/lib/warden.warden.v1beta2/types/warden/warden/v1beta2/signature";
 import { useQueryHooks } from "@/hooks/useClient";
-import { AddressType } from "@wardenprotocol/wardenjs/dist/codegen/warden/warden/v1beta2/key";
+import { AddressType } from "@wardenprotocol/wardenjs/codegen/warden/warden/v1beta2/key";
 import { ArrowUpRight } from "lucide-react";
 
 const url = "https://ethereum-sepolia-rpc.publicnode.com";

--- a/spaceward/src/features/actions/Action.tsx
+++ b/spaceward/src/features/actions/Action.tsx
@@ -4,7 +4,7 @@ import { useAddressContext } from "@/hooks/useAddressContext";
 import {
 	ActionStatus,
 	Action as ActionModel,
-} from "@wardenprotocol/wardenjs/dist/codegen/warden/intent/action";
+} from "@wardenprotocol/wardenjs/codegen/warden/intent/action";
 import { useClient } from "@/hooks/useClient";
 import { useToast } from "@/components/ui/use-toast";
 import { monitorTx } from "@/hooks/keplr";

--- a/spaceward/src/features/assets/Assets.tsx
+++ b/spaceward/src/features/assets/Assets.tsx
@@ -13,9 +13,9 @@ import { ReceiveAssetButton } from "@/features/assets";
 import { Copy } from "@/components/ui/copy";
 import { NewKeyButton } from "@/features/keys";
 import { useQueryHooks } from "@/hooks/useClient";
-import { PageRequest } from "@wardenprotocol/wardenjs/dist/codegen/cosmos/base/query/v1beta1/pagination";
-import { base64FromBytes } from "@wardenprotocol/wardenjs/dist/codegen/helpers";
-import { AddressType } from "@wardenprotocol/wardenjs/dist/codegen/warden/warden/v1beta2/key";
+import { PageRequest } from "@wardenprotocol/wardenjs/codegen/cosmos/base/query/v1beta1/pagination";
+import { base64FromBytes } from "@wardenprotocol/wardenjs/codegen/helpers";
+import { AddressType } from "@wardenprotocol/wardenjs/codegen/warden/warden/v1beta2/key";
 
 const url = "https://rpc2.sepolia.org";
 const provider = new ethers.JsonRpcProvider(url);

--- a/spaceward/src/features/home/HomeAssets.tsx
+++ b/spaceward/src/features/home/HomeAssets.tsx
@@ -12,8 +12,8 @@ import { NewKeyButton } from "@/features/keys";
 import { ReceiveAssetButton } from "@/features/assets";
 import { Copy } from "@/components/ui/copy";
 import { useQueryHooks } from "@/hooks/useClient";
-import { AddressType } from "@wardenprotocol/wardenjs/dist/codegen/warden/warden/v1beta2/key";
-import { PageRequest } from "@wardenprotocol/wardenjs/dist/codegen/cosmos/base/query/v1beta1/pagination";
+import { AddressType } from "@wardenprotocol/wardenjs/codegen/warden/warden/v1beta2/key";
+import { PageRequest } from "@wardenprotocol/wardenjs/codegen/cosmos/base/query/v1beta1/pagination";
 
 const url = "https://rpc2.sepolia.org";
 const provider = new ethers.JsonRpcProvider(url);

--- a/spaceward/src/features/home/TotalAssetValue.tsx
+++ b/spaceward/src/features/home/TotalAssetValue.tsx
@@ -5,8 +5,8 @@ import { useCurrency } from "@/hooks/useCurrency";
 import { useQueries } from "@tanstack/react-query";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useQueryHooks } from "@/hooks/useClient";
-import { PageRequest } from "@wardenprotocol/wardenjs/dist/codegen/cosmos/base/query/v1beta1/pagination";
-import { AddressType } from "@wardenprotocol/wardenjs/dist/codegen/warden/warden/v1beta2/key";
+import { PageRequest } from "@wardenprotocol/wardenjs/codegen/cosmos/base/query/v1beta1/pagination";
+import { AddressType } from "@wardenprotocol/wardenjs/codegen/warden/warden/v1beta2/key";
 
 const url = "https://rpc2.sepolia.org";
 const chainId = 11155111;

--- a/spaceward/src/features/keys/Keys.tsx
+++ b/spaceward/src/features/keys/Keys.tsx
@@ -19,10 +19,10 @@ import { useQueryHooks } from "@/hooks/useClient";
 import {
 	Key as KeyModel,
 	AddressType,
-} from "@wardenprotocol/wardenjs/dist/codegen/warden/warden/v1beta2/key";
-import { PageRequest } from "@wardenprotocol/wardenjs/dist/codegen/cosmos/base/query/v1beta1/pagination";
-import { AddressResponse } from "@wardenprotocol/wardenjs/dist/codegen/warden/warden/v1beta2/query";
-import { base64FromBytes } from "@wardenprotocol/wardenjs/dist/codegen/helpers";
+} from "@wardenprotocol/wardenjs/codegen/warden/warden/v1beta2/key";
+import { PageRequest } from "@wardenprotocol/wardenjs/codegen/cosmos/base/query/v1beta1/pagination";
+import { AddressResponse } from "@wardenprotocol/wardenjs/codegen/warden/warden/v1beta2/query";
+import { base64FromBytes } from "@wardenprotocol/wardenjs/codegen/helpers";
 
 export function Keys({ spaceId }: { spaceId: string }) {
 	const { useKeysBySpaceId, isReady } = useQueryHooks();

--- a/spaceward/src/features/walletconnect/WalletConnect.tsx
+++ b/spaceward/src/features/walletconnect/WalletConnect.tsx
@@ -44,9 +44,9 @@ import { useTheme } from "next-themes";
 import { MetadataEthereum } from "warden-protocol-wardenprotocol-client-ts/lib/warden.warden.v1beta2/module";
 import { cn } from "@/lib/utils";
 import { SignMethod } from "warden-protocol-wardenprotocol-client-ts/lib/warden.warden.v1beta2/types/warden/warden/v1beta2/signature";
-import { AddressType } from "@wardenprotocol/wardenjs/dist/codegen/warden/warden/v1beta2/key";
+import { AddressType } from "@wardenprotocol/wardenjs/codegen/warden/warden/v1beta2/key";
 import { Html5Qrcode } from "html5-qrcode";
-import { base64FromBytes } from "@wardenprotocol/wardenjs/dist/codegen/helpers";
+import { base64FromBytes } from "@wardenprotocol/wardenjs/codegen/helpers";
 import { useSpaceId } from "@/hooks/useSpaceId";
 
 function useWeb3Wallet(relayUrl: string) {

--- a/spaceward/src/utils/formatting.ts
+++ b/spaceward/src/utils/formatting.ts
@@ -1,6 +1,6 @@
-import { KeyType } from "@wardenprotocol/wardenjs/dist/codegen/warden/warden/v1beta2/key";
+import { KeyType } from "@wardenprotocol/wardenjs/codegen/warden/warden/v1beta2/key";
 import { KeyType as KeyTypeOld } from "warden-protocol-wardenprotocol-client-ts/lib/warden.warden.v1beta2/rest";
-import { ActionStatus } from "@wardenprotocol/wardenjs/dist/codegen/warden/intent/action";
+import { ActionStatus } from "@wardenprotocol/wardenjs/codegen/warden/intent/action";
 import { ActionStatus as ActionStatusOld } from "warden-protocol-wardenprotocol-client-ts/lib/warden.intent/rest";
 
 export function prettyKeyType(type: KeyType | KeyTypeOld | string) {

--- a/wardenjs/CHANGELOG.md
+++ b/wardenjs/CHANGELOG.md
@@ -38,6 +38,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.0.5]
+
+### Misc
+
+- Fix ESM support in Node.js. Previous versions were only tested in React apps using Vite.
+
 ## [v0.0.4]
 
 ### Misc

--- a/wardenjs/package.json
+++ b/wardenjs/package.json
@@ -6,6 +6,10 @@
   "homepage": "https://github.com/warden-protocol/wardenprotocol",
   "license": "SEE LICENSE IN LICENSE",
   "module": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./codegen/*": "./dist/codegen/*.js"
+  },
   "typings": "dist/index.d.ts",
   "directories": {
     "lib": "src"

--- a/wardenjs/package.json
+++ b/wardenjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wardenprotocol/wardenjs",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Warden Protocol JavaScript client",
   "author": "Warden Protocol",
   "homepage": "https://github.com/warden-protocol/wardenprotocol",

--- a/wardenjs/package.json
+++ b/wardenjs/package.json
@@ -15,7 +15,7 @@
     "!CHANGELOG.md"
   ],
   "scripts": {
-    "build:mjs": "pnpm exec tsc -p tsconfig.json --outDir dist --module es2022 || true",
+    "build:mjs": "pnpm exec tsc -p tsconfig.json --outDir dist || true",
     "clean": "rimraf dist",
     "build": "pnpm clean && pnpm build:mjs ",
     "codegen": "node scripts/codegen.js",

--- a/wardenjs/tsconfig.json
+++ b/wardenjs/tsconfig.json
@@ -6,7 +6,8 @@
         "declaration": true,
         "esModuleInterop": true,
         "target": "es2022",
-        "module": "es2022",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
         "lib": [
             "es2022",
             "DOM"
@@ -15,7 +16,6 @@
         "isolatedModules": true,
         "allowJs": true,
         "downlevelIteration": true,
-        "moduleResolution": "node",
         "resolveJsonModule": true
     },
     "include": [


### PR DESCRIPTION
You can test that it works by doing this:

- create a Node.js project (e.g. create a folder and run `npm init`)
- run `npm install @wardenprotocol/wardenjs @tanstack/react-query@4.36.1 react-dom`
- create `index.mjs` with the following content:
  ```js
  import * as Foo from "@wardenprotocol/wardenjs";
  console.log(Foo);
  ```
- run `node index.mjs`

I cleaned up import paths by removing `dist/` and fixed all occurences in SpaceWard as well.

closes #274