### PR TITLE
fix(x/intent): check correct authority address when creating Actions

### DIFF
--- a/warden/app/app_config.go
+++ b/warden/app/app_config.go
@@ -189,6 +189,7 @@ var (
 		{Account: ibctransfertypes.ModuleName, Permissions: []string{authtypes.Minter, authtypes.Burner}},
 		{Account: ibcfeetypes.ModuleName},
 		{Account: icatypes.ModuleName},
+		{Account: intentmoduletypes.ModuleName},
 		// this line is used by starport scaffolding # stargate/app/maccPerms
 	}
 

--- a/warden/testutil/keeper/intent.go
+++ b/warden/testutil/keeper/intent.go
@@ -32,6 +32,7 @@ func IntentKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 	registry := codectypes.NewInterfaceRegistry()
 	cdc := codec.NewProtoCodec(registry)
 	authority := authtypes.NewModuleAddress(govtypes.ModuleName)
+	intentAuthority := authtypes.NewModuleAddress(types.ModuleName)
 	intentRegistry := types.NewIntentsRegistry()
 
 	k := keeper.NewKeeper(
@@ -40,6 +41,7 @@ func IntentKeeper(t testing.TB) (keeper.Keeper, sdk.Context) {
 		log.NewNopLogger(),
 		nil,
 		authority.String(),
+		intentAuthority.String(),
 		nil,
 		intentRegistry,
 	)

--- a/warden/x/intent/keeper/actions.go
+++ b/warden/x/intent/keeper/actions.go
@@ -213,7 +213,7 @@ func (k Keeper) validateActionMsgSigners(msg sdk.Msg) error {
 		return types.ErrInvalidSigner
 	}
 
-	if sdk.AccAddress(signers[0]).String() != k.GetAuthority() {
+	if sdk.AccAddress(signers[0]).String() != k.GetModuleAddress() {
 		return errorsmod.Wrapf(types.ErrInvalidActionMsgSigner, sdk.AccAddress(signers[0]).String())
 	}
 

--- a/warden/x/intent/keeper/keeper.go
+++ b/warden/x/intent/keeper/keeper.go
@@ -32,8 +32,9 @@ type (
 
 		// the address capable of executing a MsgUpdateParams message. Typically, this
 		// should be the x/gov module account.
-		authority      string
-		actionHandlers map[string]types.ActionHandler
+		authority           string
+		intentModuleAddress string
+		actionHandlers      map[string]types.ActionHandler
 	}
 )
 
@@ -49,11 +50,16 @@ func NewKeeper(
 	logger log.Logger,
 	router baseapp.MessageRouter,
 	authority string,
+	intentModuleAddress string,
 	shieldExpanderFunc func() ast.Expander,
 	intentsRegistry *types.IntentsRegistry,
 ) Keeper {
 	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
 		panic(fmt.Sprintf("invalid authority address: %s", authority))
+	}
+
+	if _, err := sdk.AccAddressFromBech32(intentModuleAddress); err != nil {
+		panic(fmt.Sprintf("invalid intent module address: %s", intentModuleAddress))
 	}
 
 	sb := collections.NewSchemaBuilder(storeService)
@@ -68,11 +74,12 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		cdc:          cdc,
-		storeService: storeService,
-		authority:    authority,
-		logger:       logger,
-		router:       router,
+		cdc:                 cdc,
+		storeService:        storeService,
+		authority:           authority,
+		intentModuleAddress: intentModuleAddress,
+		logger:              logger,
+		router:              router,
 
 		shieldExpanderFunc: shieldExpanderFunc,
 		intentsRegistry:    intentsRegistry,
@@ -87,6 +94,10 @@ func NewKeeper(
 // GetAuthority returns the module's authority.
 func (k Keeper) GetAuthority() string {
 	return k.authority
+}
+
+func (k Keeper) GetModuleAddress() string {
+	return k.intentModuleAddress
 }
 
 // Logger returns a module-specific logger.

--- a/warden/x/intent/module/module.go
+++ b/warden/x/intent/module/module.go
@@ -210,6 +210,8 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		authority = authtypes.NewModuleAddressOrBech32Address(in.Config.Authority)
 	}
 
+	intentModuleAddress := authtypes.NewModuleAddress(types.ModuleName)
+
 	shieldExpanderFunc := func() ast.Expander {
 		return cosmoshield.NewExpanderManager()
 	}
@@ -224,6 +226,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.Logger,
 		in.Router,
 		authority.String(),
+		intentModuleAddress.String(),
 		shieldExpanderFunc,
 		r,
 	)


### PR DESCRIPTION
During Action creation, I was checking against the x/gov address instead of x/intent address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new `intentModuleAddress` to enhance module address handling for better security and modularity.

- **Bug Fixes**
  - Updated validation logic for action message signers to use the new module address, ensuring accurate verification.

- **Refactor**
  - Refactored various components to replace `authority` with `intentModuleAddress` for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->