### PR TITLE
AI Agents Docs update

### DIFF
--- a/docs/.spelling
+++ b/docs/.spelling
@@ -205,3 +205,5 @@ macOS
 undelegation
 tombstoned
 Coingecko
+agentic
+subtasks

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -8,7 +8,7 @@ slug: /
 
 Welcome to the Documentation Site for the Warden Protocol!
 
-The Warden Protocol is a modular L1 blockchain for omnichain applications, "OApps". Our mission is to empower developers to simply launch secure OApps by giving them modular infrastructure for security, interoperability and chain abstraction.
+The Warden Protocol is a modular L1 blockchain for developers to deploy omnichain AI-driven applications.
 
 While our documentation site is a work in progress, it will become a comprehensive resource for navigating and building with ease on Warden.
 

--- a/docs/docs/learn/eli5.md
+++ b/docs/docs/learn/eli5.md
@@ -7,9 +7,22 @@ The Warden Protocol provides modular L1 blockchain infrastructure for omnichain 
 
 OApps are modularly secure, omnichain interoperable and chain abstracted evolutions of traditional smart contracts. They consist of three parts: a smart contract, a single- or multiple keychains, and an intent configurator.
 
+## Agents
+
+In Warden, Agents are omnichain autonomous software entities or programs that interacts within the Warden Protocol. These agents are designed to perform specific tasks, make decisions, and execute actions based on predefined intents without the need for direct human intervention.
+
+
+## Agentic
+
+An agentic AI system possesses the ability to reason and collaborate autonomously. It can decompose tasks into multiple steps and execute those subtasks independently, rather than merely responding to prompts one at a time. Warden’s aim is to empower developers with agentic AI workflows, enabling them to create advanced smart workflows where actions are initiated autonomously and complex processes are managed seamlessly.
+
+## Agentic Applications
+
+
+With Agentic AI, developers can build trainable agents capable of executing various complex actions. These agents can autonomously initiate actions or enforce immutable conditions on any transaction. By integrating these agents with OApps, developers can create a new class of application—Agentic Applications.
+
 ## Modular security
 
-  
 
 Web3 will not onboard billions of users unless we fundamentally rethink user security. Warden’s modular blockchain infrastructure unbundles the application layer for greater security. Apps can support the same applications deployed with different security models, leveraging intents and keychains, thereby decoupling protocol-layer from application-layer security.
 


### PR DESCRIPTION
Updating the docs site with explainer on the intro Warden Protocol document and updated the ELI5 we some additional taxonomy. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the introductory documentation to focus on deploying omnichain AI-driven applications within the Warden Protocol.
  - Added detailed sections on "Agents," "Agentic," and "Agentic Applications" in the ELI5 guide.
  - Included "agentic" and "subtasks" in the project's spelling list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->