### PR TITLE
fix(spaceward): show the correct space avatar for connected dapps

### DIFF
--- a/spaceward/src/features/modals/ConnectedModal.tsx
+++ b/spaceward/src/features/modals/ConnectedModal.tsx
@@ -71,14 +71,17 @@ export default function ConnectedModal(props: ModalParams<{}>) {
 
 									<IconsAssets.chevronRight className="ml-auto" />
 								</a>
-
 								{sessions.map((s) => (
 									<div
 										className="flex gap-3 items-center"
 										key={s.topic}
 									>
 										<AddressAvatar
-											seed={s.topic}
+											seed={
+												localStorage.getItem(
+													`WALLETCONNECT_SESSION_WS_${s.topic}`,
+												) || ""
+											}
 											disableTooltip
 											className="w-10 h-10 object-contain shrink-0"
 										/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `AddressAvatar` component in the `ConnectedModal` to dynamically retrieve its seed value from `localStorage`, improving the rendering based on user session data. 
- **Bug Fixes**
	- Corrected the seed value assignment logic to ensure it defaults properly when local storage data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->