### PR TITLE
Docs slinky fix

### DIFF
--- a/docs/developer-docs/docs/build-an-oapp/introduction.md
+++ b/docs/developer-docs/docs/build-an-oapp/introduction.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 **Omnichain Applications** (**OApps**) are a powerful evolution of traditional smart contracts. They allow signing transactions at any chain, while traditional smart contract applications only target users of a single chain.
 
-An example of an OApp is [SpaceWard](https://help.wardenprotocol.org) – our application functioning as the front-end interface for Warden. For a full list of available OApps, see [Examples of OApps](#examples-of-oapps).
+An example of an OApp is [SpaceWard](https://help.wardenprotocol.org) – our application functioning as the front-end interface for Warden. For a full list of available OApps, see [Examples of OApps](examples-of-oapps).
 
 This section explains how to build the backend and frontend of an OApp. Here you'll also find guides for running a [node](/learn/glossary#warden-protocol-node) and a [Keychain](/learn/glossary#keychain) in the test mode.
 

--- a/docs/developer-docs/docs/learn/glossary.md
+++ b/docs/developer-docs/docs/learn/glossary.md
@@ -209,7 +209,7 @@ While most interoperability providers focus on particular ecosystems, Warden's g
 
 ## Oracle service
 
-An oracle is a third-party service that enables smart contracts access real-life data feeds: prices, stock marked data, weather conditions, etc. Warden is integrated with [Connect](https://docs.skip.build/connect/introduction) – an oracle service provided by Skip Protocol and offering mostly price data. Connect's data is [validated](#validator) by Warden's network and written on-chain.
+An oracle is a third-party service that enables smart contracts access real-life data feeds: prices, stock marked data, weather conditions, etc. Warden is integrated with [Skip:Connect](https://docs.skip.build/connect/introduction) – an oracle service provided by Skip Protocol and offering mostly price data. Connect's data is [validated](#validator) by Warden's network and written on-chain.
 
 Learn more: [Oracle services](oracle-services)
 

--- a/docs/developer-docs/docs/learn/oracle-services.md
+++ b/docs/developer-docs/docs/learn/oracle-services.md
@@ -15,9 +15,11 @@ Access to oracle data feeds significantly enhances the capabilities of Warden's 
 :::
 
 
-## Connect
+## Skip\:Connect
 
-Warden integrates with [x/oracle](/learn/warden-protocol-modules/external-modules#xoracle) – an external module by **Skip Protocol**. This module provides access to [Connect](https://docs.skip.build/connect/introduction) – an oracle service offering mostly price data (formerly known as Slinky).
+Warden integrates with [x/oracle](/learn/warden-protocol-modules/external-modules#xoracle) – an external module by **Skip Protocol**. This module provides access to **Skip:Connect** – an oracle service offering mostly price data, formerly known as Slinky.
+
+See also: [Connect documentation](https://docs.skip.build/connect/introduction)
 
 Key features of Warden's integration with Connect include the following:
 
@@ -33,4 +35,4 @@ The data provided by Connect is [validated](/learn/glossary#validator) by Warden
 
 ## Available data feeds
 
-Slinky can support over 2,000 currencies – see the available [data feeds on GitHub](https://github.com/skip-mev/slinky/blob/30bf58f5ad6dcf417a3747b7cfffdc637ae3c70f/cmd/constants/markets.go#L1615). Please note that this list may change over the course of time.
+**Skip:Connect** can support over 2,000 currencies – see the available [data feeds on GitHub](https://github.com/skip-mev/slinky/blob/30bf58f5ad6dcf417a3747b7cfffdc637ae3c70f/cmd/constants/markets.go#L1615). Please note that this list may change over the course of time.

--- a/docs/developer-docs/docs/learn/warden-protocol-modules/external-modules.md
+++ b/docs/developer-docs/docs/learn/warden-protocol-modules/external-modules.md
@@ -24,7 +24,7 @@ We should add more details here since there are things that are unique for our c
 
 ## x/oracle
 
-The `x/oracle` module is a Cosmos SDK module by **Skip Protocol** that enables storing prices on-chain in **Connect** (an oracle service).
+The `x/oracle` module is a Cosmos SDK module by **Skip Protocol** that enables storing prices on-chain in **Skip:Connect** (an oracle service).
 
 To learn more, see the following:
 

--- a/docs/developer-docs/docs/operate-a-node/operate-connect.md
+++ b/docs/developer-docs/docs/operate-a-node/operate-connect.md
@@ -2,11 +2,11 @@
 sidebar_position: 4
 ---
 
-# Operate Connect
+# Operate Skip:Connect
 
 ## Overview
 
-Warden integrates with **Connect** (formerly known as **Slinky**) – an [oracle service](/learn/oracle-services) from **Skip Protocol**. The data provided by Connect is validated by Warden's network and written on-chain.
+Warden integrates with **Skip:Connect** (formerly known as Slinky) – an [oracle service](/learn/oracle-services) from **Skip Protocol**. The data provided by Connect is validated by Warden's network and written on-chain.
 
 This article is a guide for validators explaining how to run Connect.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation Updates**
	- Clarified the branding of the Oracle service from "Connect" to "Skip:Connect" across multiple documents to improve specificity and consistency.
	- Enhanced navigation within the documentation by updating hyperlink references to examples of omnichain applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->