### PR TITLE
fix(wardenkms): default chain ID should be `warden`

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -72,7 +72,7 @@ func ConfigFromEnv() Config {
 
 	return Config{
 		CliName:        envOrDefault("CLI_NAME", "wardend"),
-		ChainID:        envOrDefault("CHAIN_ID", "wardenprotocol"),
+		ChainID:        envOrDefault("CHAIN_ID", "warden"),
 		KeyringBackend: envOrDefault("KEYRING_BACKEND", "test"),
 		Node:           envOrDefault("NODE", "http://localhost:26657"),
 		SendDenom:      envOrDefault("DENOM", "10000000uward"),

--- a/cmd/wardenkms/wardenkms.go
+++ b/cmd/wardenkms/wardenkms.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Config struct {
-	ChainID        string `env:"CHAIN_ID, default=wardenprotocol"`
+	ChainID        string `env:"CHAIN_ID, default=warden"`
 	GRPCURL        string `env:"GRPC_URL, default=localhost:9090"`
 	GRPCInsecure   bool   `env:"GRPC_INSECURE, default=true"`
 	DerivationPath string `env:"DERIVATION_PATH, default=m/44'/118'/0'/0/0"`


### PR DESCRIPTION
found a couple of old references to the chain id being "wardenprotocol"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default `ChainID` value in configurations from "wardenprotocol" to "warden".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->