### PR TITLE
tests: remove old --metadata flag

### DIFF
--- a/tests/cases/keychain_writers.go
+++ b/tests/cases/keychain_writers.go
@@ -58,7 +58,7 @@ func (c *Test_KeychainWriters) Run(t *testing.T, ctx context.Context, build fram
 
 	t.Run("create signature request", func(t *testing.T) {
 		// create a SignatureRequest
-		newReqTx := bob.Tx(t, `warden new-action new-signature-request --key-id 1 --input 'HoZ4Z+ZU7Zd08kUR5NcbtFZrmGKF18mSBJ29dg0qI44=' --metadata '{"@type": "/warden.warden.v1beta2.MetadataEthereum", "chain_id":123}'`)
+		newReqTx := bob.Tx(t, "warden new-action new-signature-request --key-id 1 --input 'HoZ4Z+ZU7Zd08kUR5NcbtFZrmGKF18mSBJ29dg0qI44='")
 		checks.SuccessTx(t, newReqTx)
 
 		// try to fulfill it from an address that's not one of the Keychain's writers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Simplified the construction of a command in a test function related to creating a signature request, removing complex metadata formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->