### PR TITLE
fix(x/warden): handle analyzers strings values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * (shield) fix possible occurring panic in case of nil env
+* (x/warden) Handle analyzers that return string values correctly
 
 ### Misc
 

--- a/warden/x/warden/keeper/wasm.go
+++ b/warden/x/warden/keeper/wasm.go
@@ -98,6 +98,10 @@ func parseShieldExpression(v json.RawMessage) (*ast.Expression, error) {
 	}
 
 	switch out := out.(type) {
+	case string:
+		return ast.NewStringLiteral(&ast.StringLiteral{
+			Value: out,
+		}), nil
 	case int64:
 		return ast.NewIntegerLiteral(&ast.IntegerLiteral{
 			Value: big.NewInt(out).String(),


### PR DESCRIPTION
The Ethereum analyzer now returns strings, but I haven't realized I wasn't unmarshalling it properly before executing the intent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a potential panic issue related to nil environment in the shield module.
  - Correctly handled analyzers that return string values in the x/warden module.

- **New Features**
  - Added support for parsing string literals in expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->