### PR TITLE
fix: wrap PreBlocker to call both app preblock and oracle preblock

### DIFF
--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -2,11 +2,6 @@ package app
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"os"
-	"path/filepath"
-
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
@@ -15,6 +10,7 @@ import (
 	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"fmt"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -70,6 +66,9 @@ import (
 	"github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/keeper"
 	wardenmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/warden/keeper"
 	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
+	"io"
+	"os"
+	"path/filepath"
 
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 
@@ -156,6 +155,7 @@ type App struct {
 	IncentivesKeeper incentiveskeeper.Keeper
 	AlertsKeeper     alertskeeper.Keeper
 	MarketMapKeeper  *marketmapkeeper.Keeper
+	oraclePreBlocker sdk.PreBlocker
 
 	// this line is used by starport scaffolding # stargate/app/keeperDeclaration
 

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -75,10 +75,6 @@ import (
 	"github.com/warden-protocol/wardenprotocol/warden/docs"
 
 	oracleclient "github.com/skip-mev/slinky/service/clients/oracle"
-	alertskeeper "github.com/skip-mev/slinky/x/alerts/keeper"
-	alerttypes "github.com/skip-mev/slinky/x/alerts/types"
-	"github.com/skip-mev/slinky/x/alerts/types/strategies"
-	incentiveskeeper "github.com/skip-mev/slinky/x/incentives/keeper"
 	marketmapkeeper "github.com/skip-mev/slinky/x/marketmap/keeper"
 	oraclekeeper "github.com/skip-mev/slinky/x/oracle/keeper"
 )
@@ -152,8 +148,6 @@ type App struct {
 
 	// Slinky
 	OracleKeeper     *oraclekeeper.Keeper
-	IncentivesKeeper incentiveskeeper.Keeper
-	AlertsKeeper     alertskeeper.Keeper
 	MarketMapKeeper  *marketmapkeeper.Keeper
 	oraclePreBlocker sdk.PreBlocker
 
@@ -196,8 +190,6 @@ func getGovProposalHandlers() []govclient.ProposalHandler {
 func AppConfig() depinject.Config {
 	return depinject.Configs(
 		moduleConfig(),
-		depinject.Provide(alerttypes.ProvideMsgAlertGetSigners),
-		depinject.Provide(ProvideIncentives),
 		// Loads the ao config from a YAML file.
 		// appconfig.LoadYAML(AppConfigYAML),
 		depinject.Supply(
@@ -208,7 +200,6 @@ func AppConfig() depinject.Config {
 				ibchookstypes.ModuleName: ibchooks.AppModuleBasic{},
 				// this line is used by starport scaffolding # stargate/appConfig/moduleBasic
 			},
-			strategies.DefaultHandleValidatorIncentive(),
 		),
 	)
 }
@@ -324,8 +315,6 @@ func New(
 		&app.ActKeeper,
 		&app.MarketMapKeeper,
 		&app.OracleKeeper,
-		&app.IncentivesKeeper,
-		&app.AlertsKeeper,
 		// this line is used by starport scaffolding # stargate/app/keeperDefinition
 	); err != nil {
 		panic(err)

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -2,6 +2,11 @@ package app
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
@@ -10,7 +15,6 @@ import (
 	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-	"fmt"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -66,9 +70,6 @@ import (
 	"github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/keeper"
 	wardenmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/warden/keeper"
 	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
-	"io"
-	"os"
-	"path/filepath"
 
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 

--- a/warden/app/app_config.go
+++ b/warden/app/app_config.go
@@ -86,15 +86,8 @@ import (
 
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 
-	alertmodulev1 "github.com/skip-mev/slinky/api/slinky/alerts/module/v1"
-	incentivesmodulev1 "github.com/skip-mev/slinky/api/slinky/incentives/module/v1"
 	marketmapmodulev1 "github.com/skip-mev/slinky/api/slinky/marketmap/module/v1"
 	oraclemodulev1 "github.com/skip-mev/slinky/api/slinky/oracle/module/v1"
-	_ "github.com/skip-mev/slinky/x/alerts"
-	alerttypes "github.com/skip-mev/slinky/x/alerts/types"
-	"github.com/skip-mev/slinky/x/alerts/types/strategies"
-	_ "github.com/skip-mev/slinky/x/incentives" // import for side-effects
-	incentivetypes "github.com/skip-mev/slinky/x/incentives/types"
 	_ "github.com/skip-mev/slinky/x/marketmap" // import for side-effects
 	marketmaptypes "github.com/skip-mev/slinky/x/marketmap/types"
 	_ "github.com/skip-mev/slinky/x/oracle" // import for side-effects
@@ -115,14 +108,6 @@ func init() {
 	config.SetBech32PrefixForValidator(validatorAddressPrefix, validatorPubKeyPrefix)
 	config.SetBech32PrefixForConsensusNode(consNodeAddressPrefix, consNodePubKeyPrefix)
 	config.Seal()
-}
-
-// ProvideIncentives provides the incentive strategies for the incentive module, wrt the expected Keeper dependencies for
-// incentive handler.
-func ProvideIncentives(bk alerttypes.BankKeeper, sk alerttypes.StakingKeeper) map[incentivetypes.Incentive]incentivetypes.Strategy {
-	return map[incentivetypes.Incentive]incentivetypes.Strategy{
-		&strategies.ValidatorAlertIncentive{}: strategies.DefaultValidatorAlertIncentiveStrategy(sk, bk),
-	}
 }
 
 var (
@@ -169,8 +154,6 @@ var (
 		wasmtypes.ModuleName,
 		// slinky modules
 		oracletypes.ModuleName,
-		incentivetypes.ModuleName,
-		alerttypes.ModuleName,
 		// market map genesis must be called AFTER all consuming modules (i.e. x/oracle, etc.)
 		marketmaptypes.ModuleName,
 		// this line is used by starport scaffolding # stargate/app/initGenesis
@@ -204,8 +187,6 @@ var (
 		actmoduletypes.ModuleName,
 		// slinky modules
 		oracletypes.ModuleName,
-		incentivetypes.ModuleName,
-		alerttypes.ModuleName,
 		marketmaptypes.ModuleName,
 		// this line is used by starport scaffolding # stargate/app/beginBlockers
 	}
@@ -232,9 +213,6 @@ var (
 		actmoduletypes.ModuleName,
 		// slinky modules
 		oracletypes.ModuleName,
-		// alert Endblock must precede incentives types EndBlocker (issued incentives should be executed same block)
-		alerttypes.ModuleName,
-		incentivetypes.ModuleName,
 		marketmaptypes.ModuleName,
 		// this line is used by starport scaffolding # stargate/app/endBlockers
 	}
@@ -257,8 +235,6 @@ var (
 		{Account: icatypes.ModuleName},
 		{Account: actmoduletypes.ModuleName},
 		{Account: oracletypes.ModuleName, Permissions: []string{}},
-		{Account: incentivetypes.ModuleName, Permissions: []string{}},
-		{Account: alerttypes.ModuleName, Permissions: []string{authtypes.Burner, authtypes.Minter}},
 		// this line is used by starport scaffolding # stargate/app/maccPerms
 	}
 
@@ -348,10 +324,6 @@ func moduleConfig() depinject.Config {
 					Config: appconfig.WrapAny(&oraclemodulev1.Module{}),
 				},
 				{
-					Name:   incentivetypes.ModuleName,
-					Config: appconfig.WrapAny(&incentivesmodulev1.Module{}),
-				},
-				{
 					Name:   genutiltypes.ModuleName,
 					Config: appconfig.WrapAny(&genutilmodulev1.Module{}),
 				},
@@ -409,12 +381,6 @@ func moduleConfig() depinject.Config {
 				{
 					Name:   actmoduletypes.ModuleName,
 					Config: appconfig.WrapAny(&actmodulev1.Module{}),
-				},
-				{
-					Name: alerttypes.ModuleName,
-					Config: appconfig.WrapAny(&alertmodulev1.Module{
-						Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-					}),
 				},
 				{
 					Name: marketmaptypes.ModuleName,

--- a/warden/app/oracle.go
+++ b/warden/app/oracle.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	abci "github.com/cometbft/cometbft/abci/types"
 	"slices"
 	"time"
 
@@ -71,6 +72,23 @@ func (app *App) initializeOracle(appOpts types.AppOptions) {
 	initializeABCIExtensions(app, oracleMetrics)
 }
 
+func (app *App) wrappedPreBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock) (*sdk.ResponsePreBlock, error) {
+	// call app's preblocker first in case there is changes made on upgrades
+	// that can modify state and lead to serialization/deserialization issues
+	resp, err := app.ModuleManager.PreBlock(ctx)
+	if err != nil {
+		return resp, err
+	}
+
+	_, err = app.oraclePreBlocker(ctx, req)
+	if err != nil {
+		return &sdk.ResponsePreBlock{}, err
+	}
+
+	// return resp from app's preblocker which can return consensus param changed flag
+	return resp, nil
+}
+
 func initializeABCIExtensions(app *App, oracleMetrics servicemetrics.Metrics) {
 	// Create the proposal handler that will be used to fill proposals with
 	// transactions and oracle data.
@@ -119,7 +137,8 @@ func initializeABCIExtensions(app *App, oracleMetrics servicemetrics.Metrics) {
 		),
 	)
 
-	app.SetPreBlocker(oraclePreBlockHandler.PreBlocker())
+	app.oraclePreBlocker = oraclePreBlockHandler.PreBlocker()
+	app.SetPreBlocker(app.wrappedPreBlocker)
 
 	// Create the vote extensions handler that will be used to extend and verify
 	// vote extensions (i.e. oracle data).

--- a/warden/app/oracle.go
+++ b/warden/app/oracle.go
@@ -29,8 +29,6 @@ import (
 	"github.com/skip-mev/slinky/pkg/math/voteweighted"
 	oracleclient "github.com/skip-mev/slinky/service/clients/oracle"
 	servicemetrics "github.com/skip-mev/slinky/service/metrics"
-	"github.com/skip-mev/slinky/x/alerts"
-	"github.com/skip-mev/slinky/x/incentives"
 	marketmaptypes "github.com/skip-mev/slinky/x/marketmap/types"
 	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
 )
@@ -259,8 +257,6 @@ func createSlinkyUpgrader(app *App) AppUpgrade {
 			Added: []string{
 				marketmaptypes.ModuleName,
 				oracletypes.ModuleName,
-				incentives.AppModuleBasic{}.Name(),
-				alerts.AppModuleBasic{}.Name(),
 			},
 		},
 	}


### PR DESCRIPTION
adds a wrapped PreBlocker that calls both the application PreBlock and the Oracle's preblocker. 

this fixes an issue where x/upgrade's preblocker wasn't running, causing scheduled upgrades to not trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new oracle pre-blocker functionality to enhance processing.

- **Refactor**
  - Removed outdated incentives and alerts modules for cleaner and more efficient code management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->