### PR TITLE
Fix SpacesByOwner index update

### DIFF
--- a/warden/x/warden/keeper/keeper.go
+++ b/warden/x/warden/keeper/keeper.go
@@ -77,19 +77,23 @@ func NewKeeper(
 
 	spacesKeeper := NewSpacesKeeper(sb, cdc)
 
-	keychainSeq := collections.NewSequence(sb, KeychainSeqPrefix, "keychain sequence")
+	keychainSeq := collections.NewSequence(sb, KeychainSeqPrefix, "keychain_sequence")
 	keychainColl := collections.NewMap(sb, KeychainsPrefix, "keychains", collections.Uint64Key, codec.CollValue[v1beta2.Keychain](cdc))
 	keychains := repo.NewSeqCollection(keychainSeq, keychainColl, func(v *v1beta2.Keychain, u uint64) { v.Id = u })
 
 	keysKeeper := NewKeysKeeper(sb, cdc)
 
-	keyRequestsSeq := collections.NewSequence(sb, KeyRequestSeqPrefix, "key requests sequence")
-	keyRequestsColl := collections.NewMap(sb, KeyRequestsPrefix, "key requests", collections.Uint64Key, codec.CollValue[v1beta2.KeyRequest](cdc))
+	keyRequestsSeq := collections.NewSequence(sb, KeyRequestSeqPrefix, "key_requests_sequence")
+	keyRequestsColl := collections.NewMap(sb, KeyRequestsPrefix, "key_requests", collections.Uint64Key, codec.CollValue[v1beta2.KeyRequest](cdc))
 	keyRequests := repo.NewSeqCollection(keyRequestsSeq, keyRequestsColl, func(kr *v1beta2.KeyRequest, u uint64) { kr.Id = u })
 
-	SignRequestsSeq := collections.NewSequence(sb, SignRequestSeqPrefix, "signature requests sequence")
-	SignRequestsColl := collections.NewMap(sb, SignRequestsPrefix, "signature requests", collections.Uint64Key, codec.CollValue[v1beta2.SignRequest](cdc))
-	SignRequests := repo.NewSeqCollection(SignRequestsSeq, SignRequestsColl, func(sr *v1beta2.SignRequest, u uint64) { sr.Id = u })
+	signRequestsSeq := collections.NewSequence(sb, SignRequestSeqPrefix, "signature_requests_sequence")
+	signRequestsColl := collections.NewMap(sb, SignRequestsPrefix, "signature_requests", collections.Uint64Key, codec.CollValue[v1beta2.SignRequest](cdc))
+	signRequests := repo.NewSeqCollection(signRequestsSeq, signRequestsColl, func(sr *v1beta2.SignRequest, u uint64) { sr.Id = u })
+
+	if _, err := sb.Build(); err != nil {
+		panic(err)
+	}
 
 	k := Keeper{
 		cdc:          cdc,
@@ -101,7 +105,7 @@ func NewKeeper(
 		keychains: keychains,
 
 		keyRequests:  keyRequests,
-		signRequests: SignRequests,
+		signRequests: signRequests,
 
 		SpacesKeeper: spacesKeeper,
 		KeysKeeper:   keysKeeper,

--- a/warden/x/warden/keeper/spaces.go
+++ b/warden/x/warden/keeper/spaces.go
@@ -17,7 +17,7 @@ type SpacesKeeper struct {
 }
 
 func NewSpacesKeeper(sb *collections.SchemaBuilder, cdc codec.BinaryCodec) SpacesKeeper {
-	spaceSeq := collections.NewSequence(sb, SpaceSeqPrefix, "spaces sequence")
+	spaceSeq := collections.NewSequence(sb, SpaceSeqPrefix, "spaces_sequence")
 	spacesColl := collections.NewMap(sb, SpacesPrefix, "spaces", collections.Uint64Key, codec.CollValue[types.Space](cdc))
 	spaces := repo.NewSeqCollection(spaceSeq, spacesColl, func(v *types.Space, u uint64) { v.Id = u })
 	spacesByOwner := collections.NewKeySet(sb, SpacesByOwnerPrefix, "spaces_by_owner", collections.PairKeyCodec(sdk.AccAddressKey, collections.Uint64Key))


### PR DESCRIPTION
I realized I broke the index even more with #423, now it gets completely wiped at every space update.

This PR finally fixes it, for good, I hope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved error handling for sequence builder, ensuring more robust operations.
  - Added functionality to manage removal of previous owners in space updates.
  - Introduced a new utility function for calculating differences between lists.

- **Refactor**
  - Renamed sequences and collections variables for better consistency and readability.
  - Adjusted `SpacesKeeper` methods to support additional parameters for more efficient updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->