### PR TITLE
chore(faucet-v2): use common writeError method

### DIFF
--- a/cmd/faucet-v2/main.go
+++ b/cmd/faucet-v2/main.go
@@ -218,13 +218,11 @@ func validateRecaptcha(c Config, recaptchaResponse, remoteIP string) error {
 }
 
 func writeBadRequest(w http.ResponseWriter, msg string) {
-	w.WriteHeader(http.StatusBadRequest)
-	_ = errorpage.Execute(w, msg)
+	writeError(w, http.StatusBadRequest, msg)
 }
 
 func writeInternalServerError(w http.ResponseWriter, msg string) {
-	w.WriteHeader(http.StatusInternalServerError)
-	_ = errorpage.Execute(w, msg)
+	writeError(w, http.StatusInternalServerError, msg)
 }
 
 func writeError(w http.ResponseWriter, status int, msg string) {


### PR DESCRIPTION
Fixes a linter error, that is correctly mentioning that I wasn't using a function I wrote.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for bad requests and internal server errors to provide more consistent and informative error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->