### PR TITLE
fix(tests): wait for height=2 before running tests

### DIFF
--- a/tests/framework/exec/warden_node.go
+++ b/tests/framework/exec/warden_node.go
@@ -89,7 +89,7 @@ func (w *WardenNode) CometPortRPC() int {
 
 func (w *WardenNode) WaitRunnning(t *testing.T) {
 	require.Eventually(t, func() bool {
-		return strings.Contains(w.Stdout.String(), "received proposal")
+		return strings.Contains(w.Stdout.String(), "height=2")
 	}, 5*time.Second, 5*time.Millisecond, "warden node never became running")
 }
 


### PR DESCRIPTION
On my laptop I hit "node not ready" once. This should definitely fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of node status checks by refining the logic used to determine if a node is running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->