### PR TITLE
fix(faucet): wrong access rights on the faucet libwasmvm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ CMD just localnet
 FROM debian:bookworm-slim AS faucet
 COPY --from=wardend-build /build/wardend /usr/bin/wardend
 COPY --from=wardend-build /build/faucet-v2 /usr/bin/faucet-v2
-ADD --checksum=sha256:b0c3b761e5f00e45bdafebcfe9c03bd703b88b3f535c944ca8e27ef9b891cd10 https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
+ADD --chown=nobody:nogroup --checksum=sha256:b0c3b761e5f00e45bdafebcfe9c03bd703b88b3f535c944ca8e27ef9b891cd10 https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
There was no `chown` in the faucet Dockerbuild which led it fail to run `wardend` binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Dockerfile to improve security by adding ownership settings and checksum verification for file downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->