### PR TITLE
feat(ethereum-analyzer): extract "to" and "value" fields from transactions

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8aa973e647ec336810a9356af8aea787249c9d00b1525359f3db29a68d231b"
+checksum = "f783611babedbbe90db3478c120fb5f5daacceffc210b39adc0af4fe0da70bad"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -818,6 +818,7 @@ name = "ethereum-analyzer"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
+ "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
  "anyhow",
@@ -1372,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f308135fef9fc398342da5472ce7c484529df23743fb7c734e0f3d472971e62"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -1396,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "ruint-macro"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86854cf50259291520509879a5c294c3c9a4c334e9ff65071c51e42ef1e2343"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hex"

--- a/contracts/contracts/ethereum-analyzer/Cargo.toml
+++ b/contracts/contracts/ethereum-analyzer/Cargo.toml
@@ -28,6 +28,7 @@ serde-json-wasm = "1.0.1"
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", default-features = false, version = "0.1.0" }
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", default-features = false, version = "0.1.0" }
 alloy-rlp = { version = "0.3", default-features = false }
+alloy-primitives = "0.7.6"
 hex = "0.4.3"
 
 [dev-dependencies]

--- a/contracts/contracts/ethereum-analyzer/src/contract.rs
+++ b/contracts/contracts/ethereum-analyzer/src/contract.rs
@@ -2,6 +2,7 @@ use crate::error::ContractError;
 use crate::ethereum;
 use crate::msg::{AnalyzeResult, EthereumAnalyzerResult, ExecuteMsg, QueryMsg};
 use alloy_consensus::SignableTransaction;
+use alloy_primitives::TxKind;
 use bindings::WardenProtocolQuery;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
@@ -46,11 +47,48 @@ pub fn analyze(input: Binary) -> Result<Response, ContractError> {
 
     let result = AnalyzeResult::new_with_data(
         tx.signature_hash().as_slice().into(),
-        EthereumAnalyzerResult {},
+        EthereumAnalyzerResult {
+            to: match tx.to {
+                TxKind::Call(to) => to.to_string(),
+                TxKind::Create => "".to_string(),
+            },
+            value: tx.value.to_string(),
+            chain_id: tx.chain_id,
+        },
     );
 
     let ser_result = serde_json_wasm::to_vec(&result)
         .map_err(|e| -> ContractError { StdError::generic_err(e.to_string()).into() })?;
     let res = Response::new().set_data(ser_result);
     Ok(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_analyze() -> Result<(), Box<dyn std::error::Error>> {
+        let txhex = "02f283aa36a70a843b9aca008529779987ce82520894077cfb491cea8f35304ab3a6015f4ea3756ba50687038d7ea4c6800080c0";
+        let txbytez = hex::decode(txhex)?;
+
+        let response = analyze(txbytez.into())?;
+        let data: AnalyzeResult<EthereumAnalyzerResult> =
+            serde_json_wasm::from_slice(&response.data.unwrap())?;
+
+        assert_eq!(
+            data.result.to,
+            "0x077Cfb491CEa8F35304aB3A6015F4Ea3756bA506".to_string()
+        );
+        assert_eq!(data.result.value, "1000000000000000".to_string());
+        assert_eq!(
+            data.data_for_signing,
+            Some(
+                hex::decode("2f53d4dcac8f9242d1c1704ac8fe8a0c2c274218b019d0ab7ce32474f9c91136")?
+                    .into()
+            )
+        );
+
+        Ok(())
+    }
 }

--- a/contracts/contracts/ethereum-analyzer/src/msg.rs
+++ b/contracts/contracts/ethereum-analyzer/src/msg.rs
@@ -29,7 +29,11 @@ impl<T> AnalyzeResult<T> {
 }
 
 #[cw_serde]
-pub struct EthereumAnalyzerResult {}
+pub struct EthereumAnalyzerResult {
+    pub to: String,
+    pub value: String,
+    pub chain_id: u64,
+}
 
 #[cw_serde]
 #[derive(QueryResponses)]


### PR DESCRIPTION
closes #306

Export `to` and `value` fields from Ethereum transactions.

It should be noted that `to` is a string in the classic ethereum format (e.g. `0x077Cfb491CEa8F35304aB3A6015F4Ea3756bA506`), mind the case when comparing to it.

On the other hand, `value` is also a string (representing the WEI being transferred) to not lose any precision. I think it will be the `shield` language that needs to provide a nice user experience when comparing strings that represent big integers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Ethereum transaction analysis results to include additional details such as recipient address, transaction value, and chain ID.
  
- **Tests**
  - Added a new test for the enhanced transaction analysis functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->