### PR TITLE
Fix SpacesByOwner index when owner is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (x/warden) Handle analyzers that return string values correctly
 * (x/warden) Fix KeyRequests query when KeychainId filter is not set
 * (x/warden) Fix SignatureRequests query when KeychainId filter is not set
+* (x/warden) Ensure that SpacesByOwner index is updated when an owner is removed
 
 ### Misc
 

--- a/tests/cases/add_remove_owner.go
+++ b/tests/cases/add_remove_owner.go
@@ -1,0 +1,52 @@
+package cases
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/warden-protocol/wardenprotocol/tests/framework"
+	"github.com/warden-protocol/wardenprotocol/tests/framework/checks"
+	"github.com/warden-protocol/wardenprotocol/tests/framework/exec"
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
+)
+
+func init() {
+	Register(&Test_AddRemoveOwner{})
+}
+
+type Test_AddRemoveOwner struct {
+	w *exec.WardenNode
+}
+
+func (c *Test_AddRemoveOwner) Setup(t *testing.T, ctx context.Context, build framework.BuildResult) {
+	c.w = exec.NewWardenNode(t, build.Wardend)
+
+	go c.w.Start(t, ctx, "./testdata/snapshot-base")
+	c.w.WaitRunnning(t)
+}
+
+func (c *Test_AddRemoveOwner) Run(t *testing.T, ctx context.Context, build framework.BuildResult) {
+	alice := exec.NewWardend(c.w, "alice")
+	res := alice.Tx(t, "warden new-space")
+	checks.SuccessTx(t, res)
+
+	resAddOwner := alice.Tx(t, "warden new-action add-space-owner --space-id 1 --new-owner warden10zm6farjqffkadjx8v0znx67x6a26f36p020td")
+	checks.SuccessTx(t, resAddOwner)
+
+	client := c.w.GRPCClient(t)
+	spacesByOwnerRes, err := client.Warden.SpacesByOwner(ctx, &types.QuerySpacesByOwnerRequest{
+		Owner: "warden10zm6farjqffkadjx8v0znx67x6a26f36p020td",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(spacesByOwnerRes.Spaces))
+
+	resRemoveOwner := alice.Tx(t, "warden new-action remove-space-owner --space-id 1 --owner warden10zm6farjqffkadjx8v0znx67x6a26f36p020td")
+	checks.SuccessTx(t, resRemoveOwner)
+
+	spacesByOwnerRes2, err := client.Warden.SpacesByOwner(ctx, &types.QuerySpacesByOwnerRequest{
+		Owner: "warden10zm6farjqffkadjx8v0znx67x6a26f36p020td",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, len(spacesByOwnerRes2.Spaces))
+}

--- a/warden/x/warden/keeper/spaces.go
+++ b/warden/x/warden/keeper/spaces.go
@@ -58,6 +58,11 @@ func (k SpacesKeeper) updateSpaceOwners(ctx context.Context, space types.Space) 
 		return fmt.Errorf("space id is not set")
 	}
 
+	err := k.spacesByOwner.Clear(ctx, nil)
+	if err != nil {
+		return err
+	}
+
 	for _, owner := range space.Owners {
 		ownerAddr, err := sdk.AccAddressFromBech32(owner)
 		if err != nil {


### PR DESCRIPTION
closes #423 

there is a more optimized version that doesn't clear owners that were not removed, but for now a working version is better than a non-working version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented a test case to verify the functionality of adding and removing owners in a warden node environment.

- **Bug Fixes**
  - Ensured the `SpacesByOwner` index is correctly updated when an owner is removed.

- **Tests**
  - Added comprehensive test coverage for owner management in spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->