### PR TITLE
docs: upgrade node to v0.4.1

### DIFF
--- a/docs/developer-docs/docs/operate-a-node/buenavista-testnet/join-buenavista.md
+++ b/docs/developer-docs/docs/operate-a-node/buenavista-testnet/join-buenavista.md
@@ -19,7 +19,7 @@ This tutorial explains how to run the Warden binary, `wardend`, and join the **B
 | Release | Upgrade block height | Upgrade date |
 | ------- | -------------------- | ------------ |
 | v0.3.0  | genesis              |              |
-| v0.4.0  | -                    | TBD          |
+| v0.4.1  | 1675700              | Aug 13, 2024 |
 
 ## Prerequisites
 

--- a/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.0.md
+++ b/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.0.md
@@ -2,13 +2,13 @@
 sidebar_position: 1
 ---
 
-# v0.4.0
+# v0.4.1
 
 ## Overview
 
-This guide provides steps for upgrading to the [Warden v0.4.0](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.4.0) release, which integrates Warden with the [Skip: Connect](https://docs.skip.build/connect/introduction) oracle service.
+This guide provides steps for upgrading to the [Warden v0.4.1](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.4.1) release, which integrates Warden with the [Skip: Connect](https://docs.skip.build/connect/introduction) oracle service.
 
-The network upgrade will take place in **August 2024**. The Warden team is going to take the snapshot, export the state, and revert it back if needed.
+The network upgrade will take place on **August 13 2024**. The Warden team is going to take the snapshot, export the state, and revert it back if needed.
 
 If you have any outstanding questions, [join our Discord](https://discord.com/invite/warden).
 
@@ -48,10 +48,10 @@ Follow this guide: [Operate Connect](/operate-a-node/operate-connect).
 
 To upgrade using [Cosmovisor](https://pkg.go.dev/cosmossdk.io/tools/cosmovisor), take these steps:
 
-1. Download the `wardend` v0.4.0 binary and put it to `$WARDEN_HOME/cosmovisor/upgrades/v03-to-v04/bin`:
+1. Download the `wardend` v0.4.1 binary and put it to `$WARDEN_HOME/cosmovisor/upgrades/v03-to-v04/bin`:
 
    ```shell
-   mkdir -p  $WARDEN_HOME/cosmovisor/upgrades/v0.4.0/bin
+   mkdir -p  $WARDEN_HOME/cosmovisor/upgrades/v03-to-v04/bin
    cp $(which wardend) $WARDEN_HOME/cosmovisor/upgrades/v03-to-v04/bin
    ```
 
@@ -71,15 +71,15 @@ To upgrade using [Cosmovisor](https://pkg.go.dev/cosmossdk.io/tools/cosmovisor),
 
 ### Option 2: Upgrade manually
 
-1. Download the [v0.4.0 wardend binary](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.4.0) or build it from the source code. See the installation instructions in the [Join Buenavista guide](/operate-a-node/buenavista-testnet/join-buenavista#1-install).
+1. Download the [v0.4.1 wardend binary](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.4.1) or build it from the source code. See the installation instructions in the [Join Buenavista guide](/operate-a-node/buenavista-testnet/join-buenavista#1-install).
 
-2. Run Warden v0.3.0 until the upgrade height. The node will panic:
+2. Run Warden v0.3.2 until the upgrade height. The node will panic:
 
    ```shell
-   ERR UPGRADE "v0.4.0" NEEDED at height: 1534500: upgrade to v0.4.0 and applying upgrade "v0.4.0" at height: 1534500
+   ERR UPGRADE "v0.4.1" NEEDED at height: 1675700: upgrade to v0.4.1 and applying upgrade "v0.4.1" at height: 1675700 
    ```
 
-3. Stop the node and switch the binary to **Warden v0.4.0**. Restart the node:
+3. Stop the node and switch the binary to **Warden v0.4.1**. Restart the node:
 
    ```shell
    wardend start


### PR DESCRIPTION
Prepare to upgrade node to binary - v0.4.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated tutorial documentation to reflect the new version 0.4.1 for joining the Buenavista testnet, including modified upgrade details.
	- Revised instructions and content in the upgrade document for Warden version 0.4.1, ensuring accurate guidance for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->