### PR TITLE
feat: add slinky setup to localnet

### DIFF
--- a/cmd/wardend/cmd/commands.go
+++ b/cmd/wardend/cmd/commands.go
@@ -57,6 +57,7 @@ func initRootCmd(
 			basicManager,
 			AddGenesisSpaceCmd(app.DefaultNodeHome),
 			AddGenesisKeychainCmd(app.DefaultNodeHome),
+			AddGenesisSlinkyMarketsCmd(app.DefaultNodeHome),
 		),
 		queryCommand(),
 		txCommand(),

--- a/cmd/wardend/cmd/gen-slinky-markets.go
+++ b/cmd/wardend/cmd/gen-slinky-markets.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+
+	"github.com/skip-mev/slinky/cmd/constants"
+	marketmaptypes "github.com/skip-mev/slinky/x/marketmap/types"
+	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
+)
+
+func AddGenesisSlinkyMarketsCmd(defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-genesis-slinky-markets",
+		Short: "Add Slinky core markets to the genesis file",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cdc, genesisFileURL := setupGenCommand(cmd)
+
+			return updateGenesisState(
+				genesisFileURL,
+				func(appState map[string]json.RawMessage) error {
+					coreMarkets := constants.CoreMarketMap
+
+					// update marketmap genesis state
+					var marketmapGenState marketmaptypes.GenesisState
+					if appState[marketmaptypes.ModuleName] != nil {
+						cdc.MustUnmarshalJSON(appState[marketmaptypes.ModuleName], &marketmapGenState)
+					}
+
+					marketmapGenState.MarketMap = coreMarkets
+
+					marketmapGenStateBz, err := cdc.MarshalJSON(&marketmapGenState)
+					if err != nil {
+						return fmt.Errorf("marshalling warden genesis state: %w", err)
+					}
+					appState[marketmaptypes.ModuleName] = marketmapGenStateBz
+
+					// update oracle genesis state
+					oracleGenState := oracletypes.GetGenesisStateFromAppState(cdc, appState)
+
+					id := uint64(1)
+					for _, market := range coreMarkets.Markets {
+						cp := oracletypes.CurrencyPairGenesis{
+							Id:                id,
+							Nonce:             0,
+							CurrencyPairPrice: nil,
+							CurrencyPair:      market.Ticker.CurrencyPair,
+						}
+						id++
+						oracleGenState.CurrencyPairGenesis = append(oracleGenState.CurrencyPairGenesis, cp)
+					}
+					oracleGenState.NextId = id
+
+					oracleGenStateBz, err := cdc.MarshalJSON(&oracleGenState)
+					if err != nil {
+						return fmt.Errorf("marshalling warden genesis state: %w", err)
+					}
+					appState[oracletypes.ModuleName] = oracleGenStateBz
+
+					return nil
+				},
+			)
+		},
+	}
+
+	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/justfile
+++ b/justfile
@@ -76,6 +76,9 @@ localnet bin="wardend":
     {{bin}} genesis add-genesis-keychain {{shulgin}} "WardenKMS"
     {{bin}} genesis gentx val 1000000000uward
     {{bin}} genesis collect-gentxs
+    {{bin}} genesis add-genesis-slinky-markets
+    GENESIS="$HOME/.warden/config/genesis.json"
+    jq '.consensus["params"]["abci"]["vote_extensions_enable_height"] = "2"' "$GENESIS" > "$GENESIS".tmp && mv "$GENESIS".tmp "$GENESIS"
 
     post_start () {
       sleep 3
@@ -102,3 +105,6 @@ deploy-contract contract from="shulgin" label="":
     CODE_ID=$(wardend tx wasm store {{contract}} --from {{from}} -y --gas auto --gas-adjustment 1.3 | wardend q wait-tx -o json | jq '.events[] | select(.type == "store_code") | .attributes[] | select(.key == "code_id") | .value | tonumber')
     ADDR=$(wardend tx wasm instantiate $CODE_ID '{}' --from {{from}} --label "{{if label == "" { "default" } else { label } }}" --no-admin -y | wardend q wait-tx -o json | jq '.events[] | select(.type == "instantiate") | .attributes[] | select(.key == "_contract_address") | .value')
     echo {{contract}} deployed at $ADDR
+
+slinky:
+    go run github.com/skip-mev/slinky/cmd/slinky


### PR DESCRIPTION
changes:
- `just localnet` sets the marketmap with the list of currencies to be tracked by slinky
- `just slinky` runs the slinky sidecar (give it a few seconds to update and you'll be able to run commands such as `wardend q oracle prices BTC USD`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a command to add genesis configurations for Slinky markets, enhancing blockchain setup.
	- Added a new `slinky` target in the justfile to integrate the Slinky application into existing workflows.

- **Bug Fixes**
	- Updated the `vote_extensions_enable_height` parameter in the genesis configuration to optimize the voting mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->