### PR TITLE
#241 Expose `x/warden` messages to CosmWasm

### DIFF
--- a/warden/app/wasm-interop/custom_msg.go
+++ b/warden/app/wasm-interop/custom_msg.go
@@ -3,7 +3,6 @@ package wasm_interop
 import (
 	"encoding/json"
 	"fmt"
-
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -16,7 +15,8 @@ type WardenProtocolMsg struct {
 }
 
 type WardenMsg struct {
-	NewKeyRequest *NewKeyRequest `json:"new_key_request,omitempty"`
+	NewKeyRequest  *NewKeyRequest  `json:"new_key_request,omitempty"`
+	NewSignRequest *NewSignRequest `json:"new_sign_request,omitempty"`
 }
 
 type NewKeyRequest struct {
@@ -27,6 +27,14 @@ type NewKeyRequest struct {
 	TimeoutHeight uint64        `json:"timeout_height"`
 }
 
+type NewSignRequest struct {
+	KeyId         uint64   `json:"key_id"`
+	Input         []byte   `json:"input"`
+	Analyzers     []string `json:"analyzers"`
+	EncryptionKey []byte   `json:"encryption_key"`
+	TimeoutHeight uint64   `json:"timeout_height"`
+}
+
 func EncodeCustomMsg(sender sdk.AccAddress, rawMsg json.RawMessage) ([]sdk.Msg, error) {
 	var msg WardenProtocolMsg
 	err := json.Unmarshal(rawMsg, &msg)
@@ -35,27 +43,56 @@ func EncodeCustomMsg(sender sdk.AccAddress, rawMsg json.RawMessage) ([]sdk.Msg, 
 	}
 	switch {
 	case msg.Warden.NewKeyRequest != nil:
-		actAuthority := authtypes.NewModuleAddress(acttypes.ModuleName)
-		newKeyRequest := msg.Warden.NewKeyRequest
-		newKeyMsg := &types.MsgNewKeyRequest{
-			Authority:  actAuthority.String(),
-			SpaceId:    newKeyRequest.SpaceID,
-			KeychainId: newKeyRequest.KeychainID,
-			KeyType:    newKeyRequest.KeyType,
-			RuleId:     newKeyRequest.RuleId,
-		}
-		msgAny, err := codectypes.NewAnyWithValue(newKeyMsg)
-		if err != nil {
-			return nil, err
-		}
-
-		newActionMsg := &acttypes.MsgNewAction{
-			Creator:             sender.String(),
-			Message:             msgAny,
-			ActionTimeoutHeight: newKeyRequest.TimeoutHeight,
-		}
-		return []sdk.Msg{newActionMsg}, nil
+		return handleNewKeyRequest(sender, msg)
+	case msg.Warden.NewSignRequest != nil:
+		return handleNewSignRequest(sender, msg)
 	default:
 		return nil, fmt.Errorf("unknown variant of WardenProtocolMsg")
 	}
+}
+
+func handleNewKeyRequest(sender sdk.AccAddress, msg WardenProtocolMsg) ([]sdk.Msg, error) {
+	actAuthority := authtypes.NewModuleAddress(acttypes.ModuleName)
+	newKeyRequest := msg.Warden.NewKeyRequest
+	newKeyMsg := &types.MsgNewKeyRequest{
+		Authority:  actAuthority.String(),
+		SpaceId:    newKeyRequest.SpaceID,
+		KeychainId: newKeyRequest.KeychainID,
+		KeyType:    newKeyRequest.KeyType,
+		RuleId:     newKeyRequest.RuleId,
+	}
+	msgAny, err := codectypes.NewAnyWithValue(newKeyMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	newActionMsg := &acttypes.MsgNewAction{
+		Creator:             sender.String(),
+		Message:             msgAny,
+		ActionTimeoutHeight: newKeyRequest.TimeoutHeight,
+	}
+	return []sdk.Msg{newActionMsg}, nil
+}
+
+func handleNewSignRequest(sender sdk.AccAddress, msg WardenProtocolMsg) ([]sdk.Msg, error) {
+	actAuthority := authtypes.NewModuleAddress(acttypes.ModuleName)
+	newSignRequest := msg.Warden.NewSignRequest
+	newKeyMsg := &types.MsgNewSignRequest{
+		Authority:     actAuthority.String(),
+		KeyId:         newSignRequest.KeyId,
+		Input:         newSignRequest.Input,
+		Analyzers:     newSignRequest.Analyzers,
+		EncryptionKey: newSignRequest.EncryptionKey,
+	}
+	msgAny, err := codectypes.NewAnyWithValue(newKeyMsg)
+	if err != nil {
+		return nil, err
+	}
+
+	newActionMsg := &acttypes.MsgNewAction{
+		Creator:             sender.String(),
+		Message:             msgAny,
+		ActionTimeoutHeight: newSignRequest.TimeoutHeight,
+	}
+	return []sdk.Msg{newActionMsg}, nil
 }

--- a/warden/app/wasm-interop/custom_query.go
+++ b/warden/app/wasm-interop/custom_query.go
@@ -13,7 +13,11 @@ type WardenProtocolQuery struct {
 }
 
 type WardenQuery struct {
-	AllKeys *types.QueryAllKeysRequest `json:"all_keys,omitempty"`
+	AllKeys         *types.QueryAllKeysRequest         `json:"all_keys,omitempty"`
+	KeysBySpaceId   *types.QueryKeysBySpaceIdRequest   `json:"keys_by_space_id,omitempty"`
+	KeyById         *types.QueryKeyByIdRequest         `json:"key_by_id,omitempty"`
+	SignRequests    *types.QuerySignRequestsRequest    `json:"sign_requests,omitempty"`
+	SignRequestById *types.QuerySignRequestByIdRequest `json:"sign_request_by_id,omitempty"`
 }
 
 func CustomQuerier(wardenKeeper wardenkeeper.Keeper) func(ctx sdk.Context, rawRequest json.RawMessage) ([]byte, error) {
@@ -26,6 +30,30 @@ func CustomQuerier(wardenKeeper wardenkeeper.Keeper) func(ctx sdk.Context, rawRe
 		switch {
 		case query.Warden.AllKeys != nil:
 			response, err := wardenKeeper.AllKeys(ctx, query.Warden.AllKeys)
+			if err != nil {
+				return nil, err
+			}
+			return json.Marshal(response)
+		case query.Warden.KeysBySpaceId != nil:
+			response, err := wardenKeeper.KeysBySpaceId(ctx, query.Warden.KeysBySpaceId)
+			if err != nil {
+				return nil, err
+			}
+			return json.Marshal(response)
+		case query.Warden.KeyById != nil:
+			response, err := wardenKeeper.KeyById(ctx, query.Warden.KeyById)
+			if err != nil {
+				return nil, err
+			}
+			return json.Marshal(response)
+		case query.Warden.SignRequests != nil:
+			response, err := wardenKeeper.SignRequests(ctx, query.Warden.SignRequests)
+			if err != nil {
+				return nil, err
+			}
+			return json.Marshal(response)
+		case query.Warden.SignRequestById != nil:
+			response, err := wardenKeeper.SignRequestById(ctx, query.Warden.SignRequestById)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
For messages:
`MsgNewSignatureRequest`
`KeysBySpaceId`
`KeyById`
`SignRequests`
`SignRequestById`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for signing operations with new `NewSignRequest` functionality in the messaging system.
  - Expanded query capabilities to include new fields for querying keys and signing requests, enhancing data retrieval options.
  
- **Improvements**
  - Enhanced message handling logic for more efficient processing of different request types.
  - Improved granularity in data queries through additional parameters in the query structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->