### PR TITLE
Fix running local chain

### DIFF
--- a/docs/developer-docs/docs/build-an-oapp/test/run-a-local-chain.md
+++ b/docs/developer-docs/docs/build-an-oapp/test/run-a-local-chain.md
@@ -8,7 +8,7 @@ Goal: run a local chain for development and testing purposes.
 
 ## Prerequisites
 
-- [Go](https://golang.org/dl/) 1.22 or later
+- [Go](https://golang.org/dl/) 1.22.5 or later
 - [just](https://just.systems/man/en/chapter_4.html)
 
 ## 1. Clone the Warden Protocol repo
@@ -21,26 +21,92 @@ cd wardenprotocol
 ## 2. Build the chain
 
 ```sh
-cd wardenprotocol
 just install
 ```
 
-This will build the chain binary called `wardend` and install it in your `$GOPATH`.
+This will build the chain binary called `wardend` and install it in your `$GOPATH`. Please check if your `wardend` binary has been properly installed by running the command `wardend version`.
+
+You will see output as:
+
+```sh
+wardend version  
+v0.4.0.0
+```
 
 
 ## 3. Run the chain
 
-### Option 1. Use `ignite`
+### Option 1. Run locally
 
 This option is recommended for development purposes.
 
+1. Initialize the Node
+
 ```sh
-ignite chain serve -p warden --home ~/.warden -v
+wardend init my-local-node --chain-id local-testnet
 ```
+
+This will initialize a new node which you can find in the `$HOME/.warden/config` folder.
+
+2. Create a Key Pair
+
+```sh
+wardend keys add my-validator
+```
+
+Tip: Note down the generated address and the mnemonic. This will be used to recover your account if needed.
+
+3. Add Genesis Account
+
+```sh
+wardend genesis add-genesis-account my-validator 100000000000stake
+```
+
+Add the validator's address to the genesis file with sufficient tokens
+
+4. Generate Genesis Transaction (gentx)
+
+```sh
+wardend genesis gentx my-validator 1000000000stake --chain-id local-testnet
+```
+
+Create a genesis transaction for your validator
+
+5. Collect Genesis Transactions
+
+```sh
+wardend genesis collect-gentxs
+```
+
+Add the gentx to the genesis file
+
+6. Validate the Genesis File
+
+```sh
+wardend genesis validate-genesis
+```
+
+Ensure the genesis file is valid
+
+7. Configure app.toml
+
+Navigate to $HOME/.warden/config/app.toml and edit the gas value as needed.
+
+```toml
+minimum-gas-prices = "0.025stake"
+```
+
+8. Start the Node
+
+```sh
+wardend start
+```
+
+This will start the chain and you will see blocks produced and height incrementing.
 
 ### Option 2. Use the devnet snapshot
 
-This option is recommended for testing purposes and doesn't require installing other tools such as `ignite`.
+This option is recommended for testing purposes.
 
 Download the devnet snapshot and extract it to `~/.warden`:
 

--- a/docs/developer-docs/docs/build-an-oapp/test/run-a-local-chain.md
+++ b/docs/developer-docs/docs/build-an-oapp/test/run-a-local-chain.md
@@ -20,6 +20,14 @@ cd wardenprotocol
 
 ## 2. Build the chain
 
+Check if `just` is installed. If not, you can install it via brew:
+
+```sh
+brew install just
+```
+
+Then, you can proceed to install the `wardend` binary.
+
 ```sh
 just install
 ```
@@ -33,12 +41,20 @@ wardend version
 v0.4.0.0
 ```
 
-
 ## 3. Run the chain
 
-### Option 1. Run locally
+### Option 1. Run the chain using `just`
 
-This option is recommended for development purposes.
+Once `just` and `wardend` are correctly installed, you can start a new chain.
+
+```sh
+just localnet
+```
+This will start the chain and you will see blocks produced and height incrementing.
+
+### Option 2. Run locally
+
+This option is recommended for development purposes, when you want to manually configure the chain.
 
 1. Initialize the Node
 
@@ -104,7 +120,7 @@ wardend start
 
 This will start the chain and you will see blocks produced and height incrementing.
 
-### Option 2. Use the devnet snapshot
+### Option 3. Use the devnet snapshot
 
 This option is recommended for testing purposes.
 


### PR DESCRIPTION
- Update go version
  - Lower versions of go run a toolchain error.
- Remove redundant information
- Remove reference to ignite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced clarity and detail in the instructions for running a local chain using the Warden Protocol.
  - Specified the required Go version as "1.22.5 or later" for compatibility.
  - Expanded the building chain section with verification steps and command execution details.
  - Reorganized instructions for running the chain, focusing on local execution with clear, detailed steps. 
  - Modified the devnet snapshot section to emphasize the absence of additional tool requirements for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->