### PR TITLE
Update relay endpoint

### DIFF
--- a/spaceward/bin/relay.mjs
+++ b/spaceward/bin/relay.mjs
@@ -12,6 +12,7 @@ const port = process.env.RELAY_LISTEN_PORT ?? 3339;
 const keyFile = process.env.KEY_FILE;
 const certFile = process.env.CERT_FILE;
 let ssl = false;
+let peerId;
 
 try {
 	accessSync(keyFile);
@@ -22,7 +23,6 @@ try {
 }
 
 const module = ssl ? import("https") : import("http");
-let multiaddrs;
 
 const { key, cert } = ssl
 	? {
@@ -39,16 +39,14 @@ const handler = (req, res) => {
 		"Access-Control-Allow-Headers": "Content-Type, Authorization",
 	});
 
-	if (!multiaddrs) {
+	if (!peerId) {
 		res.statusCode = 500;
-		res.end(JSON.stringify({ error: "No multiaddrs available" }));
+		res.end(JSON.stringify({ error: "No peerId" }));
 	}
-
-	const filtered = multiaddrs.filter((ma) => !ma.includes("127.0.0.1"));
 
 	res.end(
 		JSON.stringify({
-			multiaddrs: filtered.length ? filtered : multiaddrs,
+			peerId,
 		}),
 	);
 };
@@ -86,7 +84,7 @@ module
 			},
 		});
 
-		multiaddrs = node.getMultiaddrs().map((ma) => ma.toString());
-		console.log(`Listening on :${port}`, { multiaddrs });
+		peerId = node.peerId.toString();
+		console.log(`Listening on :${port}, peerId=${peerId}` );
 	})
 	.catch(console.error);

--- a/spaceward/src/env.ts
+++ b/spaceward/src/env.ts
@@ -20,7 +20,7 @@ const aminoAnalyzerContract =
 	import.meta.env.VITE_WARDEN_AMINO_ANALYZER_CONTRACT ||
 	"warden1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrq075d7k";
 const p2pRelayURL =
-	import.meta.env.VITE_P2P_RELAY_URL || "https://127.0.0.1:3339";
+	import.meta.env.VITE_P2P_RELAY_URL || "https://relay.alex-d.xyz:10001/"; //"https://relay.devnet.wardenprotocol.org:3339"; // "https://192.168.1.7:3339";
 
 export const env = {
 	apiURL,

--- a/spaceward/src/hooks/useLibp2p.ts
+++ b/spaceward/src/hooks/useLibp2p.ts
@@ -81,24 +81,26 @@ export default function useLibp2p() {
 		staleTime: Infinity,
 	});
 
-	const relayMultiaddrQuery = useQuery({
+	const hostname: string | undefined = env.p2pRelayURL.split("/")[2];
+
+	const relayInfoQuery = useQuery({
 		queryKey: ["relay-multiaddr"],
 		queryFn: async () => {
 			const response = await fetch(env.p2pRelayURL);
 
 			const json: {
-				multiaddrs?: string[];
+				peerId?: string
 			} = await response.json();
 
-			return json.multiaddrs;
+			return json.peerId;
 		},
-		// fixme maybe should update sometimes
 		refetchInterval: Infinity,
 		staleTime: Infinity,
 	});
 
 	return {
 		libp2p: libp2pQuery.data,
-		relayMultiaddrs: relayMultiaddrQuery.data,
+		peerId: relayInfoQuery.data,
+		hostname
 	};
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated connection logic to use `peerId` and `hostname` for improved relay handling.

- **Improvements**
  - Changed default relay URL to `https://relay.alex-d.xyz:10001/` for better reliability.
  - Enhanced dialing logic with `peerId`, `host`, and `port` for more precise connections.

- **Refactor**
  - Replaced `multiaddrs` usage with `peerId` across multiple components for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->