### PR TITLE
Spaceward: use MsgNewAction for creating new Actions

### DIFF
--- a/spaceward/.eslintrc.cjs
+++ b/spaceward/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   env: { browser: true, es2020: true },
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended', 'plugin:storybook/recommended'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended'],
   parser: '@typescript-eslint/parser',
   parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
   plugins: ['react-refresh'],

--- a/spaceward/package.json
+++ b/spaceward/package.json
@@ -79,7 +79,6 @@
     "html5-qrcode": "^2.3.8",
     "js-sha256": "^0.10.1",
     "localforage": "^1.10.0",
-    "long": "^5.2.3",
     "lucide-react": "^0.368.0",
     "match-sorter": "^6.3.1",
     "next": "^14.1.0",

--- a/spaceward/pnpm-lock.yaml
+++ b/spaceward/pnpm-lock.yaml
@@ -219,9 +219,6 @@ importers:
       localforage:
         specifier: ^1.10.0
         version: 1.10.0
-      long:
-        specifier: ^5.2.3
-        version: 5.2.3
       lucide-react:
         specifier: ^0.368.0
         version: 0.368.0(react@18.2.0)
@@ -11489,7 +11486,6 @@ snapshots:
       '@cosmjs/tendermint-rpc': 0.32.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@cosmology/lcd': 0.13.3
       '@tanstack/react-query': 4.36.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      long: 5.2.3
       protobufjs: 7.2.6
     transitivePeerDependencies:
       - bufferutil

--- a/spaceward/src/App.tsx
+++ b/spaceward/src/App.tsx
@@ -53,11 +53,13 @@ import {
 	StakingPage,
 } from "./pages";
 import { GovernancePage } from "./pages/Governance.tsx";
+import { hashQueryKey } from "./utils/queryKeyHash.ts";
 
 const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			refetchInterval: 1000,
+			queryKeyHashFn: hashQueryKey,
 		},
 	},
 });

