### PR TITLE
Improve actions cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * `EventCreateAction`
     * `EventApproveAction`
     * `EventActionStateChange`
+* (x/act) Improve CLI flags allowing to specify enums using their names instead of their numeric values
 * (x/warden) Ensure only Keychain's parties can update a SignatureRequest
 * (x/warden) Change Keychain.Fees type to Coins instead of uint64s. This makes possible to receive any token as a fee, not just uward.
 * (x/warden) Remove Keychain.IsActive field. This field was used to determine if a Keychain was active or not, to automatically reject incoming requests, but it was never used.

--- a/warden/x/act/client/actions.go
+++ b/warden/x/act/client/actions.go
@@ -195,6 +195,9 @@ func populateFromFlags(msg sdk.Msg, cmd *cobra.Command, cdc codec.Codec) error {
 				if err != nil {
 					return err
 				}
+				if jvalue == "" {
+					return nil
+				}
 				v.Field(i).Set(reflect.ValueOf(&codectypes.Any{}))
 				if err := cdc.UnmarshalJSON([]byte(jvalue), v.Field(i).Interface().(proto.Message)); err != nil {
 					return err

--- a/warden/x/act/client/actions.go
+++ b/warden/x/act/client/actions.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -101,6 +102,12 @@ func addFlagsFromMsg(msg sdk.Msg, cmd *cobra.Command) {
 			continue
 		}
 
+		isEnum := strings.Contains(v.Type().Field(i).Tag.Get("protobuf"), "enum")
+		if isEnum {
+			cmd.Flags().String(flagName, "", "")
+			return
+		}
+
 		switch v.Field(i).Kind() {
 		case reflect.String:
 			cmd.Flags().String(flagName, "", "")
@@ -145,6 +152,51 @@ func populateFromFlags(msg sdk.Msg, cmd *cobra.Command, cdc codec.Codec) error {
 	for i := 0; i < v.NumField(); i++ {
 		fieldName := strings.ToLower(v.Type().Field(i).Name)
 		flagName := strcase.ToKebab(v.Type().Field(i).Name)
+
+		// try to parse enum type from protobuf tags
+		var enumProtoType string
+		tags := strings.Split(v.Type().Field(i).Tag.Get("protobuf"), ",")
+		for _, tag := range tags {
+			if strings.HasPrefix(tag, "enum") {
+				enumProtoType = strings.TrimPrefix(tag, "enum=")
+			}
+		}
+
+		// the field is an enum, handle it differently
+		if enumProtoType != "" {
+			value, err := cmd.Flags().GetString(flagName)
+			if err != nil {
+				return err
+			}
+
+			if value == "" {
+				return nil
+			}
+
+			// if user provided a number, use it as-is
+			valueN, err := strconv.ParseInt(value, 10, 64)
+			if err == nil {
+				v.Field(i).SetInt(valueN)
+				return nil
+			}
+
+			// else, reverse lookup the enum value
+			fmt.Println(enumProtoType)
+			valsMap := proto.EnumValueMap(enumProtoType)
+			for k, val := range valsMap {
+				if strings.EqualFold(k, value) {
+					v.Field(i).SetInt(int64(val))
+					return nil
+				}
+			}
+
+			possibleValues := make([]string, 0, len(valsMap))
+			for k := range valsMap {
+				possibleValues = append(possibleValues, k)
+			}
+
+			return fmt.Errorf("invalid enum value %s for flag %s; possible values: %s", value, flagName, strings.Join(possibleValues, ", "))
+		}
 
 		switch v.Field(i).Kind() {
 		case reflect.String:


### PR DESCRIPTION
The first commit fixes a problem where `Any` objects couldn't be omitted in CLI flags (i.e. `--metadata` in new-signature-request)

The second commit specify enums using their string value, e.g. `--key-type`:

```
wardend tx warden new-action new-key-request --space-id 1 --keychain-id 1 --key-type KEY_TYPE_ECDSA_SECP256K1 --from shulgin
```

(previously you would have needed to use `1`, which is hard to remember and read)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Improved CLI functionality to specify enums by names instead of numeric values.
    - Enhanced error handling for invalid enum values in command flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->