### PR TITLE
fix: `just deploy-contract` hardcoded CODE_ID

### DIFF
--- a/justfile
+++ b/justfile
@@ -100,5 +100,5 @@ localnet bin="wardend":
 deploy-contract contract from="shulgin" label="":
     #!/usr/bin/env bash
     CODE_ID=$(wardend tx wasm store {{contract}} --from {{from}} -y --gas auto --gas-adjustment 1.3 | wardend q wait-tx -o json | jq '.events[] | select(.type == "store_code") | .attributes[] | select(.key == "code_id") | .value | tonumber')
-    ADDR=$(wardend tx wasm instantiate 1 '{}' --from {{from}} --label "{{if label == "" { "default" } else { label } }}" --no-admin -y | wardend q wait-tx -o json | jq '.events[] | select(.type == "instantiate") | .attributes[] | select(.key == "_contract_address") | .value')
+    ADDR=$(wardend tx wasm instantiate $CODE_ID '{}' --from {{from}} --label "{{if label == "" { "default" } else { label } }}" --no-admin -y | wardend q wait-tx -o json | jq '.events[] | select(.type == "instantiate") | .attributes[] | select(.key == "_contract_address") | .value')
     echo {{contract}} deployed at $ADDR


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the reliability of contract deployment by using a stored code ID in the `deploy-contract` script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->