### PR TITLE
remove date for v0.4 upgrade

### DIFF
--- a/docs/developer-docs/docs/operate-a-node/buenavista-testnet/join-buenavista.md
+++ b/docs/developer-docs/docs/operate-a-node/buenavista-testnet/join-buenavista.md
@@ -12,14 +12,14 @@ This tutorial explains how to run the Warden binary, `wardend`, and join the **B
 
 - The chain ID in queries: `buenavista-1`
 - Endpoints: [networks repository > buenavista](https://github.com/warden-protocol/networks/tree/main/testnets/buenavista)
-- The current `wardend` version: **v0.3.0**
+- The current `wardend` version: **v0.3.1**
 
 ## Version history
 
 | Release | Upgrade block height | Upgrade date |
 | ------- | -------------------- | ------------ |
 | v0.3.0  | genesis              |              |
-| v0.4.0  | 1520000              | August 1, 2024 |
+| v0.4.0  | -                    | TBD          |
 
 ## Prerequisites
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Buenavista testnet documentation with the latest Warden binary version (now v0.3.1).
	- Changed the upgrade block height for version v0.4.0 to an unspecified value and updated the date to "TBD."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->