### PR TITLE
fix(wardend): ICAHostKeeper initialization requires QueryRouter to be set

### DIFF
--- a/warden/app/legacy.go
+++ b/warden/app/legacy.go
@@ -187,6 +187,8 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 		app.MsgServiceRouter(),
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
+	app.ICAHostKeeper.WithQueryRouter(app.GRPCQueryRouter())
+
 	app.ICAControllerKeeper = icacontrollerkeeper.NewKeeper(
 		app.appCodec,
 		app.GetKey(icacontrollertypes.StoreKey),


### PR DESCRIPTION
Breaking change introduced in ibc-go v8.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced interchain account functionality by integrating the gRPC query routing mechanism, improving query handling within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->