### PR TITLE
fix(x/warden): ensure only Keychains can send FulfilSignatureRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (shield) Change integer representation from int64 to big.Int
 * (x/intent) Add `MsgNewAction` as unique entrypoint for creating Actions
 * (x/intent) Add `SimulateIntent` query request
+* (x/warden) Ensure only Keychain's parties can update a SignatureRequest
 
 ### Features
 


### PR DESCRIPTION
Without this, anyone can send a "fake" signature back to a signature request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for handling negative expressions and integers.

- **Bug Fixes**
  - Ensured only authorized parties (Keychain) can update a `SignatureRequest`.

- **Refactor**
  - Changed integer representation from `int64` to `big.Int` for improved precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->