### PR TITLE
fix(spaceward): whitelist keychains to hide test or non-functioning ones

### DIFF
--- a/spaceward/src/features/keychains/description.tsx
+++ b/spaceward/src/features/keychains/description.tsx
@@ -2,14 +2,6 @@ import { Fragment } from "react";
 
 const descriptions = [
 	{
-		key: "WardenKMS",
-		description: <Fragment>WardenKMS</Fragment>,
-		title: "WardenKMS",
-		verified: true,
-		disabled: false,
-		link: "#",
-	},
-	{
 		key: "OCP KMS",
 		description: (
 			<Fragment>
@@ -38,14 +30,6 @@ const descriptions = [
 		),
 		title: "Open Custody Protocol (Fordefi MPC)",
 		verified: true,
-		disabled: false,
-		link: "#",
-	},
-	{
-		key: "Bushinode Keychain",
-		description: <Fragment>Bushinode Keychain</Fragment>,
-		title: "Bushinode Keychain",
-		verified: false,
 		disabled: true,
 		link: "#",
 	},
@@ -61,6 +45,14 @@ const descriptions = [
 			</Fragment>
 		),
 		title: "Silence Laboratories",
+		verified: true,
+		disabled: false,
+		link: "#",
+	},
+	{
+		key: "WardenKMS",
+		description: <Fragment>WardenKMS</Fragment>,
+		title: "WardenKMS",
 		verified: true,
 		disabled: false,
 		link: "#",

--- a/spaceward/src/features/modals/CreateKey.tsx
+++ b/spaceward/src/features/modals/CreateKey.tsx
@@ -39,9 +39,9 @@ export default function CreateKeyModal({
 	const keychain = keychainsQuery.data?.keychains.find(
 		(kc) => kc.id === keychainId,
 	);
-	const [selected, setSelected] = useState(-1);
+	const [selected, setSelected] = useState(0);
 	const [isDetails, setIsDetails] = useState(false);
-	const [name, setName] = useState("Key #1");
+	const [name, setName] = useState("");
 	const [themeIndex, setThemeIndex] = useState(0);
 	const [themeOffset, setThemeOffset] = useState(0);
 
@@ -102,7 +102,7 @@ export default function CreateKeyModal({
 				Keychain details
 			</div>
 
-			<div className="bg-fill-quaternary rounded-xl	p-6">
+			<div className="bg-fill-quaternary rounded-xl p-6">
 				<div className="flex items-center gap-[6px] font-bold text-2xl mb-1">
 					{desc?.title ?? keychain?.description}
 
@@ -173,7 +173,7 @@ export default function CreateKeyModal({
 		<div className="max-w-[520px] w-[520px] text-center tracking-wide pb-5">
 			<div
 				className="font-bold text-5xl mb-6
-			 leading-[56px] tracking-[0.24px] font-display"
+			 leading-[56px] tracking-[0.24px]"
 			>
 				{!keychain ? "Select Keychain" : "Create Key"}
 			</div>
@@ -187,75 +187,78 @@ export default function CreateKeyModal({
 			{!keychain ? (
 				<div
 					className={clsx(
-						"mt-12 text-left flex flex-col gap-4 max-h-[400px]  relative",
-						(keychainsQuery.data?.keychains.length ?? 0) >= 3
-							? "before:content-[''] before:absolute no-scrollbar overflow-scroll before:left-0 before:bottom-0 before:w-full before:h-[90px] before:z-20 before:bg-gradient-to-b before:from-[transparent] before:to-[#222]							"
-							: "",
+						"mt-12 text-left flex flex-col gap-4 max-h-[400px] relative",
+						// (keychainsQuery.data?.keychains.length ?? 0) >= 3
+						// 	? "before:content-[''] before:absolute no-scrollbar overflow-scroll before:left-0 before:bottom-0 before:w-full before:h-[90px] before:z-20 before:bg-gradient-to-b before:from-[transparent] before:to-[#222]"
+						// 	: "",
 					)}
 				>
 					{keychainsQuery.data?.keychains.map((item, i) => {
 						const desc = DESCRIPTION_MAP[item.description];
 
-						return (
-							<div
-								className="rounded-xl p-6 flex flex-col bg-fill-quaternary w-full"
-								key={item.id.toString()}
-								onClick={setSelected.bind(null, i)}
-							>
-								<div className="flex items-center mb-1">
-									<div className="text-xl	font-bold flex items-center gap-[6px]">
-										{desc?.title ?? item.description}
-									</div>
+						if (desc && !desc.disabled) {
+							return (
+								<div
+									className="rounded-xl p-6 flex flex-col bg-fill-quaternary w-full"
+									key={item.id.toString()}
+									onClick={setSelected.bind(null, i)}
+								>
+									<div className="flex items-center mb-1">
+										<div className="text-xl	font-bold flex items-center gap-[6px]">
+											{desc?.title ?? item.description}
+										</div>
 
-									{selected === i ? (
-										<div className="ml-auto relative w-6 h-6">
+										{selected === i ? (
+											<div className="ml-auto relative w-6 h-6">
+												<Circle
+													stroke="#FFAEEE"
+													stroke-width="1"
+													cy={12}
+													cx={12}
+												/>
+												<Circle
+													className=" absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-4 h-4"
+													fill="#FFAEEE"
+													stroke="transparent"
+													stroke-width="0"
+												/>
+											</div>
+										) : (
 											<Circle
-												stroke="#FFAEEE"
+												className="ml-auto opacity-60"
+												stroke="#E5EEFF"
 												stroke-width="1"
 												cy={12}
 												cx={12}
 											/>
-											<Circle
-												className=" absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-4 h-4"
-												fill="#FFAEEE"
-												stroke="transparent"
-												stroke-width="0"
-											/>
-										</div>
-									) : (
-										<Circle
-											className="ml-auto opacity-60"
-											stroke="#E5EEFF"
-											stroke-width="1"
-											cy={12}
-											cx={12}
-										/>
-									)}
+										)}
+									</div>
+									{/* TODO get description from somewhere */}
+									<p className="m-0 text-muted-foreground">
+										{desc?.description ??
+											"Missing description"}
+									</p>
+									{/* <a
+										href="#"
+										onClick={(e) => {
+											e.preventDefault();
+											e.stopPropagation();
+											setSelected(i);
+											setIsDetails(true);
+										}}
+										className="mt-2 duration-300 transition-all hover:text-pixel-pink font-semibold"
+									>
+										Learn more
+									</a> */}
 								</div>
-								{/* TODO get description from somewhere */}
-								<p className="m-0 text-muted-foreground">
-									{desc?.description ?? "Missing description"}
-								</p>
-								<a
-									href="#"
-									onClick={(e) => {
-										e.preventDefault();
-										e.stopPropagation();
-										setSelected(i);
-										setIsDetails(true);
-									}}
-									className="mt-2 duration-300 transition-all hover:text-pixel-pink font-semibold"
-								>
-									Learn more
-								</a>
-							</div>
-						);
+							);
+						}
 					})}
 				</div>
 			) : (
 				<>
 					<div>
-						<div className="font-bold font-display tracking-[0.12px] text-2xl text-left mb-6">
+						<div className="font-bold tracking-[0.12px] text-2xl text-left mb-6">
 							Add a name
 						</div>
 
@@ -279,17 +282,16 @@ export default function CreateKeyModal({
 								/>
 							</div>
 							{!name ? (
-								<></>
-								// <button
-								// 	className="font-medium text-label-secondary px-2 hover:text-white transition-all duration-200"
-								// 	onClick={async (e) => {
-								// 		e.preventDefault();
-								// 		const text = await pasteFromClipboard();
-								// 		setName(text);
-								// 	}}
-								// >
-								// 	Paste
-								// </button>
+								<button
+									className="font-medium text-label-secondary px-2 hover:text-white transition-all duration-200"
+									onClick={async (e) => {
+										e.preventDefault();
+										const text = await pasteFromClipboard();
+										setName(text);
+									}}
+								>
+									Paste
+								</button>
 							) : (
 								<Icons.clearCircle
 									className="cursor-pointer"
@@ -300,7 +302,7 @@ export default function CreateKeyModal({
 					</div>
 
 					<div className="mt-8">
-						<div className="font-bold font-display tracking-[0.12px] text-2xl text-left mb-6">
+						<div className="font-bold tracking-[0.12px] text-2xl text-left mb-6">
 							Select a style
 						</div>
 
@@ -413,7 +415,7 @@ export default function CreateKeyModal({
 						onClick={create}
 						className="flex items-center rounded-lg justify-center gap-2 h-[56px] font-semibold w-full hover:bg-pixel-pink duration-200 hover:text-background"
 					>
-						Create Key
+						Create key
 					</Button>
 
 					<Button

--- a/spaceward/src/pages/Keychains.tsx
+++ b/spaceward/src/pages/Keychains.tsx
@@ -2,30 +2,6 @@ import DESCRIPTIONS from "@/features/keychains/description";
 import KeychainCard from "@/features/keychains/KeychainCard";
 import { useQueryHooks } from "@/hooks/useClient";
 
-const KEYCHAINS = [
-	{
-		name: "OCP KMS",
-		link: "#",
-		description:
-			"Open Custody Protocol (OCP), a modular custody primitive to expand the original vision from blah blah blah blah blah blah blah blah blah Open Custody Protocol (OCP), a modular custody primitive to expand the original",
-		lastSeen: "1",
-	},
-	{
-		name: "Open Custody Protocol (Fordefi MPC)",
-		link: "#",
-		description:
-			"Open Custody Protocol (OCP), a modular custody primitive to expand the original vision from Qredo by blah blah blah blah blah blah blah blah blah blah Open Custody Protocol (OCP), dy primitive to expand the original",
-		lastSeen: "3",
-	},
-	{
-		name: "OCP KMS",
-		link: "#",
-		description:
-			"Open Custody Protocol (OCP), a modular to expand the original vision from Qredo by blah blah blah blah blah blah blah blah blah blah Open Custody Protocol (OCP), a modular custody primitive to expand the original",
-		lastSeen: "2",
-	},
-];
-
 export function KeychainsPage() {
 	const { useKeychains } = useQueryHooks();
 	const q = useKeychains({});
@@ -55,20 +31,23 @@ export function KeychainsPage() {
 							({ key }) => key === item.description,
 						);
 
-						return (
-							<KeychainCard
-								id={item.id}
-								key={item.description}
-								name={desc?.title ?? item.description}
-								description={
-									desc?.description ?? "Description is empty"
-								}
-								link={desc?.link ?? "#"}
-								// fixme
-								lastSeen="never"
-								verified={desc?.verified}
-							/>
-						);
+						if (desc && !desc.disabled) {
+							return (
+								<KeychainCard
+									id={item.id}
+									key={item.description}
+									name={desc?.title ?? item.description}
+									description={
+										desc?.description ??
+										"Description is empty"
+									}
+									link={desc?.link ?? "#"}
+									// fixme
+									lastSeen="never"
+									verified={desc?.verified}
+								/>
+							);
+						}
 					})}
 				</div>
 			</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Reintroduced the "WardenKMS" keychain with its original properties.
	- Updated the "Bushinode Keychain" to be disabled, streamlining keychain selections.
	- Enhanced functionality in the Create Key modal, allowing users to paste names from the clipboard directly.

- **Improvements**
	- Improved conditional rendering for keychain details, ensuring cleaner user experiences.
	- Transitioned from static to dynamic data handling for the Keychains page, enhancing adaptability and responsiveness. 

- **Style**
	- Minor style adjustments and improvements for clarity and cleanliness in the Create Key modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->