### PR TITLE
Added Coingecko link to WARP

### DIFF
--- a/docs/.spelling
+++ b/docs/.spelling
@@ -204,3 +204,4 @@ homebrew
 macOS
 undelegation
 tombstoned
+Coingecko

--- a/docs/docs/warp/warp.md
+++ b/docs/docs/warp/warp.md
@@ -19,6 +19,7 @@ sidebar_position: 3
 | Decimals | 6 |
 | Contract Address | 0x3c8665472ec5aF30981B06B4E0143663EBeDcc1E |
 | Explorer Address | https://basescan.org/address/0x3c8665472ec5aF30981B06B4E0143663EBeDcc1E |
+| Coingecko | https://www.coingecko.com/en/coins/warden-protocol-warp |
 | DEX Tools | https://www.dextools.io/app/en/base/pair-explorer/0xf523d578816e1b537d8d69500d44d0c699b5d9a9?t=1714815531823 |
 | MEXC | https://www.mexc.com/exchange/WARP_USDT |
 


### PR DESCRIPTION
Added Coingecko link to WARP docs page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Coingecko link for Warden Protocol (WARP) in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->