### PR TITLE
Make tx fees configurable in keychain-sdk

### DIFF
--- a/cmd/wardenkms/wardenkms.go
+++ b/cmd/wardenkms/wardenkms.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"time"
 
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/sethvargo/go-envconfig"
 	"google.golang.org/grpc/connectivity"
 
@@ -32,6 +34,7 @@ type Config struct {
 	BatchSize     int           `env:"BATCH_SIZE, default=20"`
 	GasLimit      uint64        `env:"GAS_LIMIT, default=400000"`
 	TxTimeout     time.Duration `env:"TX_TIMEOUT, default=30s"`
+	TxFee         int64         `env:"TX_FEE, default=400000"`
 
 	HttpAddr string `env:"HTTP_ADDR, default=:8080"`
 
@@ -66,6 +69,7 @@ func main() {
 		BatchInterval:  cfg.BatchInterval,
 		BatchSize:      cfg.BatchSize,
 		TxTimeout:      cfg.TxTimeout,
+		TxFees:         sdk.NewCoins(sdk.NewCoin("uward", math.NewInt(cfg.TxFee))),
 	})
 
 	app.SetKeyRequestHandler(func(w keychain.KeyResponseWriter, req *keychain.KeyRequest) {

--- a/cmd/wardenkms/wardenkms.go
+++ b/cmd/wardenkms/wardenkms.go
@@ -31,9 +31,9 @@ type Config struct {
 	KeyringPassword string `env:"KEYRING_PASSWORD, required"`
 
 	BatchInterval time.Duration `env:"BATCH_INTERVAL, default=8s"`
-	BatchSize     int           `env:"BATCH_SIZE, default=20"`
+	BatchSize     int           `env:"BATCH_SIZE, default=7"`
 	GasLimit      uint64        `env:"GAS_LIMIT, default=400000"`
-	TxTimeout     time.Duration `env:"TX_TIMEOUT, default=30s"`
+	TxTimeout     time.Duration `env:"TX_TIMEOUT, default=120s"`
 	TxFee         int64         `env:"TX_FEE, default=400000"`
 
 	HttpAddr string `env:"HTTP_ADDR, default=:8080"`

--- a/keychain-sdk/config.go
+++ b/keychain-sdk/config.go
@@ -3,6 +3,8 @@ package keychain
 import (
 	"log/slog"
 	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type Config struct {
@@ -37,6 +39,9 @@ type Config struct {
 	// GasLimit is the maximum amount of gas to use for each transaction.
 	// The more messages in a batch, the more gas is needed.
 	GasLimit uint64
+
+	// TxFees are the coins used as fees for the transaction sent.
+	TxFees sdk.Coins
 
 	// TxTimeout is the amount of time to wait for a transaction to be included
 	// in a block after having broadcasted it. If the transaction isn't

--- a/keychain-sdk/keychain.go
+++ b/keychain-sdk/keychain.go
@@ -113,6 +113,7 @@ func (a *App) initConnections() error {
 
 	txClient := client.NewTxClient(identity, a.config.ChainID, conn, query)
 	a.txWriter = NewTxWriter(txClient, a.config.BatchSize, a.config.BatchInterval, a.config.TxTimeout, a.logger())
+	a.txWriter.Fees = a.config.TxFees
 	a.txWriter.GasLimit = a.config.GasLimit
 
 	return nil


### PR DESCRIPTION
It's now possible to configure tx fees to be attached in the transaction sent by keychain-sdk, and I updated wardenkms to use this new feature.

I think there could be a way for go-client to estimate gas and fees automatically, but for now let's work with this fixed values.

Also took the chance to perform some more minor cleanups in the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new transaction fee configuration across various components to enhance transaction handling.
- **Enhancements**
  - Updated default values for batch processing size and transaction timeout settings to optimize performance.
- **Bug Fixes**
  - Improved error handling and logging in transaction and signature response methods for clarity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->