### PR TITLE
chore(justfile): make `sed` work on Mac OS out of the box

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,6 +50,15 @@ shulgin_mnemonic := "exclude try nephew main caught favorite tone degree lottery
 localnet bin="wardend":
     #!/usr/bin/env bash
     set -euxo pipefail
+
+    function replace() {
+      if [[ "$(uname)" == "Darwin" ]]; then
+        /usr/bin/sed -i '' "$1" "$2"
+      else
+        sed -i "$1" "$2"
+      fi
+    }
+
     rm -rf ~/.warden
     {{bin}} init localnet --chain-id {{chain_id}} --default-denom uward > /dev/null
     {{bin}} config set client chain-id {{chain_id}}
@@ -58,7 +67,7 @@ localnet bin="wardend":
     {{bin}} config set app api.enable true
     {{bin}} config set app api.enabled-unsafe-cors true
     {{bin}} config set config consensus.timeout_commit 1s -s
-    sed -i 's/cors_allowed_origins = \[\]/cors_allowed_origins = ["*"]/' ~/.warden/config/config.toml
+    replace 's/cors_allowed_origins = \[\]/cors_allowed_origins = ["*"]/' ~/.warden/config/config.toml
     {{bin}} keys add val > /dev/null
     echo -n '{{shulgin_mnemonic}}' | {{bin}} keys add shulgin --recover > /dev/null
     {{bin}} genesis add-genesis-account val 10000000000000000000000000uward

--- a/tests/justfile
+++ b/tests/justfile
@@ -18,6 +18,14 @@ snapshot: snapshot-base
 # regenerate ./testdata/snapshot-base
 snapshot-base:
   #!/usr/bin/env bash
+  function replace() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+      /usr/bin/sed -i '' "$1" "$2"
+    else
+      sed -i "$1" "$2"
+    fi
+  }
+
   set -euxo pipefail
 
   export WARDEND_HOME=$PWD/testdata/snapshot-base
@@ -45,13 +53,13 @@ snapshot-base:
   wardend config set config consensus.timeout_commit 10ms -s --home $WARDEND_HOME
 
   # templating for changing default ports
-  sed -i 's/tcp\:\/\/localhost\:26657/tcp\:\/\/localhost:{{{{ .CometPortRPC }}/' $WARDEND_HOME/config/client.toml
+  replace 's/tcp\:\/\/localhost\:26657/tcp\:\/\/localhost:{{{{ .CometPortRPC }}/' $WARDEND_HOME/config/client.toml
 
-  sed -i 's/tcp\:\/\/localhost\:1317/tcp\:\/\/localhost:{{{{ .APIPort }}/' $WARDEND_HOME/config/app.toml
-  sed -i 's/localhost\:9090/localhost:{{{{ .GRPCPort }}/' $WARDEND_HOME/config/app.toml
+  replace 's/tcp\:\/\/localhost\:1317/tcp\:\/\/localhost:{{{{ .APIPort }}/' $WARDEND_HOME/config/app.toml
+  replace 's/localhost\:9090/localhost:{{{{ .GRPCPort }}/' $WARDEND_HOME/config/app.toml
 
-  sed -i 's/tcp\:\/\/0\.0\.0\.0\:26656/tcp\:\/\/127.0.0.1:{{{{ .CometP2PRPC }}/' $WARDEND_HOME/config/config.toml
-  sed -i 's/tcp\:\/\/127\.0\.0\.1\:26657/tcp\:\/\/127.0.0.1:{{{{ .CometPortRPC }}/' $WARDEND_HOME/config/config.toml
+  replace 's/tcp\:\/\/0\.0\.0\.0\:26656/tcp\:\/\/127.0.0.1:{{{{ .CometP2PRPC }}/' $WARDEND_HOME/config/config.toml
+  replace 's/tcp\:\/\/127\.0\.0\.1\:26657/tcp\:\/\/127.0.0.1:{{{{ .CometPortRPC }}/' $WARDEND_HOME/config/config.toml
 
   # rename *.toml in *.toml.tmpl
   mv $WARDEND_HOME/config/app.toml    $WARDEND_HOME/config/app.toml.tmpl


### PR DESCRIPTION
closes #370 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `replace()` function to handle text replacement in configuration files, adapting to different operating systems (macOS and others).

- **Refactor**
  - Replaced multiple instances of `sed` commands with the new `replace()` function to streamline and enhance the maintainability and portability of the string replacement process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->