### PR TITLE
fix(faucet): change access rights for faucet binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,18 @@ CMD just localnet
 
 ## faucet
 FROM debian:bookworm-slim AS faucet
-COPY --from=wardend-build /build/wardend /usr/bin/wardend
-COPY --from=wardend-build /build/faucet-v2 /usr/bin/faucet-v2
-ADD --chown=nobody:nogroup --checksum=sha256:b0c3b761e5f00e45bdafebcfe9c03bd703b88b3f535c944ca8e27ef9b891cd10 https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* && \
+    useradd -M -u 1000 -U -s /bin/sh -d /data warden && \
+    install -o 1000 -g 1000 -d /data
+
+COPY --from=wardend-build --chown=warden:warden /build/wardend /usr/bin/wardend
+COPY --from=wardend-build --chown=warden:warden /build/faucet-v2 /usr/bin/faucet-v2
+ADD --chown=warden:warden --checksum=sha256:b0c3b761e5f00e45bdafebcfe9c03bd703b88b3f535c944ca8e27ef9b891cd10 https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
+
 EXPOSE 8000
-USER nobody
+USER warden
 CMD ["/usr/bin/faucet-v2"]
 
 


### PR DESCRIPTION
Fixes the access rights for faucet binaries and sets new user `warden` which this container will be ran.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Docker container setup by creating a user `warden` with specific permissions.
  - Ensured files copied during build are owned by the `warden` user for better security and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->