### PR TITLE
fix(faucet): fix daily limit i64

### DIFF
--- a/cmd/faucet/pkg/config/config.go
+++ b/cmd/faucet/pkg/config/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	Fees           string        `env:"FEES" envDefault:"25uward" mapstructure:"FEES"`
 	KeyringBackend string        `env:"KEYRING" envDefault:"test" mapstructure:"KEYRING"`
 	BatchInterval  time.Duration `env:"BATCH_INTERVAL" envDefault:"5s" mapstructure:"BATCH_INTERVAL"`
-	DailyLimit     int           `env:"DAILY_LIMIT" envDefault:"100000000" mapstructure:"DAILY_LIMIT"`
+	DailyLimit     int64         `env:"DAILY_LIMIT" envDefault:"100000000" mapstructure:"DAILY_LIMIT"`
 	BatchLimit     int           `env:"BATCH_LIMIT" envDefault:"10" mapstructure:"BATCH_LIMIT"`
 	TXRetry        int           `env:"TX_RETRY" envDefault:"10" mapstructure:"TX_RETRY"`
 	Chain          string        `env:"CHAIN" envDefault:"Buenavista" mapstructure:"CHAIN"`


### PR DESCRIPTION
This fixes issue where user puts high uward amount to daily limit and go cannot parse it due to int restrictions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the capacity for daily limits by changing the data type to support larger values.
  
- **Bug Fixes**
	- Ensured that existing environment variable mappings continue to function as expected despite the data type change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->