### PR TITLE
fix(go-client): remove init() that was moved into app pkg

### DIFF
--- a/go-client/query_client.go
+++ b/go-client/query_client.go
@@ -24,7 +24,7 @@ func NewQueryClient(url string, insecure bool) (*QueryClient, error) {
 	if insecure {
 		opts = append(opts, grpc.WithTransportCredentials(insecurecreds.NewCredentials()))
 	}
-	grpcConn, err := grpc.Dial(url, opts...)
+	grpcConn, err := grpc.NewClient(url, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/go-client/tx_identity.go
+++ b/go-client/tx_identity.go
@@ -11,14 +11,6 @@ import (
 	"github.com/cosmos/go-bip39"
 )
 
-var addrPrefix = "warden"
-
-func init() {
-	// set up SDK config (singleton)
-	config := sdktypes.GetConfig()
-	config.SetBech32PrefixForAccount(addrPrefix, addrPrefix+"pub")
-}
-
 // Identity represents an account on the Warden Protocol. It can be used to sign
 // transactions.
 type Identity struct {


### PR DESCRIPTION
This init() now panics because the config initialization has been moved into the app package's init in #425. We can safely remove it to fix it.