### PR TITLE
fix(spaceward): fix issue #500 - max button sending funds

### DIFF
--- a/spaceward/src/features/modals/SendAssets.tsx
+++ b/spaceward/src/features/modals/SendAssets.tsx
@@ -300,8 +300,11 @@ export default function SendAssetsModal({
 								)}
 							</div>
 							<div
+								onClick={() => {
+									setAmount(maxAmount);
+								}}
 								className={clsx(
-									"text-xs",
+									"text-xs cursor-pointer",
 									amountWarning && "text-negative",
 									!amountWarning && "text-pixel-pink",
 								)}


### PR DESCRIPTION
https://github.com/warden-protocol/wardenprotocol/issues/500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a quick set feature in the Send Assets modal to automatically input the maximum amount.
- **Style**
	- Enhanced the user interface by indicating interactivity with a new cursor-pointer class on the maximum amount setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->