### PR TITLE
fix(docs): wrong warden block height on the upgrade documentation

### DIFF
--- a/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.0.md
+++ b/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.0.md
@@ -30,7 +30,7 @@ The method for taking a snapshot depends on your infrastructure, but generally, 
 After stopping the `wardend` process, it's critically important to back up the `.wardend/data/priv_validator_state.json` file.
 :::
 
-**Note**: The **priv_validator_state.json**  file is updated every block as your validator participates in consensus rounds. In case the upgrade fails, and you have to restart the previous chain, you'll need this file to avoid double signing. See [Handling node restarts](#handling-node-restarts).
+**Note**: The **priv_validator_state.json** file is updated every block as your validator participates in consensus rounds. In case the upgrade fails, and you have to restart the previous chain, you'll need this file to avoid double signing. See [Handling node restarts](#handling-node-restarts).
 
 ## 2. Run Connect sidecar
 
@@ -45,21 +45,21 @@ Follow this guide: [Operate Connect](/operate-a-node/operate-connect).
 To upgrade using [Cosmovisor](https://pkg.go.dev/cosmossdk.io/tools/cosmovisor), take these steps:
 
 1. Download the `wardend` v0.4.0 binary and put it to `$WARDEN_HOME/cosmovisor/upgrades/v0.4.0/bin`:
-    
-    ```bash
-    mkdir -p  $WARDEN_HOME/cosmovisor/upgrades/v0.4.0/bin
-    cp $(which wardend) $WARDEN_HOME/cosmovisor/upgrades/v0.4.0/bin
-    ```
 
-    **Note**: Alternatively, enable auto-download in Cosmovisor, and it'll automatically download the binary.
+   ```shell
+   mkdir -p  $WARDEN_HOME/cosmovisor/upgrades/v0.4.0/bin
+   cp $(which wardend) $WARDEN_HOME/cosmovisor/upgrades/v0.4.0/bin
+   ```
+
+   **Note**: Alternatively, enable auto-download in Cosmovisor, and it'll automatically download the binary.
 
 2. Start the node:
 
-    ```bash
-    cosmovisor run start --x-crisis-skip-assert-invariants --home $DAEMON_HOME
-    ```
-    
-    **Note**: We recommend skipping the invariant checks to reduce the upgrade time. Future releases of the Cosmos SDK will include additional improvements to the crisis module.
+   ```shell
+   cosmovisor run start --x-crisis-skip-assert-invariants --home $DAEMON_HOME
+   ```
+
+   **Note**: We recommend skipping the invariant checks to reduce the upgrade time. Future releases of the Cosmos SDK will include additional improvements to the crisis module.
 
 3. After reaching the upgrade block height, Warden will panic and stop.
 
@@ -71,14 +71,15 @@ To upgrade using [Cosmovisor](https://pkg.go.dev/cosmossdk.io/tools/cosmovisor),
 
 2. Run Warden v0.3.0 until the upgrade height. The node will panic:
 
-    ```bash
-    ERR UPGRADE "v0.4.0" NEEDED at height: 1520000: upgrade to v0.4.0 and applying upgrade "v0.4.0" at height: 1520000
-    ```
-3. Stop the node and switch the binary to **Warden v0.4.0**. Restart the node:  
+   ```shell
+   ERR UPGRADE "v0.4.0" NEEDED at height: 1534500: upgrade to v0.4.0 and applying upgrade "v0.4.0" at height: 1534500
+   ```
 
-    ```bash
-    wardend start
-    ```
+3. Stop the node and switch the binary to **Warden v0.4.0**. Restart the node:
+
+   ```shell
+   wardend start
+   ```
 
 4. The chain will continue producing blocks when validators with a total sum voting power > 2/3 complete their node upgrades and come back online.
 
@@ -96,10 +97,10 @@ If you discover you've made a mistake, it's not safe to repeat the upgrade proce
 
 Your node may restart during the upgrade due to OOM being killed, hardware issues, and other reasons. In this case, it's not safe to proceed with the upgrade. Instead, follow these steps:
 
-1. Recover your node from a [backup](#1-verify--back-up).  
+1. Recover your node from a [backup](#1-verify--back-up).
 
-    When applying a snapshot from the backup, keep your `./data/priv_validator_state.json` file. This will help you avoid being slashed due to double signing.
+   When applying a snapshot from the backup, keep your `./data/priv_validator_state.json` file. This will help you avoid being slashed due to double signing.
 
-3. Restart the upgrade process.
+2. Restart the upgrade process.
 
 **Note**: If you proceed with the upgrade without recovering your node, the upgrade will likely complete successfully, but you'll get the `AppHash error` once the network is up.


### PR DESCRIPTION
This fixes the block heigh to a correct one for the upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Improved readability and clarity of the upgrade guide for the Buenavista Testnet.
	- Enhanced formatting with consistent indentation for code blocks and notes.
	- Refined instructions on handling the `priv_validator_state.json` file and the upgrade process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->