### PR TITLE
Fix keychain-sdk request tracker for signature requests

### DIFF
--- a/cmd/wardenkms/wardenkms.go
+++ b/cmd/wardenkms/wardenkms.go
@@ -31,6 +31,7 @@ type Config struct {
 	BatchInterval time.Duration `env:"BATCH_INTERVAL, default=8s"`
 	BatchSize     int           `env:"BATCH_SIZE, default=20"`
 	GasLimit      uint64        `env:"GAS_LIMIT, default=400000"`
+	TxTimeout     time.Duration `env:"TX_TIMEOUT, default=30s"`
 
 	HttpAddr string `env:"HTTP_ADDR, default=:8080"`
 
@@ -64,6 +65,7 @@ func main() {
 		GasLimit:       cfg.GasLimit,
 		BatchInterval:  cfg.BatchInterval,
 		BatchSize:      cfg.BatchSize,
+		TxTimeout:      cfg.TxTimeout,
 	})
 
 	app.SetKeyRequestHandler(func(w keychain.KeyResponseWriter, req *keychain.KeyRequest) {

--- a/cmd/wardenkms/wardenkms.go
+++ b/cmd/wardenkms/wardenkms.go
@@ -28,9 +28,9 @@ type Config struct {
 	KeyringMnemonic string `env:"KEYRING_MNEMONIC, required"`
 	KeyringPassword string `env:"KEYRING_PASSWORD, required"`
 
-	BatchTimeout time.Duration `env:"BATCH_TIMEOUT, default=8s"`
-	BatchSize    int           `env:"BATCH_SIZE, default=20"`
-	GasLimit     uint64        `env:"GAS_LIMIT, default=400000"`
+	BatchInterval time.Duration `env:"BATCH_INTERVAL, default=8s"`
+	BatchSize     int           `env:"BATCH_SIZE, default=20"`
+	GasLimit      uint64        `env:"GAS_LIMIT, default=400000"`
 
 	HttpAddr string `env:"HTTP_ADDR, default=:8080"`
 
@@ -62,7 +62,7 @@ func main() {
 		Mnemonic:       cfg.Mnemonic,
 		KeychainId:     cfg.KeychainId,
 		GasLimit:       cfg.GasLimit,
-		BatchTimeout:   cfg.BatchTimeout,
+		BatchInterval:  cfg.BatchInterval,
 		BatchSize:      cfg.BatchSize,
 	})
 

--- a/keychain-sdk/config.go
+++ b/keychain-sdk/config.go
@@ -27,9 +27,9 @@ type Config struct {
 	// Mnemonic is the mnemonic to use to derive this Keychain's party private key.
 	Mnemonic string
 
-	// BatchTimeout is the time to wait before sending a batch of requests to the blockchain.
+	// BatchInterval is the time to wait before sending a batch of requests to the blockchain.
 	// Tipically, the batch timeout should be set to the time it takes to produce a block on the blockchain.
-	BatchTimeout time.Duration
+	BatchInterval time.Duration
 
 	// BatchSize is the maximum number of requests to batch together before sending them to the blockchain.
 	BatchSize int

--- a/keychain-sdk/config.go
+++ b/keychain-sdk/config.go
@@ -37,4 +37,10 @@ type Config struct {
 	// GasLimit is the maximum amount of gas to use for each transaction.
 	// The more messages in a batch, the more gas is needed.
 	GasLimit uint64
+
+	// TxTimeout is the amount of time to wait for a transaction to be included
+	// in a block after having broadcasted it. If the transaction isn't
+	// included in a block, it will be considered as failed (but the blockchain
+	// might still include in a block later).
+	TxTimeout time.Duration
 }

--- a/keychain-sdk/key_requests.go
+++ b/keychain-sdk/key_requests.go
@@ -27,13 +27,17 @@ type keyResponseWriter struct {
 	onComplete   func()
 }
 
-func (w *keyResponseWriter) Fulfil(publicKey []byte) error {
+func (w *keyResponseWriter) Fulfil(publicKey []byte) (err error) {
 	w.logger.Debug("fulfilling key request", "id", w.keyRequestID, "public_key", hex.EncodeToString(publicKey))
-	defer w.onComplete()
-	return w.txWriter.Write(w.ctx, client.KeyRequestFulfilment{
+	defer func() {
+		w.onComplete()
+		w.logger.Debug("fulfilled key request", "id", w.keyRequestID, "error", err)
+	}()
+	err = w.txWriter.Write(w.ctx, client.KeyRequestFulfilment{
 		RequestID: w.keyRequestID,
 		PublicKey: publicKey,
 	})
+	return
 }
 
 func (w *keyResponseWriter) Reject(reason string) error {

--- a/keychain-sdk/key_requests.go
+++ b/keychain-sdk/key_requests.go
@@ -103,5 +103,5 @@ func (a *App) handleKeyRequest(keyRequest *wardentypes.KeyRequest) {
 }
 
 func (a *App) keyRequests(ctx context.Context) ([]*wardentypes.KeyRequest, error) {
-	return a.query.PendingKeyRequests(ctx, &client.PageRequest{Limit: defaultPageLimit}, a.config.KeychainId)
+	return a.query.PendingKeyRequests(ctx, &client.PageRequest{Limit: uint64(a.config.BatchSize)}, a.config.KeychainId)
 }

--- a/keychain-sdk/keychain.go
+++ b/keychain-sdk/keychain.go
@@ -112,7 +112,7 @@ func (a *App) initConnections() error {
 	a.logger().Info("keychain party identity", "address", identity.Address.String())
 
 	txClient := client.NewTxClient(identity, a.config.ChainID, conn, query)
-	a.txWriter = NewTxWriter(txClient, a.config.BatchSize, a.config.BatchTimeout, a.logger())
+	a.txWriter = NewTxWriter(txClient, a.config.BatchSize, a.config.BatchInterval, a.config.TxTimeout, a.logger())
 	a.txWriter.GasLimit = a.config.GasLimit
 
 	return nil

--- a/keychain-sdk/keychain.go
+++ b/keychain-sdk/keychain.go
@@ -117,5 +117,3 @@ func (a *App) initConnections() error {
 
 	return nil
 }
-
-var defaultPageLimit = uint64(20)

--- a/keychain-sdk/sign_requests.go
+++ b/keychain-sdk/sign_requests.go
@@ -27,13 +27,17 @@ type signResponseWriter struct {
 	onComplete    func()
 }
 
-func (w *signResponseWriter) Fulfil(signature []byte) error {
+func (w *signResponseWriter) Fulfil(signature []byte) (err error) {
 	w.logger.Debug("fulfilling sign request", "id", w.signRequestID, "signature", hex.EncodeToString(signature))
-	defer w.onComplete()
-	return w.txWriter.Write(w.ctx, client.SignRequestFulfilment{
+	defer func() {
+		w.onComplete()
+		w.logger.Debug("fulfilled sign request", "id", w.signRequestID, "error", err)
+	}()
+	err = w.txWriter.Write(w.ctx, client.SignRequestFulfilment{
 		RequestID: w.signRequestID,
 		Signature: signature,
 	})
+	return
 }
 
 func (w *signResponseWriter) Reject(reason string) error {

--- a/keychain-sdk/sign_requests.go
+++ b/keychain-sdk/sign_requests.go
@@ -104,5 +104,5 @@ func (a *App) handleSignRequest(signRequest *wardentypes.SignRequest) {
 }
 
 func (a *App) signRequests(ctx context.Context) ([]*wardentypes.SignRequest, error) {
-	return a.query.PendingSignatureRequests(ctx, &client.PageRequest{Limit: defaultPageLimit}, a.config.KeychainId)
+	return a.query.PendingSignatureRequests(ctx, &client.PageRequest{Limit: uint64(a.config.BatchSize)}, a.config.KeychainId)
 }

--- a/keychain-sdk/sign_requests.go
+++ b/keychain-sdk/sign_requests.go
@@ -84,7 +84,7 @@ func (a *App) handleSignRequest(signRequest *wardentypes.SignRequest) {
 			signRequestID: signRequest.Id,
 			logger:        a.logger(),
 			onComplete: func() {
-				a.keyRequestTracker.Done(signRequest.Id)
+				a.signRequestTracker.Done(signRequest.Id)
 			},
 		}
 		defer func() {

--- a/keychain-sdk/writer.go
+++ b/keychain-sdk/writer.go
@@ -56,9 +56,11 @@ func (w *TxWriter) Start(ctx context.Context, flushErrors chan error) error {
 		case <-ctx.Done():
 			return nil
 		default:
+			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			if err := w.Flush(ctx); err != nil {
 				flushErrors <- err
 			}
+			cancel()
 			time.Sleep(w.BatchTimeout)
 		}
 	}

--- a/keychain-sdk/writer.go
+++ b/keychain-sdk/writer.go
@@ -51,17 +51,15 @@ func NewTxWriter(
 
 func (w *TxWriter) Start(ctx context.Context, flushErrors chan error) error {
 	w.Logger.Info("starting tx writer")
-	ticker := time.NewTicker(w.BatchTimeout)
-	defer ticker.Stop()
-
 	for {
 		select {
-		case <-ticker.C:
+		case <-ctx.Done():
+			return nil
+		default:
 			if err := w.Flush(ctx); err != nil {
 				flushErrors <- err
 			}
-		case <-ctx.Done():
-			return nil
+			time.Sleep(w.BatchTimeout)
 		}
 	}
 }

--- a/keychain-sdk/writer.go
+++ b/keychain-sdk/writer.go
@@ -11,8 +11,8 @@ import (
 )
 
 type TxWriter struct {
-	// BatchTimeout is the maximum time to wait before sending a batch of messages.
-	BatchTimeout time.Duration
+	// BatchInterval is the time to wait between trying to send a batch of messages.
+	BatchInterval time.Duration
 
 	// Client is the client used to send transactions to the chain.
 	Client *client.TxClient
@@ -34,14 +34,14 @@ type TxWriter struct {
 func NewTxWriter(
 	client *client.TxClient,
 	batchSize int,
-	batchTimeout time.Duration,
+	batchInterval time.Duration,
 	logger *slog.Logger,
 ) *TxWriter {
 	return &TxWriter{
 		Client:       client,
-		BatchTimeout: batchTimeout,
 		Logger:       logger,
 		batch:        Batch{messages: make(chan BatchItem, batchSize)},
+		BatchInterval: batchInterval,
 	}
 }
 
@@ -57,7 +57,7 @@ func (w *TxWriter) Start(ctx context.Context, flushErrors chan error) error {
 				flushErrors <- err
 			}
 			cancel()
-			time.Sleep(w.BatchTimeout)
+			time.Sleep(w.BatchInterval)
 		}
 	}
 }

--- a/keychain-sdk/writer.go
+++ b/keychain-sdk/writer.go
@@ -14,6 +14,10 @@ type TxWriter struct {
 	// BatchInterval is the time to wait between trying to send a batch of messages.
 	BatchInterval time.Duration
 
+	// TxTimeout is the maximum amount of time to wait for a transaction to be
+	// included in a block after being broadcasted.
+	TxTimeout time.Duration
+
 	// Client is the client used to send transactions to the chain.
 	Client *client.TxClient
 
@@ -35,13 +39,15 @@ func NewTxWriter(
 	client *client.TxClient,
 	batchSize int,
 	batchInterval time.Duration,
+	txTimeout time.Duration,
 	logger *slog.Logger,
 ) *TxWriter {
 	return &TxWriter{
-		Client:       client,
-		Logger:       logger,
-		batch:        Batch{messages: make(chan BatchItem, batchSize)},
+		Client:        client,
 		BatchInterval: batchInterval,
+		TxTimeout:     txTimeout,
+		Logger:        logger,
+		batch:         Batch{messages: make(chan BatchItem, batchSize)},
 	}
 }
 
@@ -52,7 +58,10 @@ func (w *TxWriter) Start(ctx context.Context, flushErrors chan error) error {
 		case <-ctx.Done():
 			return nil
 		default:
-			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			ctx, cancel := context.WithCancel(ctx)
+			if w.TxTimeout > 0 {
+				ctx, cancel = context.WithTimeout(ctx, w.TxTimeout)
+			}
 			if err := w.Flush(ctx); err != nil {
 				flushErrors <- err
 			}

--- a/keychain-sdk/writer.go
+++ b/keychain-sdk/writer.go
@@ -11,9 +11,6 @@ import (
 )
 
 type TxWriter struct {
-	// Limit is the maximum number of messages to batch together. When the limit is reached, the batch is sent.
-	Limit int
-
 	// BatchTimeout is the maximum time to wait before sending a batch of messages.
 	BatchTimeout time.Duration
 
@@ -42,7 +39,6 @@ func NewTxWriter(
 ) *TxWriter {
 	return &TxWriter{
 		Client:       client,
-		Limit:        batchSize,
 		BatchTimeout: batchTimeout,
 		Logger:       logger,
 		batch:        Batch{messages: make(chan BatchItem, batchSize)},


### PR DESCRIPTION
There was a bug in keychain-sdk that was using the request tracker meant for key requests, for signature requests too.

Apart from that I'm adding a few more logs, adding a timeout for waiting for the transaction to be included in a block, and ensure that the "flushes" don't accumulate over time in case of slow network.

I feel like something is still not working exactly as intended but this PR should at least give more clarity on what's going on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced error handling and logging in key response and sign response workflows.
  - Transitioned to customizable batch sizes from fixed limits for request processing.

- **Bug Fixes**
  - Refined context cancellation and message batching mechanisms in transaction writing procedures.

- **Chores**
  - Streamlined configuration management by eliminating the redundant global variable `defaultPageLimit`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->