### PR TITLE
Restrict `nil` KeychainFees

### DIFF
--- a/warden/x/warden/types/v1beta3/keychain.go
+++ b/warden/x/warden/types/v1beta3/keychain.go
@@ -76,6 +76,10 @@ func (k *Keychain) SetKeybaseId(keybaseId *KeybaseId) {
 }
 
 func (kf *KeychainFees) EnsureValid() error {
+	if kf == nil {
+		return fmt.Errorf("nil KeychainFees. Use zero-filled fees instead")
+	}
+
 	if err := kf.KeyReq.Validate(); err != nil {
 		return fmt.Errorf("key req is invalid: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation in the KeychainFees method to handle nil instances, preventing runtime errors and enhancing stability.
	- Added error messaging for nil KeychainFees instances, guiding users to use zero-filled fees instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->