### PR TITLE
feat(ci): build spaceward when there's changes in wardenjs

### DIFF
--- a/.github/workflows/spaceward.yml
+++ b/.github/workflows/spaceward.yml
@@ -7,11 +7,13 @@ on:
       - main
     paths:
       - "spaceward/**"
+      - "wardenjs/**"
     tags:
       - "spaceward/v*"
   pull_request:
     paths:
       - "spaceward/**"
+      - "wardenjs/**"
 
 jobs:
   build:


### PR DESCRIPTION
Spaceward uses wardenjs so it makes sense to build it everytime there's a change in wardenjs as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to include `wardenjs` path for pull request triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->