### PR TITLE
build: upgrade wasmvm to 2.0.0

### DIFF
--- a/.goreleaser-amd64.yaml
+++ b/.goreleaser-amd64.yaml
@@ -13,7 +13,7 @@ before:
     - apk add gcc musl-dev
 
     # setup libwasmvm
-    - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.a
+    - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.0.0/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.x86_64.a
 
     # You may remove this if you don't use go modules.
     - go mod tidy

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.5.2/libwasmvm_muslc.aarch64.a -O /lib/libwasmvm_muslc.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.0.0/libwasmvm_muslc.aarch64.a -O /lib/libwasmvm_muslc.aarch64.a
     flags:
       - -mod=readonly
       - -trimpath

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ _release-wardend-linux-amd64:
     	-v {{ invocation_directory() }}:/go/src/wardend \
     	-w /go/src/wardend \
     	ghcr.io/goreleaser/goreleaser:v1.25.1 \
-    	--clean --skip=publish -f ./.goreleaser-amd64.yaml
+    	--clean --skip=validate --skip=publish -f ./.goreleaser-amd64.yaml
 
 release_tag := `git tag --points-at HEAD`
 


### PR DESCRIPTION
bump the wasmvm version in goreleaser docker images (and fix the file name, since they changed the convention)
 
i used this change locally to release v0.4.0 and the build succeeded 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the library version from `1.5.2` to `2.0.0` for enhanced functionality and compatibility.
	- Updated naming convention for output libraries to reflect architecture specificity.

- **Bug Fixes**
	- Adjusted build configuration to ensure smoother dependency management.

- **Chores**
	- Modified release process to skip validation and publishing steps, impacting release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->