### PR TITLE
Faucet v2

### DIFF
--- a/.github/workflows/wardend.yml
+++ b/.github/workflows/wardend.yml
@@ -7,16 +7,18 @@ on:
       - main
     paths:
       - "cmd/faucet/**"
+      - "cmd/faucet-v2/**"
       - "cmd/wardend/**"
       - "warden/**"
   pull_request:
     paths:
       - "cmd/faucet/**"
+      - "cmd/faucet-v2/**"
       - "cmd/wardend/**"
       - "warden/**"
 
 env:
-  modules: "./warden/... ./cmd/wardend/... ./cmd/faucet/..."
+  modules: "./warden/... ./cmd/wardend/... ./cmd/faucet/... ./cmd/faucet-v2/..."
 
 jobs:
   lint:
@@ -62,5 +64,5 @@ jobs:
     needs: [lint, unit-test]
     uses: ./.github/workflows/build_push.yml
     with:
-      service_name: faucet
+      service_name: faucet-v2
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ dist-linux-amd64
 *.njsproj
 *.sln
 *.sw?
+.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (wardend) analyzers smart contract: a way for 3rd party builders to provide metadata to shield's intents during new signature requests
 * (wardend) Initial version Ethereum analyzer
     * can be used to pass an Ethereum unsigned transaction, and will return the correct DataForSigning
+* (faucet/v2) New web-based version of the faucet that uses recaptcha.
 
 ### Bug Fixes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=bind,source=.,target=.,readonly\
 RUN --mount=type=bind,source=.,target=.,readonly\
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    just output_dir=/build build faucet
+    just output_dir=/build build faucet-v2
 
 
 FROM debian:bookworm-slim AS wardend
@@ -38,14 +38,14 @@ CMD just localnet
 ## faucet
 FROM debian:bookworm-slim AS faucet
 COPY --from=wardend-build /build/wardend /usr/bin/wardend
-COPY --from=wardend-build /build/faucet /usr/bin/faucet
+COPY --from=wardend-build /build/faucet-v2 /usr/bin/faucet-v2
 ADD --checksum=sha256:b0c3b761e5f00e45bdafebcfe9c03bd703b88b3f535c944ca8e27ef9b891cd10 https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 EXPOSE 8000
 USER nobody
-CMD ["/usr/bin/faucet"]
+CMD ["/usr/bin/faucet-v2"]
 
 
 ## wardenkms

