### PR TITLE
Add chain upgrade instructions for v0.4.2

### DIFF
--- a/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.2.md
+++ b/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.2.md
@@ -34,8 +34,6 @@ The method for taking a snapshot depends on your infrastructure, but generally, 
 After stopping the `wardend` process, it's critically important to back up the `.wardend/data/priv_validator_state.json` file.
 :::
 
-**Note**: The **priv_validator_state.json** file is updated every block as your validator participates in consensus rounds. In case the upgrade fails, and you have to restart the previous chain, you'll need this file to avoid double signing. See [Handling node restarts](#handling-node-restarts).
-
 ## 2. Run Connect sidecar
 
 Prior to the update, you should also run the **Skip:Connect** binary on the same machine as `wardend`. Make sure you enable it from the [configuration](/operate-a-node/operate-connect#3-configure-wardend).

--- a/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.2.md
+++ b/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.2.md
@@ -58,7 +58,7 @@ To upgrade using [Cosmovisor](https://pkg.go.dev/cosmossdk.io/tools/cosmovisor),
 2. Start the node:
 
    ```shell
-   cosmovisor run start --x-crisis-skip-assert-invariants --home $DAEMON_HOME
+   cosmovisor run start --home $DAEMON_HOME
    ```
 
    **Note**: We recommend skipping the invariant checks to reduce the upgrade time. Future releases of the Cosmos SDK will include additional improvements to the crisis module.

--- a/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.2.md
+++ b/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.2.md
@@ -1,0 +1,110 @@
+﻿---
+sidebar_position: 2
+---
+
+# v0.4.2
+
+## Overview
+
+This guide provides steps for upgrading to the [Warden v0.4.2](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.4.2) release, which makes changes to `keychainFees` to be non nullable.
+
+The network upgrade will take place on **September 2 2024**. The Warden team is going to take the snapshot, export the state, and revert it back if needed.
+
+If you have any outstanding questions, [join our Discord](https://discord.com/invite/warden).
+
+:::tip
+Stay tuned for the precise upgrade date and additional details to be clarified.
+:::
+
+:::warning
+The upgrade procedure carries heightened risks of double-signing and being slashed. To handle these risks and securely address any issues that may arise during the upgrade, [back up](#1-verify--back-up) your data prior to the upgrade. During the upgrade, follow our tips listed in [Security and troubleshooting](#security--troubleshooting).
+:::
+
+## 1. Verify & back up
+
+Before starting your validator and signing, do the following:
+
+- Verify your software version and the genesis file hash.
+- Back up your **private node keys**.
+- Take a **full data snapshot**.
+
+The method for taking a snapshot depends on your infrastructure, but generally, you can achieve this by backing up the **wardend** directory. If you're [using Cosmovisor](#option-1-use-cosmovisor) to upgrade, it'll back up your data by default.
+
+:::warning
+After stopping the `wardend` process, it's critically important to back up the `.wardend/data/priv_validator_state.json` file.
+:::
+
+**Note**: The **priv_validator_state.json** file is updated every block as your validator participates in consensus rounds. In case the upgrade fails, and you have to restart the previous chain, you'll need this file to avoid double signing. See [Handling node restarts](#handling-node-restarts).
+
+## 2. Run Connect sidecar
+
+Prior to the update, you should also run the **Skip:Connect** binary on the same machine as `wardend`. Make sure you enable it from the [configuration](/operate-a-node/operate-connect#3-configure-wardend).
+
+Follow this guide: [Operate Connect](/operate-a-node/operate-connect).
+
+## 3. Upgrade
+
+### Option 1: Use Cosmovisor
+
+To upgrade using [Cosmovisor](https://pkg.go.dev/cosmossdk.io/tools/cosmovisor), take these steps:
+
+1. Download the `wardend` v0.4.2 binary and put it to `$WARDEN_HOME/cosmovisor/upgrades/v042/bin`:
+
+   ```shell
+   mkdir -p  $WARDEN_HOME/cosmovisor/upgrades/v042/bin
+   cp $(which wardend) $WARDEN_HOME/cosmovisor/upgrades/v042/bin
+   ```
+
+   **Note**: Alternatively, enable auto-download in Cosmovisor, and it'll automatically download the binary.
+
+2. Start the node:
+
+   ```shell
+   cosmovisor run start --x-crisis-skip-assert-invariants --home $DAEMON_HOME
+   ```
+
+   **Note**: We recommend skipping the invariant checks to reduce the upgrade time. Future releases of the Cosmos SDK will include additional improvements to the crisis module.
+
+3. After reaching the upgrade block height, Warden will panic and stop.
+
+4. The chain will continue producing blocks when validators with a total sum voting power > 2/3 complete their node upgrades and come back online.
+
+### Option 2: Upgrade manually
+
+1. Download the [v0.4.2 wardend binary](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.4.2) or build it from the source code. See the installation instructions in the [Join Buenavista guide](/operate-a-node/buenavista-testnet/join-buenavista#1-install).
+
+2. Run Warden v0.4.1 until the upgrade height. The node will panic:
+
+   ```shell
+   ERR UPGRADE "v0.4.2" NEEDED at height: 1965400 : upgrade to v0.4.2 and applying upgrade "v0.4.2" at height: 1965400
+   ```
+
+3. Stop the node and switch the binary to **Warden v0.4.2**. Restart the node:
+
+   ```shell
+   wardend start
+   ```
+
+4. The chain will continue producing blocks when validators with a total sum voting power > 2/3 complete their node upgrades and come back online.
+
+## Security & troubleshooting
+
+:::warning
+The upgrade procedure carries heightened risks of double-signing and being slashed. To mitigate these risks and securely address any issues that may arise during the upgrade, [back up](#1-verify--back-up) your data prior to the upgrade. During the upgrade, follow the rules listed below.
+:::
+
+### Handling mistakes
+
+If you discover you've made a mistake, it's not safe to repeat the upgrade procedure during the network startup. Instead, wait for the network to start and then correct the mistake.
+
+### Handling node restarts
+
+Your node may restart during the upgrade due to OOM being killed, hardware issues, and other reasons. In this case, it's not safe to proceed with the upgrade. Instead, follow these steps:
+
+1. Recover your node from a [backup](#1-verify--back-up).
+
+   When applying a snapshot from the backup, keep your `./data/priv_validator_state.json` file. This will help you avoid being slashed due to double signing.
+
+2. Restart the upgrade process.
+
+**Note**: If you proceed with the upgrade without recovering your node, the upgrade will likely complete successfully, but you'll get the `AppHash error` once the network is up.

--- a/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.2.md
+++ b/docs/developer-docs/docs/operate-a-node/buenavista-testnet/upgrade/v0.4.2.md
@@ -34,13 +34,7 @@ The method for taking a snapshot depends on your infrastructure, but generally, 
 After stopping the `wardend` process, it's critically important to back up the `.wardend/data/priv_validator_state.json` file.
 :::
 
-## 2. Run Connect sidecar
-
-Prior to the update, you should also run the **Skip:Connect** binary on the same machine as `wardend`. Make sure you enable it from the [configuration](/operate-a-node/operate-connect#3-configure-wardend).
-
-Follow this guide: [Operate Connect](/operate-a-node/operate-connect).
-
-## 3. Upgrade
+## 2. Upgrade
 
 ### Option 1: Use Cosmovisor
 
@@ -85,7 +79,7 @@ To upgrade using [Cosmovisor](https://pkg.go.dev/cosmossdk.io/tools/cosmovisor),
 
 4. The chain will continue producing blocks when validators with a total sum voting power > 2/3 complete their node upgrades and come back online.
 
-## Security & troubleshooting
+## 3. Security & troubleshooting
 
 :::warning
 The upgrade procedure carries heightened risks of double-signing and being slashed. To mitigate these risks and securely address any issues that may arise during the upgrade, [back up](#1-verify--back-up) your data prior to the upgrade. During the upgrade, follow the rules listed below.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Introduced an upgrade guide for the Warden protocol (version 0.4.2) to assist users with the transition process.
	- Provided detailed instructions for both automatic and manual upgrade options, including necessary precautions and recovery strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->