### PR TITLE
docs: automatic persistent peers list

### DIFF
--- a/docs/developer-docs/docs/operate-a-node/networks/join-buenavista.mdx
+++ b/docs/developer-docs/docs/operate-a-node/networks/join-buenavista.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 2
 ---
 
+import PersistentPeers from "@site/src/components/PersistentPeers";
+
 # Join Buenavista
 
 ## Overview
@@ -66,11 +68,14 @@ To configure `wardend`, do the following:
 
 2. Set the mandatory configuration options:
 
-    ```bash
-    # Set minimum gas price & peers
-    sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.0025uward"/' app.toml
-    sed -i 's/persistent_peers = ""/persistent_peers = "650c66dda5f7aa954f44fd6148a6f32b085ca792@sentry-0.buenavista.wardenprotocol.org:26656,7c70120717ef5eae8236162ede6819249bd6587d@sentry-1.buenavista.wardenprotocol.org:26656,288116b75c3c710268b5d86182d8dd5e33a6b56f@sentry-2.buenavista.wardenprotocol.org:26656"/' config.toml
-    ```
+```bash
+# Set minimum gas price & peers
+sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.0025uward"/' app.toml
+```
+
+<PersistentPeers
+    chainInfoUrl='https://raw.githubusercontent.com/warden-protocol/networks/main/testnets/buenavista/chain.json'
+    code={`sed -i 's/persistent_peers = ""/persistent_peers = "{{persistent_peers}}"/' config.toml`} />
 
 <!--- To be confirmed
 ## (Recommended) Setup state sync

--- a/docs/developer-docs/docs/operate-a-node/networks/join-buenavista.mdx
+++ b/docs/developer-docs/docs/operate-a-node/networks/join-buenavista.mdx
@@ -77,7 +77,7 @@ sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.0025uward"/' app.toml
     chainInfoUrl='https://raw.githubusercontent.com/warden-protocol/networks/main/testnets/buenavista/chain.json'
     code={`sed -i 's/persistent_peers = ""/persistent_peers = "{{persistent_peers}}"/' config.toml`} />
 
-<!--- To be confirmed
+{/* To be confirmed
 ## (Recommended) Setup state sync
 
 This step is optional.
@@ -122,7 +122,7 @@ s|^(rpc_servers[[:space:]]+=[[:space:]]+).*$|\1\"$SNAP_RPC_SERVERS\"| ; \
 s|^(trust_height[[:space:]]+=[[:space:]]+).*$|\1$BLOCK_HEIGHT| ; \
 s|^(trust_hash[[:space:]]+=[[:space:]]+).*$|\1\"$TRUST_HASH\"|" $HOME/.warden/config/config.toml
 ```
---->
+*/}
 
 ## 3. Start the node
 

--- a/docs/developer-docs/package-lock.json
+++ b/docs/developer-docs/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.2.1",
-        "@docusaurus/plugin-google-gtag": "^3.2.1",
-        "@docusaurus/plugin-google-tag-manager": "^3.2.1",
+        "@docusaurus/plugin-google-gtag": "3.2.1",
+        "@docusaurus/plugin-google-tag-manager": "3.2.1",
         "@docusaurus/preset-classic": "3.2.1",
-        "@docusaurus/theme-mermaid": "^3.2.1",
+        "@docusaurus/theme-mermaid": "3.2.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",

--- a/docs/developer-docs/package.json
+++ b/docs/developer-docs/package.json
@@ -19,10 +19,10 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.2.1",
-    "@docusaurus/plugin-google-gtag": "^3.2.1",
-    "@docusaurus/plugin-google-tag-manager": "^3.2.1",
+    "@docusaurus/plugin-google-gtag": "3.2.1",
+    "@docusaurus/plugin-google-tag-manager": "3.2.1",
     "@docusaurus/preset-classic": "3.2.1",
-    "@docusaurus/theme-mermaid": "^3.2.1",
+    "@docusaurus/theme-mermaid": "3.2.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",

--- a/docs/developer-docs/src/components/PersistentPeers/index.tsx
+++ b/docs/developer-docs/src/components/PersistentPeers/index.tsx
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import Admonition from '@theme/Admonition';
+
+export default function PersistentPeers({ code, chainInfoUrl }: { code: string, chainInfoUrl: string }) {
+    const [peers, setPeers] = useState<string[]>(["loading..."]);
+    const [error, setError] = useState<Error | undefined>(undefined);
+
+    useEffect(() => {
+        const fetchPeers = async () => {
+            try {
+                const response = await fetch(chainInfoUrl);
+                if (!response.ok) {
+                    setError(new Error(`Failed to fetch peers from ${chainInfoUrl}`));
+                    return;
+                }
+
+                const data = await response.json();
+                const peers = data.peers.persistent_peers.map((p) => `${p.id}@${p.address}`);
+                setPeers(peers);
+            } catch (e) {
+                setError(e);
+            }
+        };
+        fetchPeers();
+    }, []);
+
+    if (error) {
+        return (
+            <Admonition type="error" title="Error" icon="🚨">
+                <div>Error: {error.message}</div>
+            </Admonition>
+        );
+    }
+
+    const txt = code.replace(/{{persistent_peers}}/g, peers.join(','));
+    return (
+        <div>
+            <CodeBlock language="bash">
+                {txt}
+            </CodeBlock>
+        </div>
+    );
+}
+


### PR DESCRIPTION
I made a little react component for our docs website that fetches the list of persistent peers dynamically (= client-side) from our github repo, instead of manually having to update it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `PersistentPeers` component for displaying persistent peer information in the documentation.
  - Updated the documentation to include new configuration steps with the `PersistentPeers` component.

- **Documentation**
  - Updated the network joining guide for the Buenavista network to reflect new persistent peer configuration using the `PersistentPeers` component.

- **Dependencies**
  - Updated versions of `@docusaurus/plugin-google-gtag`, `@docusaurus/plugin-google-tag-manager`, and `@docusaurus/theme-mermaid` for enhanced compatibility and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->