--- a/cmd/faucet-v2/client.go
+++ b/cmd/faucet-v2/client.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Client struct {
+	logger *slog.Logger
+	cfg    Config
+
+	batchmu sync.Mutex
+	batch   map[string]chan error
+}
+
+func NewClient(ctx context.Context, logger *slog.Logger, cfg Config) (*Client, error) {
+	c := &Client{
+		logger: logger,
+		cfg:    cfg,
+		batch:  make(map[string]chan error),
+	}
+
+	if cfg.Mnemonic != "" {
+		if _, err := c.setupNewAccount(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	go c.sendBatchLoop(ctx)
+
+	return c, nil
+}
+
+func (c *Client) setupNewAccount(ctx context.Context) (Out, error) {
+	// echo $mnemonic | $baseCmd keys add $SK1 --recover
+	cmd := strings.Join([]string{
+		"echo",
+		c.cfg.Mnemonic,
+		"|",
+		c.cfg.CliName,
+		"keys",
+		"--keyring-backend",
+		c.cfg.KeyringBackend,
+		"add",
+		c.cfg.AccountName,
+		"--recover",
+	}, " ")
+	return e(ctx, cmd, false)
+}
+
+func (c *Client) Send(addr string) chan error {
+	c.batchmu.Lock()
+	defer c.batchmu.Unlock()
+
+	if len(c.batch) > c.cfg.BatchLimit {
+		return nil
+	}
+
+	ch := make(chan error, 1)
+	c.batch[addr] = ch
+	batchSize.Inc()
+	slog.Info("add address to batch", "address", addr)
+	return ch
+}
+
+func (c *Client) sendBatchLoop(ctx context.Context) {
+	ticker := time.NewTicker(c.cfg.BatchInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := c.sendBatchIfNeeded(ctx); err != nil {
+				log.Printf("error sending batch: %s", err)
+			}
+		}
+	}
+}
+
+func (c *Client) sendBatchIfNeeded(ctx context.Context) error {
+	c.batchmu.Lock()
+	defer c.batchmu.Unlock()
+
+	if len(c.batch) == 0 {
+		return nil
+	}
+
+	slog.Info("sending batch", "size", len(c.batch))
+	err := c.sendBatch(ctx)
+	if err != nil {
+		// propagate error to each batch entry
+		slog.Error("error sending batch", "err", err)
+		for _, dest := range c.batch {
+			dest <- err
+		}
+	} else {
+		// clear batch entries chans
+		for _, dest := range c.batch {
+			close(dest)
+		}
+	}
+
+	// Clear batch even if the transaction failed, it's easier to not get stuck
+	// for some reasons this way. Users can retry using the faucet after a
+	// while.
+	clear(c.batch)
+	batchSize.Set(0)
+
+	return err
+}
+
+func (c *Client) sendBatch(ctx context.Context) error {
+	send := "send"
+	if len(c.batch) > 1 {
+		send = "multi-send"
+	}
+
+	addrs := make([]string, 0, len(c.batch))
+	for addr := range c.batch {
+		addrs = append(addrs, addr)
+	}
+
+	cmd := strings.Join([]string{
+		c.cfg.CliName,
+		"tx",
+		"bank",
+		send,
+		c.cfg.AccountName,
+		strings.Join(addrs, " "),
+		c.cfg.SendDenom,
+		"--yes",
+		"--keyring-backend",
+		c.cfg.KeyringBackend,
+		"--chain-id",
+		c.cfg.ChainID,
+		"--node",
+		c.cfg.Node,
+		"--gas-prices",
+		c.cfg.Fees,
+		"-o",
+		"json",
+	}, " ")
+
+	out, err := e(ctx, cmd, false)
+	if err != nil {
+		return err
+	}
+
+	var result struct {
+		Code   int    `json:"code"`
+		TxHash string `json:"txhash"`
+	}
+	if err := json.Unmarshal(out.Stdout, &result); err != nil {
+		return fmt.Errorf("error unmarshalling tx result: %w", err)
+	}
+	if result.Code != 0 {
+		return fmt.Errorf("tx failed with code %d", result.Code)
+	}
+
+	err = c.waitTx(ctx, result.TxHash)
+	if err != nil {
+		return fmt.Errorf("error waiting for tx: %w", err)
+	}
+
+	batchSendCount.Inc()
+	return nil
+}
+
+func (c *Client) waitTx(ctx context.Context, txHash string) error {
+	cmd := strings.Join([]string{
+		c.cfg.CliName,
+		"q",
+		"tx",
+		txHash,
+		"--node",
+		c.cfg.Node,
+		"-o",
+		"json",
+	}, " ")
+
+	deadline, cancel := context.WithTimeout(ctx, c.cfg.WaitTxTimeout)
+	defer cancel()
+	ticker := time.NewTicker(1 * time.Second)
+
+	var txErr error
+	for {
+		select {
+		case <-deadline.Done():
+			return txErr
+		case <-ticker.C:
+			out, err := e(ctx, cmd, true)
+			if err != nil {
+				txErr = err
+				continue
+			}
+			var result struct {
+				Code int `json:"code"`
+			}
+			if err := json.Unmarshal(out.Stdout, &result); err != nil {
+				return err
+			}
+			if result.Code == 0 {
+				return nil
+			}
+		}
+	}
+}
+
+type Out struct {
+	Stdout []byte
+	Stderr []byte
+}
+
+func e(ctx context.Context, cmd string, silent bool) (Out, error) {
+	cccc := exec.CommandContext(ctx, "sh", "-c", cmd)
+	stdout, err := cccc.Output()
+	var (
+		exitErr *exec.ExitError
+		stderr  []byte
+	)
+	if errors.As(err, &exitErr) {
+		stderr = exitErr.Stderr
+		if !silent {
+			log.Printf("failed exec: %s\nstdout: %s\nstderr: %s\n", cmd, string(stdout), string(stderr))
+		}
+	}
+	return Out{Stdout: stdout, Stderr: stderr}, err
+}

--- a/cmd/faucet-v2/html.go
+++ b/cmd/faucet-v2/html.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"html/template"
+)
+
+var homepage = template.Must(template.New("homepage").Parse(`<!DOCTYPE html>
+<html>
+<head>
+<title>Faucet - Warden Protocol</title>
+<script src="https://www.google.com/recaptcha/api.js?render={{ .C.RecaptchaSiteKey }}"></script>
+<script>
+grecaptcha.ready(function() {
+    grecaptcha.execute('{{ .C.RecaptchaSiteKey }}', {action: 'submit'}).then(function(token) {
+        document.getElementById('recaptchaResponse').value = token;
+    });
+});
+</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..500&display=swap" rel="stylesheet">
+<style>
+body {
+    color: white;
+    height: 100dvh;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: #0A0A0A;
+    font-family: "Inter", sans-serif;
+}
+
+form {
+    margin-top: 4rem;
+}
+
+button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    border: none;
+    text-decoration: none;
+    font-weight: 400;
+    padding: 1rem 1.375rem;
+    box-sizing: border-box;
+    font-size: 0.875rem;
+    gap: 0.625rem;
+    cursor: pointer;
+    width: 100%;
+    line-height: 1rem;
+    max-height: 3.75rem;
+    background: #D196CA;
+    transition: 0.2s ease-in-out;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1rem;
+    color: #0A0A0A;
+}
+
+button:hover {
+    background: #FFAEEE;
+}
+
+input {
+    border: 0.03125rem solid #F5F5F5;
+    color: #F5F5F5;
+    font-size: 0.875rem;
+    font-weight: 300;
+    padding: 0.375rem 0.5625rem;
+    height: 2.625rem;
+    box-sizing: border-box;
+    background: transparent;
+    outline: none;
+    width: 100%;
+    min-width: 500px;
+}
+
+h1 {
+    font-weight: 400;
+    font-size: 2.875rem;
+    color: #F5F5F5;
+    margin: 0 0 1rem 0;
+}
+</style>
+</head>
+<body>
+    <div>
+        <h1>Warden Protocol faucet</h1>
+        <span>Insert your warden address and click the button to receive some test WARD.</span>
+    </div>
+    <form action="/submit" method="post">
+		<input type="hidden" id="recaptchaResponse" name="g-recaptcha-response">
+        <input type="text" name="address" value="warden1ucgwsdqsdva08095erm7a02lj6pzwx0m03w2kv" placeholder="Warden Protocol address" />
+        <button type="submit">Get WARD</button>
+    </form>
+</body>
+</html>`,
+))
+
+var successpage = template.Must(template.New("successpage").Parse(`<!DOCTYPE html>
+<html>
+<head>
+<title>Faucet - Warden Protocol</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..500&display=swap" rel="stylesheet">
+<style>
+body {
+    color: white;
+    height: 100dvh;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: #0A0A0A;
+    font-family: "Inter", sans-serif;
+}
+
+h1 {
+    font-weight: 400;
+    font-size: 2.875rem;
+    color: #F5F5F5;
+    margin: 0 0 1rem 0;
+}
+</style>
+</head>
+<body>
+    <div>
+        <h1>Warden Protocol faucet</h1>
+        <span>Success! You'll receive your WARDs shortly.</span>
+    </div>
+</body>
+</html>`,
+))