--- a/spaceward/src/components/SendEth.tsx
+++ b/spaceward/src/components/SendEth.tsx
@@ -1,4 +1,3 @@
-import Long from "long";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { ethers } from "ethers";
@@ -51,7 +50,7 @@ function SendEth() {
 
 	const q = useKeyById({
 		request: {
-			id: Long.fromString(keyId),
+			id: BigInt(keyId),
 			deriveAddresses: [AddressType.ADDRESS_TYPE_ETHEREUM],
 		},
 		options: {

--- a/spaceward/src/features/assets/Assets.tsx
+++ b/spaceward/src/features/assets/Assets.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-import Long from "long";
 import { Skeleton } from "@/components/ui/skeleton";
 import AddressAvatar from "@/components/AddressAvatar";
 import { ethers } from "ethers";
@@ -14,7 +12,6 @@ import { Copy } from "@/components/ui/copy";
 import { NewKeyButton } from "@/features/keys";
 import { useQueryHooks } from "@/hooks/useClient";
 import { PageRequest } from "@wardenprotocol/wardenjs/codegen/cosmos/base/query/v1beta1/pagination";
-import { base64FromBytes } from "@wardenprotocol/wardenjs/codegen/helpers";
 import { AddressType } from "@wardenprotocol/wardenjs/codegen/warden/warden/v1beta2/key";
 import { getProvider } from "@/lib/eth";
 
@@ -42,13 +39,13 @@ export function Assets({ spaceId }: { spaceId: string }) {
 	const { useKeysBySpaceId, isReady } = useQueryHooks();
 	const query = useKeysBySpaceId({
 		request: {
-			spaceId: Long.fromString(spaceId),
+			spaceId: BigInt(spaceId),
 			deriveAddresses: [
 				AddressType.ADDRESS_TYPE_ETHEREUM,
 				AddressType.ADDRESS_TYPE_OSMOSIS,
 			],
 			pagination: PageRequest.fromPartial({
-				limit: Long.fromInt(10),
+				limit: BigInt(10),
 			}),
 		},
 		options: {
@@ -78,7 +75,7 @@ export function Assets({ spaceId }: { spaceId: string }) {
 			{query.data?.keys?.map((key) => (
 				<div
 					className="flex flex-col min-w-[600px]"
-					key={key.key.id.toNumber()}
+					key={key.key.id.toString()}
 				>
 					<div className="flex flex-row justify-between px-4 py-4">
 						<div className="flex flex-row items-center gap-4">
@@ -88,7 +85,7 @@ export function Assets({ spaceId }: { spaceId: string }) {
 
 							<span className="font-sans flex flex-col">
 								<span className="text-muted-foreground">
-									Key #{key.key.id.toNumber()}
+									Key #{key.key.id.toString()}
 								</span>
 							</span>
 						</div>
@@ -120,7 +117,7 @@ function Address({
 }: {
 	address: string;
 	type: AddressType;
-	keyId: Long;
+	keyId: bigint;
 }) {
 	if (type !== AddressType.ADDRESS_TYPE_ETHEREUM) {
 		return null;
@@ -165,7 +162,7 @@ function Address({
 	);
 }
 
-function Sepolia({ address, keyId }: { address: string; keyId: Long }) {
+function Sepolia({ address, keyId }: { address: string; keyId: bigint }) {
 	const { currency } = useCurrency();
 	const query = useQuery({
 		queryKey: ["eth-balance", address],

--- a/spaceward/src/features/home/HomeAssets.tsx
+++ b/spaceward/src/features/home/HomeAssets.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-import Long from "long";
 import { Skeleton } from "@/components/ui/skeleton";
 import AddressAvatar from "@/components/AddressAvatar";
 import { ethers } from "ethers";
@@ -28,13 +26,13 @@ export function HomeAssets() {
 	const { useKeysBySpaceId, isReady } = useQueryHooks();
 	const query = useKeysBySpaceId({
 		request: {
-			spaceId: Long.fromString(spaceId || ""),
+			spaceId: BigInt(spaceId || ""),
 			deriveAddresses: [
 				AddressType.ADDRESS_TYPE_ETHEREUM,
 				AddressType.ADDRESS_TYPE_OSMOSIS,
 			],
 			pagination: PageRequest.fromPartial({
-				limit: Long.fromInt(10),
+				limit: BigInt(10),
 			}),
 		},
 		options: {
@@ -68,7 +66,7 @@ export function HomeAssets() {
 			{query.data?.keys?.map((key) => (
 				<div
 					className="flex flex-col m-4 rounded-xl"
-					key={key.key.id.toNumber()}
+					key={key.key.id.toString()}
 				>
 					<div>
 						<div className="space-y-3">
@@ -100,7 +98,7 @@ function Address({
 }: {
 	address: string;
 	type: AddressType;
-	keyId: Long;
+	keyId: bigint;
 }) {
 	// if (type != AddressType.ADDRESS_TYPE_ETHEREUM) {
 	// 	return null;
@@ -139,7 +137,7 @@ function Address({
 	);
 }
 
-function Sepolia({ address, keyId }: { address: string; keyId: Long }) {
+function Sepolia({ address, keyId }: { address: string; keyId: bigint }) {
 	const query = useQuery({
 		queryKey: ["eth-balance", address],
 		queryFn: () => getEthBalance(address),

--- a/spaceward/src/features/home/TotalAssetValue.tsx
+++ b/spaceward/src/features/home/TotalAssetValue.tsx
@@ -1,4 +1,3 @@
-import Long from "long";
 import { formatEther } from "ethers";
 import { useSpaceId } from "@/hooks/useSpaceId";
 import { useCurrency } from "@/hooks/useCurrency";
@@ -37,10 +36,10 @@ export function TotalAssetValue() {
 	const { useKeysBySpaceId, isReady } = useQueryHooks();
 	const keysQ = useKeysBySpaceId({
 		request: {
-			spaceId: Long.fromString(spaceId || ""),
+			spaceId: BigInt(spaceId || ""),
 			deriveAddresses: [AddressType.ADDRESS_TYPE_ETHEREUM],
 			pagination: PageRequest.fromPartial({
-				limit: Long.fromInt(10),
+				limit: BigInt(10),
 			}),
 		},
 		options: {

--- a/spaceward/src/features/keys/Keys.tsx
+++ b/spaceward/src/features/keys/Keys.tsx
@@ -1,4 +1,3 @@
-import Long from "long";
 import { prettyKeyType } from "@/utils/formatting";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -9,7 +8,6 @@ import {
 	AccordionTrigger,
 } from "@/components/ui/accordion";
 import AddressAvatar from "@/components/AddressAvatar";
-import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import { Copy } from "@/components/ui/copy";
 import { ReceiveAssetButton } from "@/features/assets";
 import { MoveUpRight, KeyIcon } from "lucide-react";
@@ -28,13 +26,13 @@ export function Keys({ spaceId }: { spaceId: string }) {
 	const { useKeysBySpaceId, isReady } = useQueryHooks();
 	const query = useKeysBySpaceId({
 		request: {
-			spaceId: Long.fromString(spaceId),
+			spaceId: BigInt(spaceId),
 			deriveAddresses: [
 				AddressType.ADDRESS_TYPE_ETHEREUM,
 				AddressType.ADDRESS_TYPE_OSMOSIS,
 			],
 			pagination: PageRequest.fromPartial({
-				limit: Long.fromInt(10),
+				limit: BigInt(10),
 			}),
 		},
 		options: {

--- a/spaceward/src/features/metamask/AddToMetaMaskButton.tsx
+++ b/spaceward/src/features/metamask/AddToMetaMaskButton.tsx
@@ -1,4 +1,3 @@
-import Long from "long";
 import { isLocalSnap } from "@/lib/metamask";
 import { Button } from "@/components/ui/button";
 import { useMetaMask } from "@/hooks/useMetaMask";
@@ -12,7 +11,7 @@ export function AddToMetaMaskButton({
 	keyId,
 	address,
 }: {
-	keyId: Long;
+	keyId: bigint;
 	address: string;
 }) {
 	const { isFlask, snapsDetected, installedSnap } = useMetaMask();

--- a/spaceward/src/features/spaces/SpaceSelector.tsx
+++ b/spaceward/src/features/spaces/SpaceSelector.tsx
@@ -1,4 +1,3 @@
-import Long from "long";
 import { Button } from "@/components/ui/button";
 import { ChevronsUpDown } from "lucide-react";
 import {
@@ -11,7 +10,6 @@ import { useAddressContext } from "@/hooks/useAddressContext";
 import useWardenWardenV1Beta2 from "@/hooks/useWardenWardenV1Beta2";
 import { useSpaceId } from "@/hooks/useSpaceId";
 import { useTx } from "@/hooks/useClient";
-import { useToast } from "@/components/ui/use-toast";
 import cn from "clsx";
 import { Plus } from "lucide-react";
 import { useMediaQuery } from "@uidotdev/usehooks";
@@ -20,17 +18,17 @@ import { warden } from "@wardenprotocol/wardenjs";
 interface SpacesQueryResult {
 	pageParam: number;
 	pagination?:
-		| { next_key?: string | undefined; total?: string | undefined }
-		| undefined;
+	| { next_key?: string | undefined; total?: string | undefined }
+	| undefined;
 	spaces?:
-		| {
-				id?: string | undefined;
-				creator?: string | undefined;
-				owners?: string[] | undefined;
-				admin_intent_id?: string | undefined;
-				sign_intent_id?: string | undefined;
-		  }[]
-		| undefined;
+	| {
+		id?: string | undefined;
+		creator?: string | undefined;
+		owners?: string[] | undefined;
+		admin_intent_id?: string | undefined;
+		sign_intent_id?: string | undefined;
+	}[]
+	| undefined;
 }
 
 export function SpaceSelector() {
@@ -45,8 +43,8 @@ export function SpaceSelector() {
 			[
 				newSpace({
 					creator: address,
-					signIntentId: Long.fromNumber(0),
-					adminIntentId: Long.fromNumber(0),
+					signIntentId: BigInt(0),
+					adminIntentId: BigInt(0),
 					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 					// @ts-ignore: telescope generated code doesn't handle empty array correctly, use `undefined` instead of `[]`
 					additionalOwners: undefined,
@@ -110,8 +108,8 @@ export function SpaceSelector() {
 						<div className="flex flex-col gap-4 w-full">
 							{(
 								(spacesQuery as any)?.pages[0] as
-									| SpacesQueryResult
-									| undefined
+								| SpacesQueryResult
+								| undefined
 							)?.spaces?.map((space) => (
 								<div
 									key={space.id}

--- a/spaceward/src/features/walletconnect/WalletConnect.tsx
+++ b/spaceward/src/features/walletconnect/WalletConnect.tsx
@@ -1,4 +1,3 @@
-import Long from "long";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useMediaQuery } from "@uidotdev/usehooks";
@@ -258,7 +257,7 @@ async function fetchAddresses(spaceId: string, type: AddressType) {
 	const client = await getClient();
 	const queryKeys = client.warden.warden.v1beta2.keysBySpaceId;
 	const res = await queryKeys({
-		spaceId: Long.fromString(spaceId),
+		spaceId: BigInt(spaceId),
 		deriveAddresses: [type],
 	});
 	return res.keys?.map((key) => ({
@@ -272,7 +271,7 @@ async function findKeyByAddress(spaceId: string, address: string) {
 	const client = await getClient();
 	const queryKeys = client.warden.warden.v1beta2.keysBySpaceId;
 	const res = await queryKeys({
-		spaceId: Long.fromString(spaceId),
+		spaceId: BigInt(spaceId),
 		deriveAddresses: [
 			AddressType.ADDRESS_TYPE_ETHEREUM,
 			AddressType.ADDRESS_TYPE_OSMOSIS,

--- a/spaceward/src/hooks/useAction.ts
+++ b/spaceward/src/hooks/useAction.ts
@@ -1,0 +1,31 @@
+import { TxOptions, useTx } from "./useClient";
+import { useAddressContext } from "./useAddressContext";
+import { useModuleAccount } from "./useModuleAccount";
+import { Msg, packAny } from "@/utils/any";
+import { warden } from "@wardenprotocol/wardenjs";
+
+const { newAction: newActionMsg } = warden.intent.MessageComposer.withTypeUrl;
+
+export function useNewAction<Data>(msg: Msg<Data>) {
+	const { address } = useAddressContext();
+	const { tx } = useTx();
+
+	const { account: authorityAccount } = useModuleAccount("intent");
+	const authority = authorityAccount?.baseAccount?.address;
+
+	async function newAction(data: Data, opts: TxOptions, actionTimeoutHeight = 0) {
+		const m = newActionMsg({
+			creator: address,
+			message: packAny(msg, data),
+			actionTimeoutHeight: BigInt(actionTimeoutHeight),
+		});
+		const res = await tx([m], opts);
+		return res;
+	}
+
+	return {
+		newAction,
+		authority,
+	};
+}
+

--- a/spaceward/src/hooks/useClient.ts
+++ b/spaceward/src/hooks/useClient.ts
@@ -54,7 +54,7 @@ export enum TxStatus {
 }
 
 export function useTx() {
-	const { address, getOfflineSigner } = useChain(env.cosmoskitChainName);
+	const { address, getOfflineSignerDirect: getOfflineSigner } = useChain(env.cosmoskitChainName);
 	const { toast } = useToast();
 
 	const tx = async (msgs: EncodeObject[], options: TxOptions) => {
@@ -116,6 +116,7 @@ export function useTx() {
 				update({
 					id,
 					title: TxStatus.Failed,
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 					// @ts-ignore
 					description: err?.message,
 					duration: 10000,

--- a/spaceward/src/hooks/useEthereumTx.tsx
+++ b/spaceward/src/hooks/useEthereumTx.tsx
@@ -1,4 +1,3 @@
-import Long from "long";
 import { ethers } from "ethers";
 import useRequestSignature from "./useRequestSignature";
 import { env } from "@/env";
@@ -6,7 +5,7 @@ import { env } from "@/env";
 export function useEthereumTx() {
 	const { state, error, requestSignature, reset } = useRequestSignature();
 
-	const signRaw = async (keyId: Long, input: Uint8Array) => {
+	const signRaw = async (keyId: bigint, input: Uint8Array) => {
 		return await requestSignature(
 			keyId,
 			[],
@@ -15,7 +14,7 @@ export function useEthereumTx() {
 		);
 	};
 
-	const signEthereumTx = async (keyId: Long, tx: ethers.Transaction) => {
+	const signEthereumTx = async (keyId: bigint, tx: ethers.Transaction) => {
 		if (!env.ethereumAnalyzerContract) {
 			console.warn("Missing ethereumAnalyzerContract. Can't use Ethereum transactions.");
 			return;

--- a/spaceward/src/hooks/useModuleAccount.ts
+++ b/spaceward/src/hooks/useModuleAccount.ts
@@ -1,0 +1,14 @@
+import { ModuleAccount } from "@wardenprotocol/wardenjs/codegen/cosmos/auth/v1beta1/auth";
+import { useQueryHooks } from "./useClient";
+
+export function useModuleAccount(name: string) {
+	const { cosmos } = useQueryHooks();
+	const { data, status } = cosmos.auth.v1beta1.useModuleAccounts({
+		options: { staleTime: Infinity },
+	});
+	const account = data?.accounts
+		.filter((a) => a.typeUrl === "/cosmos.auth.v1beta1.ModuleAccount")
+		.map((a) => ModuleAccount.decode(a.value))
+		.find((a) => a.name === name);
+	return { account, status };
+}

--- a/spaceward/src/utils/any.ts
+++ b/spaceward/src/utils/any.ts
@@ -1,0 +1,15 @@
+import { BinaryWriter, google } from "@wardenprotocol/wardenjs";
+import { Any } from "cosmjs-types/google/protobuf/any";
+
+export interface Msg<Data> {
+	typeUrl: string;
+	fromPartial: (data: Partial<Data>) => Data;
+	encode: (data: Data) => BinaryWriter;
+}
+
+export function packAny<Data>(msg: Msg<Data>, data: Data): Any {
+	return google.protobuf.Any.fromPartial({
+		typeUrl: msg.typeUrl,
+		value: msg.encode(msg.fromPartial(data)).finish(),
+	})
+}

--- a/spaceward/src/utils/queryKeyHash.ts
+++ b/spaceward/src/utils/queryKeyHash.ts
@@ -1,0 +1,72 @@
+export type QueryKey = string | readonly unknown[]
+export type EnsuredQueryKey<T extends QueryKey> = T extends string
+	? [T]
+	: Exclude<T, string>
+
+export function hashQueryKey(queryKey: QueryKey): string {
+	const asArray = ensureQueryKeyArray(queryKey)
+	return stableValueHash(asArray)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function stableValueHash(value: any): string {
+	return JSON.stringify(value, (_, val) =>
+		isBigInt(val)
+			? val.toString()
+			: isPlainObject(val)
+				? Object.keys(val)
+					.sort()
+					.reduce((result, key) => {
+						result[key] = val[key]
+						return result
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					}, {} as any)
+				: val
+	)
+}
+
+function isBigInt(value: unknown): value is bigint {
+	return typeof value === 'bigint'
+}
+
+export function ensureQueryKeyArray<T extends QueryKey>(
+	value: T
+): EnsuredQueryKey<T> {
+	return (Array.isArray(value)
+		? value
+		: ([value] as unknown)) as EnsuredQueryKey<T>
+}
+
+// Copied from: https://github.com/jonschlinkert/is-plain-object
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+export function isPlainObject(o: any): o is Object {
+	if (!hasObjectPrototype(o)) {
+		return false
+	}
+
+	// If has modified constructor
+	const ctor = o.constructor
+	if (typeof ctor === 'undefined') {
+		return true
+	}
+
+	// If has modified prototype
+	const prot = ctor.prototype
+	if (!hasObjectPrototype(prot)) {
+		return false
+	}
+
+	// If constructor does not have an Object-specific method
+	// eslint-disable-next-line no-prototype-builtins
+	if (!prot.hasOwnProperty('isPrototypeOf')) {
+		return false
+	}
+
+	// Most likely a plain Object
+	return true
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function hasObjectPrototype(o: any): boolean {
+	return Object.prototype.toString.call(o) === '[object Object]'
+}


### PR DESCRIPTION
Bump wardenjs to use BigInts instead of Longs (see #384), and use a new hook called `useNewAction()` to create and broadcast transactions with a `MsgNewAction` message.

This affects: MsgUpdateSpace, MsgAddSpaceOwner, MsgRemoveSpaceOwner, MsgUpdateKey (unused in Spaceward), MsgNewKeyRequest, MsgNewSignatureRequest.

I think I fixed all usages.

I had to switch back from Amino to Protobuf message encoding, unfortunately, because I couldn't get Keplr/wardenjs to play well with the fact that MsgNewAction has a `Any` field. I'm in contact with the Telescope team to figure this out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `useNewAction` for creating new actions and transactions.
  - Added functionality for packing data into Google Protocol Buffers `Any` messages.
  - Implemented query key hashing for stability.

- **Refactor**
  - Replaced `Long` with `BigInt` for handling numeric values across multiple components.
  - Updated key request and signature request functionalities to use `useNewAction`.

- **Chores**
  - Removed dependency on `"long": "^5.2.3"`.
  - Removed `'plugin:storybook/recommended'` from ESLint configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->