### PR TITLE
fix(x/intent): Action results being wrapped in Any twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (shield) Add negative prefix operator to handle negative expressions and integers
 * (shield) Change integer representation from int64 to big.Int
 * (x/intent) Add `MsgNewAction` as unique entrypoint for creating Actions
+* (x/intent) Fix bug where Actions' Results were being wrapped in `Any` twice
 * (x/intent) Add `SimulateIntent` query request
 * (x/warden) Ensure only Keychain's parties can update a SignatureRequest
 

--- a/warden/x/intent/types/action.go
+++ b/warden/x/intent/types/action.go
@@ -6,7 +6,6 @@ import (
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	proto "github.com/cosmos/gogoproto/proto"
 )
 
 func NewApprover(address string, timestamp time.Time) *Approver {
@@ -18,18 +17,13 @@ func NewApprover(address string, timestamp time.Time) *Approver {
 
 func (a *Action) SetId(id uint64) { a.Id = id }
 
-func (a *Action) SetResult(result proto.Message) error {
+func (a *Action) SetResult(result *codectypes.Any) error {
 	if a.Status != ActionStatus_ACTION_STATUS_PENDING {
 		return fmt.Errorf("cannot set result of action in status: %s", a.Status.String())
 	}
 
-	anyV, err := codectypes.NewAnyWithValue(result)
-	if err != nil {
-		return err
-	}
-
 	a.Status = ActionStatus_ACTION_STATUS_COMPLETED
-	a.Result = anyV
+	a.Result = result
 	return nil
 }
 


### PR DESCRIPTION
The result of an action is of Any type. Due to a bug, the Any was being wrapped in another Any.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where Actions' Results were being wrapped in `Any` twice.

- **New Features**
  - Added a negative prefix operator.
  - Changed integer representation to `big.Int`.
  - Introduced `MsgNewAction` for creating Actions.
  - Added `SimulateIntent` query request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->