--- a/cmd/faucet-v2/ip.go
+++ b/cmd/faucet-v2/ip.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+func getIP(r *http.Request) (string, error) {
+	forwardedFor := r.Header.Get("X-Real-Ip")
+	if forwardedFor != "" {
+		hops := strings.SplitN(forwardedFor, ",", 2)
+		client := strings.TrimSpace(hops[0])
+		return client, nil
+	}
+
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return "", fmt.Errorf("userip: %q is not IP:port", r.RemoteAddr)
+	}
+	return ip, nil
+}

--- a/cmd/faucet-v2/limiter.go
+++ b/cmd/faucet-v2/limiter.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+var ErrRateLimited = errors.New("rate limited")
+
+type Limiter struct {
+	cooldown time.Duration
+	last     map[string]time.Time
+	mu       sync.Mutex
+}
+
+func NewLimiter(cooldown time.Duration) *Limiter {
+	return &Limiter{
+		cooldown: cooldown,
+		last:     make(map[string]time.Time),
+	}
+}
+
+func (l *Limiter) Allow(key string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if time.Since(l.last[key]) < l.cooldown {
+		return fmt.Errorf("%w: key '%s' must wait %s", ErrRateLimited, key, time.Until(l.last[key].Add(l.cooldown)).String())
+	}
+
+	l.last[key] = time.Now()
+	return nil
+}
+
+func (l *Limiter) Reset(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.last[key] = time.Time{}
+}

--- a/cmd/faucet-v2/main.go
+++ b/cmd/faucet-v2/main.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sethvargo/go-envconfig"
+)
+
+type Config struct {
+	CliName        string `env:"CLI_NAME, default=wardend"`
+	ChainID        string `env:"CHAIN_ID, default=warden"`
+	KeyringBackend string `env:"KEYRING_BACKEND, default=test"`
+	Node           string `env:"NODE, default=http://localhost:26657"`
+	SendDenom      string `env:"DENOM, default=10000000uward"`
+	AccountName    string `env:"ACCOUNT_NAME, default=shulgin"`
+	Mnemonic       string `env:"MNEMONIC"`
+	HDPath         string `env:"HD_PATH, default=m/44'/118'/0'/0/0"`
+	Fees           string `env:"FEES, default=1uward"`
+	OtherFlags     string `env:"OTHER_FLAGS"`
+
+	Cooldown      time.Duration `env:"COOLDOWN, default=12h"`
+	BatchInterval time.Duration `env:"BATCH_INTERVAL, default=6s"`
+	BatchLimit    int           `env:"BATCH_LIMIT, default=10"`
+	WaitTxTimeout time.Duration `env:"WAIT_TX_TIMEOUT, default=15s"`
+
+	RecaptchaSiteKey      string  `env:"RECAPTCHA_SITE_KEY"`
+	RecaptchaSecret       string  `env:"RECAPTCHA_SECRET_KEY"`
+	RecaptchaMinimumScore float64 `env:"RECAPTCHA_MINIMUM_SCORE, default=0.8"`
+}
+
+type Env struct {
+	Logger         *slog.Logger
+	AddressLimiter *Limiter
+	IPLimiter      *Limiter
+	Client         *Client
+}
+
+func main() {
+	ctx := context.Background()
+	var c Config
+	if err := envconfig.Process(ctx, &c); err != nil {
+		log.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+
+	client, err := NewClient(ctx, logger.With("module", "client"), c)
+	if err != nil {
+		log.Fatalf("can't init client: %v", err)
+	}
+
+	env := Env{
+		Logger:         logger,
+		AddressLimiter: NewLimiter(c.Cooldown),
+		IPLimiter:      NewLimiter(c.Cooldown),
+		Client:         client,
+	}
+
+	http.HandleFunc("/", formHandler(c))
+	http.HandleFunc("/submit", submitHandler(c, env))
+	http.Handle("/metrics", promhttp.Handler())
+
+	addr := ":8000"
+	server := &http.Server{
+		Addr:              addr,
+		ReadHeaderTimeout: 300 * time.Millisecond,
+	}
+
+	logger.Info("faucet started", "addr", addr)
+	if err := server.ListenAndServe(); err != nil {
+		logger.Error("failed to start server", "error", err)
+		os.Exit(1)
+	}
+}
+
+func formHandler(c Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		addr := r.FormValue("addr")
+
+		err := homepage.Execute(w, struct {
+			C       Config
+			Address string
+		}{C: c, Address: addr})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+func submitHandler(c Config, e Env) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Inc()
+
+		remoteIP, err := getIP(r)
+		if err != nil {
+			e.Logger.Info("couldn't get remote ip", "err", err)
+			http.Error(w, "Error getting real IP", http.StatusInternalServerError)
+			reqInvalidIPCount.Inc()
+			return
+		}
+
+		if err := validateIP(e, remoteIP); err != nil {
+			e.Logger.Info("invalid ip", "ip", remoteIP, "err", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			reqInvalidIPCount.Inc()
+			return
+		}
+
+		address := r.FormValue("address")
+		if err := validateAddress(e, address); err != nil {
+			e.Logger.Info("invalid address", "ip", remoteIP, "address", address, "err", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			reqInvalidAddrCount.Inc()
+			return
+		}
+
+		recaptchaResponse := r.FormValue("g-recaptcha-response")
+		if err := validateRecaptcha(c, recaptchaResponse, remoteIP); err != nil {
+			e.Logger.Info("invalid captcha", "ip", remoteIP, "address", address, "err", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			reqInvalidCaptchaCount.Inc()
+			return
+		}
+
+		if err := <-e.Client.Send(address); err != nil {
+			e.Logger.Info("failed send", "ip", remoteIP, "address", address, "err", err)
+			e.IPLimiter.Reset(remoteIP)
+			e.AddressLimiter.Reset(address)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if err := successpage.Execute(w, nil); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			reqErrorCount.Inc()
+			return
+		}
+	}
+}
+
+func validateAddress(e Env, addr string) error {
+	// check format
+	pref, _, err := bech32.DecodeAndConvert(addr)
+	if err != nil {
+		return fmt.Errorf("invalid address: %w", err)
+	}
+	if pref != "warden" {
+		return fmt.Errorf("invalid address prefix: %s", pref)
+	}
+
+	// check rate-limit
+	if err := e.AddressLimiter.Allow(addr); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateIP(e Env, remoteIP string) error {
+	return e.IPLimiter.Allow(remoteIP)
+}
+
+func validateRecaptcha(c Config, recaptchaResponse, remoteIP string) error {
+	resp, err := http.PostForm("https://www.google.com/recaptcha/api/siteverify", url.Values{
+		"secret":   {c.RecaptchaSecret},
+		"response": {recaptchaResponse},
+		"remoteip": {remoteIP},
+	})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Success     bool     `json:"success"`
+		Score       float64  `json:"score"`
+		Action      string   `json:"action"`
+		ChallengeTs string   `json:"challenge_ts"`
+		Hostname    string   `json:"hostname"`
+		ErrorCodes  []string `json:"error-codes"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+
+	if !result.Success || result.Score < c.RecaptchaMinimumScore {
+		return fmt.Errorf("verification failed")
+	}
+
+	return nil
+}

--- a/cmd/faucet-v2/metrics.go
+++ b/cmd/faucet-v2/metrics.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	batchSendCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "faucet",
+		Name:      "batch_send_count",
+		Help:      "The total number of sent batches (success or error)",
+	})
+
+	batchSize = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "faucet",
+		Name:      "batch_size",
+		Help:      "The size of the batch of addresses waiting for tokens",
+	})
+
+	reqCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "faucet",
+		Name:      "req_count",
+		Help:      "The total number of faucet requests",
+	})
+
+	reqInvalidIPCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "faucet",
+		Name:      "req_invalid_ip_count",
+		Help:      "The total number of failed requests for invalid IP",
+	})
+
+	reqInvalidAddrCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "faucet",
+		Name:      "req_invalid_addr_count",
+		Help:      "The total number of failed requests for invalid address",
+	})
+
+	reqInvalidCaptchaCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "faucet",
+		Name:      "req_invalid_captcha_count",
+		Help:      "The total number of failed requests for invalid captcha",
+	})
+
+	reqErrorCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "faucet",
+		Name:      "req_error_count",
+		Help:      "The total number of failed requests for errors during send",
+	})
+)

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0
-	github.com/prometheus/client_golang v1.19.0
+	github.com/prometheus/client_golang v1.19.1
 	github.com/sethvargo/go-envconfig v1.0.0
 	github.com/spf13/cast v1.6.0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1014,6 +1014,8 @@ github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3O
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.19.0 h1:ygXvpU1AoN1MhdzckN+PyD9QJOSD4x7kmXYlnfbA6JU=
 github.com/prometheus/client_golang v1.19.0/go.mod h1:ZRM9uEAypZakd+q/x7+gmsvXdURP+DABIEIjnmDdp+k=
+github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
+github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/spaceward/src/components/FaucetButton.tsx
+++ b/spaceward/src/components/FaucetButton.tsx
@@ -1,81 +1,23 @@
-import { useState } from "react";
 import { env } from "@/env";
 import { useAddressContext } from "@/hooks/useAddressContext";
 import { Button } from "@/components/ui/button";
-import Plausible from "plausible-tracker";
-import { PlusCircleIcon, RefreshCwIcon } from "lucide-react";
-import { useToast } from "./ui/use-toast";
-
-async function getFaucetTokens(addr: string) {
-	const res = await fetch(env.faucetURL, {
-		method: "POST",
-		body: JSON.stringify({ address: addr }),
-	});
-	if (!res.ok) {
-		const data = await res.json();
-		throw new Error(data.message);
-	}
-}
+import { PlusCircleIcon } from "lucide-react";
 
 function FaucetButton() {
-	const [loading, setLoading] = useState(false);
 	const { address } = useAddressContext();
-	const { toast } = useToast();
-
-	const { trackEvent } = Plausible();
-
-	const getTokens = async () => {
-		setLoading(true);
-		const { id, update } = toast({
-			title: "Requesting tokens",
-			duration: 5000,
-		});
-		try {
-			await getFaucetTokens(address);
-			update({
-				id,
-				title: "Tokens requested",
-				description:
-					"Please wait a few seconds for the tokens to arrive.",
-				duration: 5000,
-			});
-			trackEvent("Get WARD");
-		} catch (err) {
-			update({
-				id,
-				title: "Error getting tokens",
-				description:
-					"If you already requested tokens recently, please wait a few hours before trying again.",
-				duration: 5000,
-			});
-		} finally {
-			setTimeout(() => {
-				setLoading(false);
-			}, 5000);
-		}
-	};
+	const u = new URL(env.faucetURL);
+	u.searchParams.set("addr", address);
 
 	return (
 		<Button
-			disabled={loading}
-			onClick={() => getTokens()}
 			className="w-full h-12 gap-2"
 			size={"sm"}
+			asChild
 		>
-			{loading ? (
-				<>
-					<RefreshCwIcon
-						strokeWidth={1}
-						className="h-6 w-6 animate-spin"
-					/>
-					Please wait
-				</>
-			) : (
-				<>
-					<PlusCircleIcon strokeWidth={1} className="h-6 w-6" />
-					Get WARD
-				</>
-			)}
+			<a href={u.toString()} target="_blank">
+				<PlusCircleIcon strokeWidth={1} className="h-6 w-6" />
+				Get WARD
+			</a>
 		</Button>
 	);
 }

--- a/spaceward/src/env.ts
+++ b/spaceward/src/env.ts
@@ -1,7 +1,7 @@
 const apiURL = import.meta.env.VITE_WARDEN_REST_URL ?? "http://127.0.0.1:1317";
 const rpcURL = import.meta.env.VITE_WARDEN_RPC_URL ?? "http://127.0.0.1:26657";
 const prefix = import.meta.env.VITE_ADDRESS_PREFIX ?? "warden";
-const faucetURL = import.meta.env.VITE_FAUCET_URL ?? "/api/faucet";
+const faucetURL = import.meta.env.VITE_FAUCET_URL ?? "http://127.0.0.1:8000";
 const chainName =
 	import.meta.env.VITE_WARDEN_CHAIN_NAME || "Warden Protocol (local)";
 const cosmoskitChainName =

--- a/spaceward/vite.config.ts
+++ b/spaceward/vite.config.ts
@@ -7,14 +7,6 @@ const require = createRequire( import.meta.url );
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	server: {
-		proxy: {
-			"/api/faucet": {
-				target: "http://localhost:8000/",
-				rewrite: (path) => path.replace(/^\/api\/faucet/, "/"),
-			},
-		},
-	},
 	plugins: [
 		react(),
 		nodePolyfills({


### PR DESCRIPTION
A web-based faucet that uses recaptcha v3 for validating incoming requests.

I modified spaceward "Get WARD" buttons to open the faucet url in a new tab instead of making the HTTP request in the background.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new web-based version of the faucet with reCAPTCHA verification for enhanced security.
  - Added rate-limiting functionality to manage request frequency.
  - Implemented Prometheus metrics for tracking faucet service statistics.

- **Bug Fixes**
  - Updated button behavior to open a URL in a new tab on click for better user experience.

- **Chores**
  - Updated `.gitignore` to ignore `.envrc` files.
  - Revised Dockerfile to transition to version 2 of the faucet component.
  - Updated GitHub workflows to include paths and configurations for the new faucet-v2 service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->