### PR TITLE
feat(spaceward): update to support Evmos

### DIFF
--- a/spaceward/src/components/ConnectWallet.tsx
+++ b/spaceward/src/components/ConnectWallet.tsx
@@ -30,8 +30,8 @@ export function ConnectWallet() {
 	const [showTooltip, setShowTooltip] = useState<Boolean>(false);
 	const [currentWallet, setCurrentWallet] = useState("");
 
-	const { balance } = useAsset("uward");
-	const ward = parseInt(balance?.amount || "0") / 10 ** 6;
+	const { balance } = useAsset("award");
+	const ward = parseInt(balance?.amount || "0") / 10 ** 18;
 
 	useEffect(() => {
 		typeof window !== undefined &&

--- a/spaceward/src/config/chains.ts
+++ b/spaceward/src/config/chains.ts
@@ -6,16 +6,16 @@ export const wardenprotocollocal: Chain = {
 	status: "live",
 	network_type: "testnet",
 	pretty_name: "Warden Protocol (local)",
-	chain_id: "warden",
+	chain_id: "warden_1337-1",
 	bech32_prefix: "warden",
 	daemon_name: "wardend",
 	node_home: "$HOME/.warden",
-	key_algos: ["secp256k1"],
-	slip44: 118,
+	key_algos: ["ethsecp256k1"],
+	slip44: 60,
 	fees: {
 		fee_tokens: [
 			{
-				denom: "uward",
+				denom: "award",
 				fixed_min_gas_price: 0.005,
 				low_gas_price: 0.01,
 				average_gas_price: 0.025,
@@ -26,7 +26,7 @@ export const wardenprotocollocal: Chain = {
 	staking: {
 		staking_tokens: [
 			{
-				denom: "uward",
+				denom: "award",
 			},
 		],
 	},
@@ -91,15 +91,15 @@ export const wardenprotocollocalAssets: AssetList = {
 			description: "The native token of Warden Protocol Testnet",
 			denom_units: [
 				{
-					denom: "uward",
+					denom: "award",
 					exponent: 0,
 				},
 				{
 					denom: "ward",
-					exponent: 6,
+					exponent: 18,
 				},
 			],
-			base: "uward",
+			base: "award",
 			name: "Ward",
 			display: "ward",
 			symbol: "WARD",
@@ -126,12 +126,12 @@ export const wardenprotocoldevnet: Chain = {
 	bech32_prefix: "warden",
 	daemon_name: "wardend",
 	node_home: "$HOME/.warden",
-	key_algos: ["secp256k1"],
-	slip44: 118,
+	key_algos: ["secp256k1", "ethsecp256k1"],
+	slip44: 60,
 	fees: {
 		fee_tokens: [
 			{
-				denom: "uward",
+				denom: "award",
 				fixed_min_gas_price: 0.005,
 				low_gas_price: 0.01,
 				average_gas_price: 0.025,
@@ -142,7 +142,7 @@ export const wardenprotocoldevnet: Chain = {
 	staking: {
 		staking_tokens: [
 			{
-				denom: "uward",
+				denom: "award",
 			},
 		],
 	},
@@ -207,15 +207,15 @@ export const wardenprotocoldevnetAssets: AssetList = {
 			description: "The native token of Warden Protocol Testnet",
 			denom_units: [
 				{
-					denom: "uward",
+					denom: "award",
 					exponent: 0,
 				},
 				{
 					denom: "ward",
-					exponent: 6,
+					exponent: 18,
 				},
 			],
-			base: "uward",
+			base: "award",
 			name: "Ward",
 			display: "ward",
 			symbol: "WARD",

--- a/spaceward/src/features/actions/hooks.ts
+++ b/spaceward/src/features/actions/hooks.ts
@@ -16,7 +16,7 @@ const getActionId = () =>
 
 const defaultFee: StdFee = {
 	gas: "200000",
-	amount: [{ denom: "uward", amount: "250" }],
+	amount: [{ denom: "award", amount: "250000000000000" }],
 };
 
 export enum QueuedActionStatus {

--- a/spaceward/src/features/governance/hooks.ts
+++ b/spaceward/src/features/governance/hooks.ts
@@ -101,7 +101,7 @@ export const useGovernanceTx = (dispatch: GovernanceDispatch) => {
 
 		const res = await tx([submitProposal({
 			messages: [],
-			initialDeposit: [{ denom: "uward", amount: "10000000" }],
+			initialDeposit: [{ denom: "award", amount: "10000000000000000000" }],
 			proposer: address,
 			metadata: JSON.stringify({
 				title: "New Proposal",

--- a/spaceward/src/features/spaces/NoSpaces.tsx
+++ b/spaceward/src/features/spaces/NoSpaces.tsx
@@ -8,11 +8,11 @@ import { Icons } from "@/components/ui/icons";
 
 export function NoSpaces() {
 	const { address } = useAddressContext();
-	const { balance } = useAsset("uward");
+	const { balance } = useAsset("award");
 	const { tx } = useTx();
 	const { newSpace } = warden.warden.v1beta3.MessageComposer.withTypeUrl;
 
-	const ward = parseInt(balance?.amount || "0") / 10 ** 6;
+	const ward = parseInt(balance?.amount || "0") / 10 ** 18;
 	return (
 		<div className="relative w-full min-h-[calc(100vh-20px)] dark:bg-transparent  rounded-xl -mt-[48px] flex flex-col gap-4 items-center place-content-center text-center no-space">
 			<Icons.corner className="absolute top-0 left-0" />

--- a/spaceward/src/features/staking/StakeModal.tsx
+++ b/spaceward/src/features/staking/StakeModal.tsx
@@ -21,8 +21,8 @@ const StakeModal = ({
 	const { submitStakeTx } = useStakingTx(dispatch);
 	const isInactive = BondStatus.BOND_STATUS_BONDED !== validator.status;
 
-	const { balance } = useAsset("uward");
-	const ward = parseInt(balance?.amount ?? "0") / 10 ** 6;
+	const { balance } = useAsset("award");
+	const ward = parseInt(balance?.amount ?? "0") / 10 ** 18;
 
 	let maxAmount = ward - 1;
 	const isInputError = Number(amount) > maxAmount;
@@ -39,7 +39,7 @@ const StakeModal = ({
 			return;
 		}
 
-		const rawAmount = BigInt((10 ** 6 * numAmount).toFixed(0));
+		const rawAmount = BigInt((10 ** 18 * numAmount).toFixed(0));
 		const res = await submitStakeTx(rawAmount, validator.operatorAddress);
 		dispatch({ type: "set", payload: { modal: undefined, tab: "my" } });
 	}

--- a/spaceward/src/features/staking/ValidatorRow.tsx
+++ b/spaceward/src/features/staking/ValidatorRow.tsx
@@ -80,7 +80,7 @@ export default function ValidatorRow(props: ValidatorProps) {
 					onClick={() => props.openStakeModal(props.operatorAddress)}
 				>
 					<div>
-						{(Number(props.stakedAmount.amount) / 10 ** 6).toFixed(
+						{(Number(props.stakedAmount.amount) / 10 ** 18).toFixed(
 							6,
 						)}
 					</div>

--- a/spaceward/src/features/staking/hooks.ts
+++ b/spaceward/src/features/staking/hooks.ts
@@ -154,7 +154,7 @@ export const useStakingTx = (dispatch: Dispatch) => {
 						validatorAddress,
 						amount: {
 							amount: amount.toString(),
-							denom: "uward",
+							denom: "award",
 						},
 					}),
 				],
@@ -189,7 +189,7 @@ export const useStakingTx = (dispatch: Dispatch) => {
 						validatorAddress,
 						amount: {
 							amount: amount.toString(),
-							denom: "uward",
+							denom: "award",
 						},
 					}),
 				],
@@ -225,7 +225,7 @@ export const useStakingTx = (dispatch: Dispatch) => {
 						validatorDstAddress: to,
 						amount: {
 							amount: amount.toString(),
-							denom: "uward",
+							denom: "award",
 						},
 					}),
 				],

--- a/spaceward/src/features/staking/util.ts
+++ b/spaceward/src/features/staking/util.ts
@@ -19,7 +19,7 @@ export const getDelegationsData = (delegations?: DelegationResponse[]) => {
 		const delegation = delegations![i];
 		delegationsByAddress[delegation.delegation.validatorAddress] = i;
 
-		if (delegation.balance.denom === "uward") {
+		if (delegation.balance.denom === "award") {
 			availableWard += BigInt(delegation.balance.amount);
 		}
 	}
@@ -53,7 +53,7 @@ export const getParamData = ({
 	let total = BigInt(0);
 
 	for (const supply of totalSupply ?? []) {
-		if (supply.denom === "uward") {
+		if (supply.denom === "award") {
 			total += BigInt(supply.amount);
 		}
 	}
@@ -88,7 +88,7 @@ export const getParamData = ({
 export const formatReward = (reward?: DecCoin[]) => {
 	const rewardNum =
 		reward?.reduce((total, item) => {
-			return item.denom === "uward" ? total + BigInt(item.amount) : total;
+			return item.denom === "award" ? total + BigInt(item.amount) : total;
 		}, BigInt(0)) ?? BigInt(0);
 
 	// fixme

--- a/spaceward/src/hooks/useClient.ts
+++ b/spaceward/src/hooks/useClient.ts
@@ -22,7 +22,7 @@ const txRaw = cosmos.tx.v1beta1.TxRaw;
 
 const defaultFee: StdFee = {
 	gas: '200000',
-	amount: [{ denom: 'uward', amount: '250' }],
+	amount: [{ denom: 'award', amount: '250000000000000' }],
 };
 
 export interface TxOptions {

--- a/spaceward/src/hooks/useClient.ts
+++ b/spaceward/src/hooks/useClient.ts
@@ -1,5 +1,4 @@
 import {
-	cosmos,
 	createRpcQueryHooks,
 	getSigningWardenClient,
 	useRpcClient,
@@ -7,9 +6,14 @@ import {
 } from "@wardenprotocol/wardenjs";
 import { env } from "../env";
 import { useChain } from "@cosmos-kit/react";
-import { EncodeObject, OfflineSigner } from "@cosmjs/proto-signing";
+import { EncodeObject, OfflineDirectSigner, OfflineSigner, TxBodyEncodeObject, makeAuthInfoBytes, makeSignDoc } from "@cosmjs/proto-signing";
 import { ToasterToast, useToast } from "@/components/ui/use-toast";
-import { DeliverTxResponse, StdFee, isDeliverTxSuccess } from "@cosmjs/stargate";
+import { DeliverTxResponse, SigningStargateClient, StdFee, isDeliverTxSuccess } from "@cosmjs/stargate";
+import { TxBody, TxRaw } from "@wardenprotocol/wardenjs/codegen/cosmos/tx/v1beta1/tx";
+import { Any } from "@wardenprotocol/wardenjs/codegen/google/protobuf/any";
+import { Int53 } from "@cosmjs/math";
+import { PubKey } from "@wardenprotocol/wardenjs/codegen/ethermint/crypto/v1/ethsecp256k1/keys";
+import { fromBase64 } from "@cosmjs/encoding";
 
 export async function getSigningClient(signer: OfflineSigner) {
 	return await getSigningWardenClient({
@@ -17,8 +21,6 @@ export async function getSigningClient(signer: OfflineSigner) {
 		rpcEndpoint: env.rpcURL,
 	});
 }
-
-const txRaw = cosmos.tx.v1beta1.TxRaw;
 
 const defaultFee: StdFee = {
 	gas: '200000',
@@ -38,7 +40,7 @@ export enum TxStatus {
 }
 
 export function useTx() {
-	const { address, getOfflineSignerDirect: getOfflineSigner } = useChain(env.cosmoskitChainName);
+	const { address, getOfflineSignerDirect: getOfflineSigner, chain } = useChain(env.cosmoskitChainName);
 	const { toast } = useToast();
 
 	const tx = async (msgs: EncodeObject[], options: TxOptions) => {
@@ -50,13 +52,17 @@ export function useTx() {
 			return;
 		}
 
-		let signed: Parameters<typeof txRaw.encode>['0'];
+		let signed: Uint8Array;
 		const signer = getOfflineSigner();
 		const client = await getSigningClient(signer);
 
 		try {
 			const fee = options.fee || defaultFee;
-			signed = await client.sign(address, msgs, fee, '');
+			const txBody = TxBody.fromPartial({
+				messages: msgs,
+				memo: '',
+			});
+			signed = await buildTxRaw(chain.chain_id, client, signer, txBody, fee);
 		} catch (e: unknown) {
 			console.error(e);
 			toast({
@@ -75,7 +81,7 @@ export function useTx() {
 
 		if (client && signed) {
 			try {
-				const res = await client.broadcastTx(Uint8Array.from(txRaw.encode(signed).finish()));
+				const res = await client.broadcastTx(signed);
 				if (isDeliverTxSuccess(res)) {
 					if (options.onSuccess) options.onSuccess(res);
 
@@ -134,4 +140,54 @@ export function getClient() {
 	return warden.ClientFactory.createRPCQueryClient({
 		rpcEndpoint: env.rpcURL,
 	});
+}
+
+async function buildTxRaw(
+	chainId: string,
+	client: SigningStargateClient,
+	signer: OfflineDirectSigner,
+	txBody: TxBody,
+	fee: StdFee,
+) {
+	const walletAccounts = await signer.getAccounts();
+	const signerAddress = walletAccounts[0].address;
+	const account = await fetchAccount(signerAddress);
+
+	const pubk = Any.fromPartial({
+		typeUrl: PubKey.typeUrl,
+		value: PubKey.encode({
+			key: walletAccounts[0].pubkey,
+		}).finish(),
+	});
+
+	const txBodyEncodeObject: TxBodyEncodeObject = {
+		typeUrl: "/cosmos.tx.v1beta1.TxBody",
+		value: txBody,
+	};
+	const txBodyBytes = client.registry.encode(txBodyEncodeObject);
+	const gasLimit = Int53.fromString(fee.gas).toNumber();
+	const authInfoBytes = makeAuthInfoBytes(
+		[{ pubkey: pubk, sequence: account.sequence }],
+		fee.amount,
+		gasLimit,
+		fee.granter,
+		fee.payer,
+	);
+	const signDoc = makeSignDoc(txBodyBytes, authInfoBytes, chainId, Number(account.accountNumber));
+	const { signature, signed } = await signer.signDirect(signerAddress, signDoc);
+
+	return TxRaw.encode({
+		bodyBytes: signed.bodyBytes,
+		authInfoBytes: signed.authInfoBytes,
+		signatures: [fromBase64(signature.signature)],
+	}).finish();
+}
+
+async function fetchAccount(address: string) {
+	const rpcClient = await getClient();
+	const { account } = await rpcClient.cosmos.auth.v1beta1.account({ address });
+	if (!account) {
+		throw new Error("Failed to retrieve account from chain", account);
+	}
+	return account;
 }

--- a/spaceward/src/pages/Staking.tsx
+++ b/spaceward/src/pages/Staking.tsx
@@ -48,7 +48,7 @@ export function StakingPage() {
 		[queryDelegations.data?.delegationResponses],
 	);
 
-	const { balance: availableWard } = useAsset("uward");
+	const { balance: availableWard } = useAsset("award");
 
 	const { bondedTokens, apr } = useMemo(
 		() =>

--- a/wardenjs/proto/ethermint/crypto/v1/ethsecp256k1/keys.proto
+++ b/wardenjs/proto/ethermint/crypto/v1/ethsecp256k1/keys.proto
@@ -1,0 +1,25 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.crypto.v1.ethsecp256k1;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/evmos/evmos/v19/crypto/ethsecp256k1";
+
+// PubKey defines a type alias for an ecdsa.PublicKey that implements
+// Tendermint's PubKey interface. It represents the 33-byte compressed public
+// key format.
+message PubKey {
+  option (gogoproto.goproto_stringer) = false;
+
+  // key is the public key in byte form
+  bytes key = 1;
+}
+
+// PrivKey defines a type alias for an ecdsa.PrivateKey that implements
+// Tendermint's PrivateKey interface.
+message PrivKey {
+  // key is the private key in byte form
+  bytes key = 1;
+}

--- a/wardenjs/proto/ethermint/evm/v1/events.proto
+++ b/wardenjs/proto/ethermint/evm/v1/events.proto
@@ -1,0 +1,46 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.evm.v1;
+
+option go_package = "github.com/evmos/evmos/v19/x/evm/types";
+
+// EventEthereumTx defines the event for an Ethereum transaction
+message EventEthereumTx {
+  // amount
+  string amount = 1;
+  // eth_hash is the Ethereum hash of the transaction
+  string eth_hash = 2;
+  // index of the transaction in the block
+  string index = 3;
+  // gas_used is the amount of gas used by the transaction
+  string gas_used = 4;
+  // hash is the Tendermint hash of the transaction
+  string hash = 5;
+  // recipient of the transaction
+  string recipient = 6;
+  // eth_tx_failed contains a VM error should it occur
+  string eth_tx_failed = 7;
+}
+
+// EventTxLog defines the event for an Ethereum transaction log
+message EventTxLog {
+  // tx_logs is an array of transaction logs
+  repeated string tx_logs = 1;
+}
+
+// EventMessage
+message EventMessage {
+  // module which emits the event
+  string module = 1;
+  // sender of the message
+  string sender = 2;
+  // tx_type is the type of the message
+  string tx_type = 3;
+}
+
+// EventBlockBloom defines an Ethereum block bloom filter event
+message EventBlockBloom {
+  // bloom is the bloom filter of the block
+  string bloom = 1;
+}

--- a/wardenjs/proto/ethermint/evm/v1/evm.proto
+++ b/wardenjs/proto/ethermint/evm/v1/evm.proto
@@ -1,0 +1,258 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.evm.v1;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/evmos/evmos/v19/x/evm/types";
+
+// Params defines the EVM module parameters
+message Params {
+  // evm_denom represents the token denomination used to run the EVM state
+  // transitions.
+  string evm_denom = 1 [(gogoproto.moretags) = "yaml:\"evm_denom\""];
+  // enable_create and enable call have been deprecated
+  reserved 2, 3;
+  // extra_eips defines the additional EIPs for the vm.Config
+  repeated string extra_eips = 4 [(gogoproto.customname) = "ExtraEIPs", (gogoproto.moretags) = "yaml:\"extra_eips\""];
+  // chain_config defines the EVM chain configuration parameters
+  ChainConfig chain_config = 5 [(gogoproto.moretags) = "yaml:\"chain_config\"", (gogoproto.nullable) = false];
+  // allow_unprotected_txs defines if replay-protected (i.e non EIP155
+  // signed) transactions can be executed on the state machine.
+  bool allow_unprotected_txs = 6;
+  // renamed active_precompiles to active_static_precompiles
+  reserved 7;
+  // evm_channels is the list of channel identifiers from EVM compatible chains
+  repeated string evm_channels = 8 [(gogoproto.customname) = "EVMChannels"];
+  // access_control defines the permission policy of the EVM
+  AccessControl access_control = 9 [(gogoproto.customname) = "AccessControl", (gogoproto.nullable) = false];
+  // active_static_precompiles defines the slice of hex addresses of the precompiled
+  // contracts that are active
+  repeated string active_static_precompiles = 10;
+}
+
+// AccessControl defines the permission policy of the EVM
+// for creating and calling contracts
+message AccessControl {
+  // create defines the permission policy for creating contracts
+  AccessControlType create = 1 [(gogoproto.nullable) = false];
+  // call defines the permission policy for calling contracts
+  AccessControlType call = 2 [(gogoproto.nullable) = false];
+}
+
+// AccessControlType defines the permission type for policies
+message AccessControlType {
+  // access_type defines which type of permission is required for the operation
+  AccessType access_type = 1 [(gogoproto.customname) = "AccessType", (gogoproto.moretags) = "yaml:\"access_type\""];
+  // access_control_list defines defines different things depending on the AccessType:
+  // - ACCESS_TYPE_PERMISSIONLESS: list of addresses that are blocked from performing the operation
+  // - ACCESS_TYPE_RESTRICTED: ignored
+  // - ACCESS_TYPE_PERMISSIONED: list of addresses that are allowed to perform the operation
+  repeated string access_control_list = 2
+      [(gogoproto.customname) = "AccessControlList", (gogoproto.moretags) = "yaml:\"access_control_list\""];
+}
+
+// AccessType defines the types of permissions for the operations
+enum AccessType {
+  option (gogoproto.goproto_enum_prefix) = false;
+
+  // ACCESS_TYPE_PERMISSIONLESS does not restrict the operation to anyone
+  ACCESS_TYPE_PERMISSIONLESS = 0 [(gogoproto.enumvalue_customname) = "AccessTypePermissionless"];
+  // ACCESS_TYPE_RESTRICTED restrict the operation to anyone
+  ACCESS_TYPE_RESTRICTED = 1 [(gogoproto.enumvalue_customname) = "AccessTypeRestricted"];
+  // ACCESS_TYPE_PERMISSIONED only allows the operation for specific addresses
+  ACCESS_TYPE_PERMISSIONED = 2 [(gogoproto.enumvalue_customname) = "AccessTypePermissioned"];
+}
+
+// ChainConfig defines the Ethereum ChainConfig parameters using *sdk.Int values
+// instead of *big.Int.
+message ChainConfig {
+  // homestead_block switch (nil no fork, 0 = already homestead)
+  string homestead_block = 1
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"homestead_block\""];
+  // dao_fork_block corresponds to TheDAO hard-fork switch block (nil no fork)
+  string dao_fork_block = 2 [
+    (gogoproto.customname) = "DAOForkBlock",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.moretags) = "yaml:\"dao_fork_block\""
+  ];
+  // dao_fork_support defines whether the nodes supports or opposes the DAO hard-fork
+  bool dao_fork_support = 3
+      [(gogoproto.customname) = "DAOForkSupport", (gogoproto.moretags) = "yaml:\"dao_fork_support\""];
+  // eip150_block: EIP150 implements the Gas price changes
+  // (https://github.com/ethereum/EIPs/issues/150) EIP150 HF block (nil no fork)
+  string eip150_block = 4 [
+    (gogoproto.customname) = "EIP150Block",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.moretags) = "yaml:\"eip150_block\""
+  ];
+  // eip150_hash: EIP150 HF hash (needed for header only clients as only gas pricing changed)
+  string eip150_hash = 5 [(gogoproto.customname) = "EIP150Hash", (gogoproto.moretags) = "yaml:\"byzantium_block\""];
+  // eip155_block: EIP155Block HF block
+  string eip155_block = 6 [
+    (gogoproto.customname) = "EIP155Block",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.moretags) = "yaml:\"eip155_block\""
+  ];
+  // eip158_block: EIP158 HF block
+  string eip158_block = 7 [
+    (gogoproto.customname) = "EIP158Block",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.moretags) = "yaml:\"eip158_block\""
+  ];
+  // byzantium_block: Byzantium switch block (nil no fork, 0 = already on byzantium)
+  string byzantium_block = 8
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"byzantium_block\""];
+  // constantinople_block: Constantinople switch block (nil no fork, 0 = already activated)
+  string constantinople_block = 9
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"constantinople_block\""];
+  // petersburg_block: Petersburg switch block (nil same as Constantinople)
+  string petersburg_block = 10
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"petersburg_block\""];
+  // istanbul_block: Istanbul switch block (nil no fork, 0 = already on istanbul)
+  string istanbul_block = 11
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"istanbul_block\""];
+  // muir_glacier_block: Eip-2384 (bomb delay) switch block (nil no fork, 0 = already activated)
+  string muir_glacier_block = 12
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"muir_glacier_block\""];
+  // berlin_block: Berlin switch block (nil = no fork, 0 = already on berlin)
+  string berlin_block = 13
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"berlin_block\""];
+  // DEPRECATED: EWASM, YOLOV3 and Catalyst block have been deprecated
+  reserved 14, 15, 16;
+  reserved "yolo_v3_block", "ewasm_block", "catalyst_block";
+  // london_block: London switch block (nil = no fork, 0 = already on london)
+  string london_block = 17
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"london_block\""];
+  // arrow_glacier_block: Eip-4345 (bomb delay) switch block (nil = no fork, 0 = already activated)
+  string arrow_glacier_block = 18
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"arrow_glacier_block\""];
+  // DEPRECATED: merge fork block was deprecated: https://github.com/ethereum/go-ethereum/pull/24904
+  reserved 19;
+  reserved "merge_fork_block";
+  // gray_glacier_block: EIP-5133 (bomb delay) switch block (nil = no fork, 0 = already activated)
+  string gray_glacier_block = 20
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"gray_glacier_block\""];
+  // merge_netsplit_block: Virtual fork after The Merge to use as a network splitter
+  string merge_netsplit_block = 21
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"merge_netsplit_block\""];
+  // shanghai_block switch block (nil = no fork, 0 = already on shanghai)
+  string shanghai_block = 22
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"shanghai_block\""];
+  // cancun_block switch block (nil = no fork, 0 = already on cancun)
+  string cancun_block = 23
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.moretags) = "yaml:\"cancun_block\""];
+}
+
+// State represents a single Storage key value pair item.
+message State {
+  // key is the stored key
+  string key = 1;
+  // value is the stored value for the given key
+  string value = 2;
+}
+
+// TransactionLogs define the logs generated from a transaction execution
+// with a given hash. It it used for import/export data as transactions are not
+// persisted on blockchain state after an upgrade.
+message TransactionLogs {
+  // hash of the transaction
+  string hash = 1;
+  // logs is an array of Logs for the given transaction hash
+  repeated Log logs = 2;
+}
+
+// Log represents an protobuf compatible Ethereum Log that defines a contract
+// log event. These events are generated by the LOG opcode and stored/indexed by
+// the node.
+//
+// NOTE: address, topics and data are consensus fields. The rest of the fields
+// are derived, i.e. filled in by the nodes, but not secured by consensus.
+message Log {
+  // address of the contract that generated the event
+  string address = 1;
+  // topics is a list of topics provided by the contract.
+  repeated string topics = 2;
+  // data which is supplied by the contract, usually ABI-encoded
+  bytes data = 3;
+
+  // block_number of the block in which the transaction was included
+  uint64 block_number = 4 [(gogoproto.jsontag) = "blockNumber"];
+  // tx_hash is the transaction hash
+  string tx_hash = 5 [(gogoproto.jsontag) = "transactionHash"];
+  // tx_index of the transaction in the block
+  uint64 tx_index = 6 [(gogoproto.jsontag) = "transactionIndex"];
+  // block_hash of the block in which the transaction was included
+  string block_hash = 7 [(gogoproto.jsontag) = "blockHash"];
+  // index of the log in the block
+  uint64 index = 8 [(gogoproto.jsontag) = "logIndex"];
+
+  // removed is true if this log was reverted due to a chain
+  // reorganisation. You must pay attention to this field if you receive logs
+  // through a filter query.
+  bool removed = 9;
+}
+
+// TxResult stores results of Tx execution.
+message TxResult {
+  option (gogoproto.goproto_getters) = false;
+
+  // contract_address contains the ethereum address of the created contract (if
+  // any). If the state transition is an evm.Call, the contract address will be
+  // empty.
+  string contract_address = 1 [(gogoproto.moretags) = "yaml:\"contract_address\""];
+  // bloom represents the bloom filter bytes
+  bytes bloom = 2;
+  // tx_logs contains the transaction hash and the proto-compatible ethereum
+  // logs.
+  TransactionLogs tx_logs = 3 [(gogoproto.moretags) = "yaml:\"tx_logs\"", (gogoproto.nullable) = false];
+  // ret defines the bytes from the execution.
+  bytes ret = 4;
+  // reverted flag is set to true when the call has been reverted
+  bool reverted = 5;
+  // gas_used notes the amount of gas consumed while execution
+  uint64 gas_used = 6;
+}
+
+// AccessTuple is the element type of an access list.
+message AccessTuple {
+  option (gogoproto.goproto_getters) = false;
+
+  // address is a hex formatted ethereum address
+  string address = 1;
+  // storage_keys are hex formatted hashes of the storage keys
+  repeated string storage_keys = 2 [(gogoproto.jsontag) = "storageKeys"];
+}
+
+// TraceConfig holds extra parameters to trace functions.
+message TraceConfig {
+  // DEPRECATED: DisableMemory and DisableReturnData have been renamed to
+  // Enable*.
+  reserved 4, 7;
+  reserved "disable_memory", "disable_return_data";
+
+  // tracer is a custom javascript tracer
+  string tracer = 1;
+  // timeout overrides the default timeout of 5 seconds for JavaScript-based tracing
+  // calls
+  string timeout = 2;
+  // reexec defines the number of blocks the tracer is willing to go back
+  uint64 reexec = 3;
+  // disable_stack switches stack capture
+  bool disable_stack = 5 [(gogoproto.jsontag) = "disableStack"];
+  // disable_storage switches storage capture
+  bool disable_storage = 6 [(gogoproto.jsontag) = "disableStorage"];
+  // debug can be used to print output during capture end
+  bool debug = 8;
+  // limit defines the maximum length of output, but zero means unlimited
+  int32 limit = 9;
+  // overrides can be used to execute a trace using future fork rules
+  ChainConfig overrides = 10;
+  // enable_memory switches memory capture
+  bool enable_memory = 11 [(gogoproto.jsontag) = "enableMemory"];
+  // enable_return_data switches the capture of return data
+  bool enable_return_data = 12 [(gogoproto.jsontag) = "enableReturnData"];
+  // tracer_json_config configures the tracer using a JSON string
+  string tracer_json_config = 13 [(gogoproto.jsontag) = "tracerConfig"];
+}

--- a/wardenjs/proto/ethermint/evm/v1/genesis.proto
+++ b/wardenjs/proto/ethermint/evm/v1/genesis.proto
@@ -1,0 +1,29 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.evm.v1;
+
+import "ethermint/evm/v1/evm.proto";
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/evmos/evmos/v19/x/evm/types";
+
+// GenesisState defines the evm module's genesis state.
+message GenesisState {
+  // accounts is an array containing the ethereum genesis accounts.
+  repeated GenesisAccount accounts = 1 [(gogoproto.nullable) = false];
+  // params defines all the parameters of the module.
+  Params params = 2 [(gogoproto.nullable) = false];
+}
+
+// GenesisAccount defines an account to be initialized in the genesis state.
+// Its main difference between with Geth's GenesisAccount is that it uses a
+// custom storage type and that it doesn't contain the private key field.
+message GenesisAccount {
+  // address defines an ethereum hex formated address of an account
+  string address = 1;
+  // code defines the hex bytes of the account code.
+  string code = 2;
+  // storage defines the set of state key values for the account.
+  repeated State storage = 3 [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "Storage"];
+}

--- a/wardenjs/proto/ethermint/evm/v1/query.proto
+++ b/wardenjs/proto/ethermint/evm/v1/query.proto
@@ -1,0 +1,304 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.evm.v1;
+
+import "cosmos/base/query/v1beta1/pagination.proto";
+import "ethermint/evm/v1/evm.proto";
+import "ethermint/evm/v1/tx.proto";
+import "gogoproto/gogo.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/evmos/evmos/v19/x/evm/types";
+
+// Query defines the gRPC querier service.
+service Query {
+  // Account queries an Ethereum account.
+  rpc Account(QueryAccountRequest) returns (QueryAccountResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/account/{address}";
+  }
+
+  // CosmosAccount queries an Ethereum account's Cosmos Address.
+  rpc CosmosAccount(QueryCosmosAccountRequest) returns (QueryCosmosAccountResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/cosmos_account/{address}";
+  }
+
+  // ValidatorAccount queries an Ethereum account's from a validator consensus
+  // Address.
+  rpc ValidatorAccount(QueryValidatorAccountRequest) returns (QueryValidatorAccountResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/validator_account/{cons_address}";
+  }
+
+  // Balance queries the balance of a the EVM denomination for a single
+  // account.
+  rpc Balance(QueryBalanceRequest) returns (QueryBalanceResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/balances/{address}";
+  }
+
+  // Storage queries the balance of all coins for a single account.
+  rpc Storage(QueryStorageRequest) returns (QueryStorageResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/storage/{address}/{key}";
+  }
+
+  // Code queries the balance of all coins for a single account.
+  rpc Code(QueryCodeRequest) returns (QueryCodeResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/codes/{address}";
+  }
+
+  // Params queries the parameters of x/evm module.
+  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/params";
+  }
+
+  // EthCall implements the `eth_call` rpc api
+  rpc EthCall(EthCallRequest) returns (MsgEthereumTxResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/eth_call";
+  }
+
+  // EstimateGas implements the `eth_estimateGas` rpc api
+  rpc EstimateGas(EthCallRequest) returns (EstimateGasResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/estimate_gas";
+  }
+
+  // TraceTx implements the `debug_traceTransaction` rpc api
+  rpc TraceTx(QueryTraceTxRequest) returns (QueryTraceTxResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/trace_tx";
+  }
+
+  // TraceBlock implements the `debug_traceBlockByNumber` and `debug_traceBlockByHash` rpc api
+  rpc TraceBlock(QueryTraceBlockRequest) returns (QueryTraceBlockResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/trace_block";
+  }
+
+  // BaseFee queries the base fee of the parent block of the current block,
+  // it's similar to feemarket module's method, but also checks london hardfork status.
+  rpc BaseFee(QueryBaseFeeRequest) returns (QueryBaseFeeResponse) {
+    option (google.api.http).get = "/evmos/evm/v1/base_fee";
+  }
+}
+
+// QueryAccountRequest is the request type for the Query/Account RPC method.
+message QueryAccountRequest {
+  option (gogoproto.equal) = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // address is the ethereum hex address to query the account for.
+  string address = 1;
+}
+
+// QueryAccountResponse is the response type for the Query/Account RPC method.
+message QueryAccountResponse {
+  // balance is the balance of the EVM denomination.
+  string balance = 1;
+  // code_hash is the hex-formatted code bytes from the EOA.
+  string code_hash = 2;
+  // nonce is the account's sequence number.
+  uint64 nonce = 3;
+}
+
+// QueryCosmosAccountRequest is the request type for the Query/CosmosAccount RPC
+// method.
+message QueryCosmosAccountRequest {
+  option (gogoproto.equal) = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // address is the ethereum hex address to query the account for.
+  string address = 1;
+}
+
+// QueryCosmosAccountResponse is the response type for the Query/CosmosAccount
+// RPC method.
+message QueryCosmosAccountResponse {
+  // cosmos_address is the cosmos address of the account.
+  string cosmos_address = 1;
+  // sequence is the account's sequence number.
+  uint64 sequence = 2;
+  // account_number is the account number
+  uint64 account_number = 3;
+}
+
+// QueryValidatorAccountRequest is the request type for the
+// Query/ValidatorAccount RPC method.
+message QueryValidatorAccountRequest {
+  option (gogoproto.equal) = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // cons_address is the validator cons address to query the account for.
+  string cons_address = 1;
+}
+
+// QueryValidatorAccountResponse is the response type for the
+// Query/ValidatorAccount RPC method.
+message QueryValidatorAccountResponse {
+  // account_address is the cosmos address of the account in bech32 format.
+  string account_address = 1;
+  // sequence is the account's sequence number.
+  uint64 sequence = 2;
+  // account_number is the account number
+  uint64 account_number = 3;
+}
+
+// QueryBalanceRequest is the request type for the Query/Balance RPC method.
+message QueryBalanceRequest {
+  option (gogoproto.equal) = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // address is the ethereum hex address to query the balance for.
+  string address = 1;
+}
+
+// QueryBalanceResponse is the response type for the Query/Balance RPC method.
+message QueryBalanceResponse {
+  // balance is the balance of the EVM denomination.
+  string balance = 1;
+}
+
+// QueryStorageRequest is the request type for the Query/Storage RPC method.
+message QueryStorageRequest {
+  option (gogoproto.equal) = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // address is the ethereum hex address to query the storage state for.
+  string address = 1;
+
+  // key defines the key of the storage state
+  string key = 2;
+}
+
+// QueryStorageResponse is the response type for the Query/Storage RPC
+// method.
+message QueryStorageResponse {
+  // value defines the storage state value hash associated with the given key.
+  string value = 1;
+}
+
+// QueryCodeRequest is the request type for the Query/Code RPC method.
+message QueryCodeRequest {
+  option (gogoproto.equal) = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // address is the ethereum hex address to query the code for.
+  string address = 1;
+}
+
+// QueryCodeResponse is the response type for the Query/Code RPC
+// method.
+message QueryCodeResponse {
+  // code represents the code bytes from an ethereum address.
+  bytes code = 1;
+}
+
+// QueryTxLogsRequest is the request type for the Query/TxLogs RPC method.
+message QueryTxLogsRequest {
+  option (gogoproto.equal) = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // hash is the ethereum transaction hex hash to query the logs for.
+  string hash = 1;
+  // pagination defines an optional pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 2;
+}
+
+// QueryTxLogsResponse is the response type for the Query/TxLogs RPC method.
+message QueryTxLogsResponse {
+  // logs represents the ethereum logs generated from the given transaction.
+  repeated Log logs = 1;
+  // pagination defines the pagination in the response.
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+// QueryParamsRequest defines the request type for querying x/evm parameters.
+message QueryParamsRequest {}
+
+// QueryParamsResponse defines the response type for querying x/evm parameters.
+message QueryParamsResponse {
+  // params define the evm module parameters.
+  Params params = 1 [(gogoproto.nullable) = false];
+}
+
+// EthCallRequest defines EthCall request
+message EthCallRequest {
+  // args uses the same json format as the json rpc api.
+  bytes args = 1;
+  // gas_cap defines the default gas cap to be used
+  uint64 gas_cap = 2;
+  // proposer_address of the requested block in hex format
+  bytes proposer_address = 3 [(gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.ConsAddress"];
+  // chain_id is the eip155 chain id parsed from the requested block header
+  int64 chain_id = 4;
+}
+
+// EstimateGasResponse defines EstimateGas response
+message EstimateGasResponse {
+  // gas returns the estimated gas
+  uint64 gas = 1;
+}
+
+// QueryTraceTxRequest defines TraceTx request
+message QueryTraceTxRequest {
+  // msg is the MsgEthereumTx for the requested transaction
+  MsgEthereumTx msg = 1;
+  // tx_index is not necessary anymore
+  reserved 2;
+  reserved "tx_index";
+  // trace_config holds extra parameters to trace functions.
+  TraceConfig trace_config = 3;
+  // predecessors is an array of transactions included in the same block
+  // need to be replayed first to get correct context for tracing.
+  repeated MsgEthereumTx predecessors = 4;
+  // block_number of requested transaction
+  int64 block_number = 5;
+  // block_hash of requested transaction
+  string block_hash = 6;
+  // block_time of requested transaction
+  google.protobuf.Timestamp block_time = 7 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  // proposer_address is the proposer of the requested block
+  bytes proposer_address = 8 [(gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.ConsAddress"];
+  // chain_id is the eip155 chain id parsed from the requested block header
+  int64 chain_id = 9;
+  // block_max_gas of the block of the requested transaction
+  int64 block_max_gas = 10;
+}
+
+// QueryTraceTxResponse defines TraceTx response
+message QueryTraceTxResponse {
+  // data is the response serialized in bytes
+  bytes data = 1;
+}
+
+// QueryTraceBlockRequest defines TraceTx request
+message QueryTraceBlockRequest {
+  // txs is an array of messages in the block
+  repeated MsgEthereumTx txs = 1;
+  // trace_config holds extra parameters to trace functions.
+  TraceConfig trace_config = 3;
+  // block_number of the traced block
+  int64 block_number = 5;
+  // block_hash (hex) of the traced block
+  string block_hash = 6;
+  // block_time of the traced block
+  google.protobuf.Timestamp block_time = 7 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  // proposer_address is the address of the requested block
+  bytes proposer_address = 8 [(gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.ConsAddress"];
+  // chain_id is the eip155 chain id parsed from the requested block header
+  int64 chain_id = 9;
+  // block_max_gas of the traced block
+  int64 block_max_gas = 10;
+}
+
+// QueryTraceBlockResponse defines TraceBlock response
+message QueryTraceBlockResponse {
+  // data is the response serialized in bytes
+  bytes data = 1;
+}
+
+// QueryBaseFeeRequest defines the request type for querying the EIP1559 base
+// fee.
+message QueryBaseFeeRequest {}
+
+// QueryBaseFeeResponse returns the EIP1559 base fee.
+message QueryBaseFeeResponse {
+  // base_fee is the EIP1559 base fee
+  string base_fee = 1 [(gogoproto.customtype) = "cosmossdk.io/math.Int"];
+}

--- a/wardenjs/proto/ethermint/evm/v1/tx.proto
+++ b/wardenjs/proto/ethermint/evm/v1/tx.proto
@@ -1,0 +1,179 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.evm.v1;
+
+import "cosmos/msg/v1/msg.proto";
+import "cosmos_proto/cosmos.proto";
+import "ethermint/evm/v1/evm.proto";
+import "gogoproto/gogo.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/any.proto";
+
+option go_package = "github.com/evmos/evmos/v19/x/evm/types";
+
+// Msg defines the evm Msg service.
+service Msg {
+  // EthereumTx defines a method submitting Ethereum transactions.
+  rpc EthereumTx(MsgEthereumTx) returns (MsgEthereumTxResponse) {
+    option (google.api.http).post = "/evmos/evm/v1/ethereum_tx";
+  };
+  // UpdateParams defined a governance operation for updating the x/evm module parameters.
+  // The authority is hard-coded to the Cosmos SDK x/gov module account
+  rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
+}
+
+// MsgEthereumTx encapsulates an Ethereum transaction as an SDK message.
+message MsgEthereumTx {
+  option (gogoproto.goproto_getters) = false;
+
+  // data is inner transaction data of the Ethereum transaction
+  google.protobuf.Any data = 1;
+
+  // size is the encoded storage size of the transaction (DEPRECATED)
+  double size = 2 [(gogoproto.jsontag) = "-"];
+  // hash of the transaction in hex format
+  string hash = 3 [(gogoproto.moretags) = "rlp:\"-\""];
+  // from is the ethereum signer address in hex format. This address value is checked
+  // against the address derived from the signature (V, R, S) using the
+  // secp256k1 elliptic curve
+  string from = 4;
+}
+
+// LegacyTx is the transaction data of regular Ethereum transactions.
+// NOTE: All non-protected transactions (i.e non EIP155 signed) will fail if the
+// AllowUnprotectedTxs parameter is disabled.
+message LegacyTx {
+  option (gogoproto.goproto_getters) = false;
+  option (cosmos_proto.implements_interface) = "TxData";
+
+  // nonce corresponds to the account nonce (transaction sequence).
+  uint64 nonce = 1;
+  // gas_price defines the value for each gas unit
+  string gas_price = 2 [(gogoproto.customtype) = "cosmossdk.io/math.Int"];
+  // gas defines the gas limit defined for the transaction.
+  uint64 gas = 3 [(gogoproto.customname) = "GasLimit"];
+  // to is the hex formatted address of the recipient
+  string to = 4;
+  // value defines the unsigned integer value of the transaction amount.
+  string value = 5 [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.customname) = "Amount"];
+  // data is the data payload bytes of the transaction.
+  bytes data = 6;
+  // v defines the signature value
+  bytes v = 7;
+  // r defines the signature value
+  bytes r = 8;
+  // s define the signature value
+  bytes s = 9;
+}
+
+// AccessListTx is the data of EIP-2930 access list transactions.
+message AccessListTx {
+  option (gogoproto.goproto_getters) = false;
+  option (cosmos_proto.implements_interface) = "TxData";
+
+  // chain_id of the destination EVM chain
+  string chain_id = 1 [
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.customname) = "ChainID",
+    (gogoproto.jsontag) = "chainID"
+  ];
+  // nonce corresponds to the account nonce (transaction sequence).
+  uint64 nonce = 2;
+  // gas_price defines the value for each gas unit
+  string gas_price = 3 [(gogoproto.customtype) = "cosmossdk.io/math.Int"];
+  // gas defines the gas limit defined for the transaction.
+  uint64 gas = 4 [(gogoproto.customname) = "GasLimit"];
+  // to is the recipient address in hex format
+  string to = 5;
+  // value defines the unsigned integer value of the transaction amount.
+  string value = 6 [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.customname) = "Amount"];
+  // data is the data payload bytes of the transaction.
+  bytes data = 7;
+  // accesses is an array of access tuples
+  repeated AccessTuple accesses = 8
+      [(gogoproto.castrepeated) = "AccessList", (gogoproto.jsontag) = "accessList", (gogoproto.nullable) = false];
+  // v defines the signature value
+  bytes v = 9;
+  // r defines the signature value
+  bytes r = 10;
+  // s define the signature value
+  bytes s = 11;
+}
+
+// DynamicFeeTx is the data of EIP-1559 dynamic fee transactions.
+message DynamicFeeTx {
+  option (gogoproto.goproto_getters) = false;
+  option (cosmos_proto.implements_interface) = "TxData";
+
+  // chain_id of the destination EVM chain
+  string chain_id = 1 [
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.customname) = "ChainID",
+    (gogoproto.jsontag) = "chainID"
+  ];
+  // nonce corresponds to the account nonce (transaction sequence).
+  uint64 nonce = 2;
+  // gas_tip_cap defines the max value for the gas tip
+  string gas_tip_cap = 3 [(gogoproto.customtype) = "cosmossdk.io/math.Int"];
+  // gas_fee_cap defines the max value for the gas fee
+  string gas_fee_cap = 4 [(gogoproto.customtype) = "cosmossdk.io/math.Int"];
+  // gas defines the gas limit defined for the transaction.
+  uint64 gas = 5 [(gogoproto.customname) = "GasLimit"];
+  // to is the hex formatted address of the recipient
+  string to = 6;
+  // value defines the transaction amount.
+  string value = 7 [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.customname) = "Amount"];
+  // data is the data payload bytes of the transaction.
+  bytes data = 8;
+  // accesses is an array of access tuples
+  repeated AccessTuple accesses = 9
+      [(gogoproto.castrepeated) = "AccessList", (gogoproto.jsontag) = "accessList", (gogoproto.nullable) = false];
+  // v defines the signature value
+  bytes v = 10;
+  // r defines the signature value
+  bytes r = 11;
+  // s define the signature value
+  bytes s = 12;
+}
+
+// ExtensionOptionsEthereumTx is an extension option for ethereum transactions
+message ExtensionOptionsEthereumTx {
+  option (gogoproto.goproto_getters) = false;
+}
+
+// MsgEthereumTxResponse defines the Msg/EthereumTx response type.
+message MsgEthereumTxResponse {
+  option (gogoproto.goproto_getters) = false;
+
+  // hash of the ethereum transaction in hex format. This hash differs from the
+  // Tendermint sha256 hash of the transaction bytes. See
+  // https://github.com/tendermint/tendermint/issues/6539 for reference
+  string hash = 1;
+  // logs contains the transaction hash and the proto-compatible ethereum
+  // logs.
+  repeated Log logs = 2;
+  // ret is the returned data from evm function (result or data supplied with revert
+  // opcode)
+  bytes ret = 3;
+  // vm_error is the error returned by vm execution
+  string vm_error = 4;
+  // gas_used specifies how much gas was consumed by the transaction
+  uint64 gas_used = 5;
+}
+
+// MsgUpdateParams defines a Msg for updating the x/evm module parameters.
+message MsgUpdateParams {
+  option (cosmos.msg.v1.signer) = "authority";
+
+  // authority is the address of the governance account.
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+
+  // params defines the x/evm parameters to update.
+  // NOTE: All parameters must be supplied.
+  Params params = 2 [(gogoproto.nullable) = false];
+}
+
+// MsgUpdateParamsResponse defines the response structure for executing a
+// MsgUpdateParams message.
+message MsgUpdateParamsResponse {}

--- a/wardenjs/proto/ethermint/feemarket/v1/events.proto
+++ b/wardenjs/proto/ethermint/feemarket/v1/events.proto
@@ -1,0 +1,20 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.feemarket.v1;
+
+option go_package = "github.com/evmos/evmos/v19/x/feemarket/types";
+
+// EventFeeMarket is the event type for the fee market module
+message EventFeeMarket {
+  // base_fee for EIP-1559 blocks
+  string base_fee = 1;
+}
+
+// EventBlockGas defines an Ethereum block gas event
+message EventBlockGas {
+  // height of the block
+  string height = 1;
+  // amount of gas wanted by the block
+  string amount = 2;
+}

--- a/wardenjs/proto/ethermint/feemarket/v1/feemarket.proto
+++ b/wardenjs/proto/ethermint/feemarket/v1/feemarket.proto
@@ -1,0 +1,32 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.feemarket.v1;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/evmos/evmos/v19/x/feemarket/types";
+
+// Params defines the EVM module parameters
+message Params {
+  // no_base_fee forces the EIP-1559 base fee to 0 (needed for 0 price calls)
+  bool no_base_fee = 1;
+  // base_fee_change_denominator bounds the amount the base fee can change
+  // between blocks.
+  uint32 base_fee_change_denominator = 2;
+  // elasticity_multiplier bounds the maximum gas limit an EIP-1559 block may
+  // have.
+  uint32 elasticity_multiplier = 3;
+  // DEPRECATED: initial base fee for EIP-1559 blocks.
+  reserved 4;
+  reserved "initial_base_fee";
+  // enable_height defines at which block height the base fee calculation is enabled.
+  int64 enable_height = 5;
+  // base_fee for EIP-1559 blocks.
+  string base_fee = 6 [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.nullable) = false];
+  // min_gas_price defines the minimum gas price value for cosmos and eth transactions
+  string min_gas_price = 7 [(gogoproto.customtype) = "cosmossdk.io/math.LegacyDec", (gogoproto.nullable) = false];
+  // min_gas_multiplier bounds the minimum gas used to be charged
+  // to senders based on gas limit
+  string min_gas_multiplier = 8 [(gogoproto.customtype) = "cosmossdk.io/math.LegacyDec", (gogoproto.nullable) = false];
+}

--- a/wardenjs/proto/ethermint/feemarket/v1/genesis.proto
+++ b/wardenjs/proto/ethermint/feemarket/v1/genesis.proto
@@ -1,0 +1,22 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.feemarket.v1;
+
+import "ethermint/feemarket/v1/feemarket.proto";
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/evmos/evmos/v19/x/feemarket/types";
+
+// GenesisState defines the feemarket module's genesis state.
+message GenesisState {
+  // params defines all the parameters of the feemarket module.
+  Params params = 1 [(gogoproto.nullable) = false];
+  // DEPRECATED: base fee is the exported value from previous software version.
+  // Zero by default.
+  reserved 2;
+  reserved "base_fee";
+  // block_gas is the amount of gas wanted on the last block before the upgrade.
+  // Zero by default.
+  uint64 block_gas = 3;
+}

--- a/wardenjs/proto/ethermint/feemarket/v1/query.proto
+++ b/wardenjs/proto/ethermint/feemarket/v1/query.proto
@@ -1,0 +1,57 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.feemarket.v1;
+
+import "ethermint/feemarket/v1/feemarket.proto";
+import "gogoproto/gogo.proto";
+import "google/api/annotations.proto";
+
+option go_package = "github.com/evmos/evmos/v19/x/feemarket/types";
+
+// Query defines the gRPC querier service.
+service Query {
+  // Params queries the parameters of x/feemarket module.
+  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+    option (google.api.http).get = "/evmos/feemarket/v1/params";
+  }
+
+  // BaseFee queries the base fee of the parent block of the current block.
+  rpc BaseFee(QueryBaseFeeRequest) returns (QueryBaseFeeResponse) {
+    option (google.api.http).get = "/evmos/feemarket/v1/base_fee";
+  }
+
+  // BlockGas queries the gas used at a given block height
+  rpc BlockGas(QueryBlockGasRequest) returns (QueryBlockGasResponse) {
+    option (google.api.http).get = "/evmos/feemarket/v1/block_gas";
+  }
+}
+
+// QueryParamsRequest defines the request type for querying x/evm parameters.
+message QueryParamsRequest {}
+
+// QueryParamsResponse defines the response type for querying x/evm parameters.
+message QueryParamsResponse {
+  // params define the evm module parameters.
+  Params params = 1 [(gogoproto.nullable) = false];
+}
+
+// QueryBaseFeeRequest defines the request type for querying the EIP1559 base
+// fee.
+message QueryBaseFeeRequest {}
+
+// QueryBaseFeeResponse returns the EIP1559 base fee.
+message QueryBaseFeeResponse {
+  // base_fee is the EIP1559 base fee
+  string base_fee = 1 [(gogoproto.customtype) = "cosmossdk.io/math.Int"];
+}
+
+// QueryBlockGasRequest defines the request type for querying the EIP1559 base
+// fee.
+message QueryBlockGasRequest {}
+
+// QueryBlockGasResponse returns block gas used for a given height.
+message QueryBlockGasResponse {
+  // gas is the returned block gas
+  int64 gas = 1;
+}

--- a/wardenjs/proto/ethermint/feemarket/v1/tx.proto
+++ b/wardenjs/proto/ethermint/feemarket/v1/tx.proto
@@ -1,0 +1,32 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.feemarket.v1;
+
+import "cosmos/msg/v1/msg.proto";
+import "cosmos_proto/cosmos.proto";
+import "ethermint/feemarket/v1/feemarket.proto";
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/evmos/evmos/v19/x/feemarket/types";
+
+// Msg defines the erc20 Msg service.
+service Msg {
+  // UpdateParams defined a governance operation for updating the x/feemarket module parameters.
+  // The authority is hard-coded to the Cosmos SDK x/gov module account
+  rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
+}
+
+// MsgUpdateParams defines a Msg for updating the x/feemarket module parameters.
+message MsgUpdateParams {
+  option (cosmos.msg.v1.signer) = "authority";
+  // authority is the address of the governance account.
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // params defines the x/feemarket parameters to update.
+  // NOTE: All parameters must be supplied.
+  Params params = 2 [(gogoproto.nullable) = false];
+}
+
+// MsgUpdateParamsResponse defines the response structure for executing a
+// MsgUpdateParams message.
+message MsgUpdateParamsResponse {}

--- a/wardenjs/proto/ethermint/types/v1/dynamic_fee.proto
+++ b/wardenjs/proto/ethermint/types/v1/dynamic_fee.proto
@@ -1,0 +1,14 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.types.v1;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/evmos/evmos/v19/types";
+
+// ExtensionOptionDynamicFeeTx is an extension option that specifies the maxPrioPrice for cosmos tx
+message ExtensionOptionDynamicFeeTx {
+  // max_priority_price is the same as `max_priority_fee_per_gas` in eip-1559 spec
+  string max_priority_price = 1 [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.nullable) = false];
+}

--- a/wardenjs/proto/ethermint/types/v1/indexer.proto
+++ b/wardenjs/proto/ethermint/types/v1/indexer.proto
@@ -1,0 +1,32 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.types.v1;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/evmos/evmos/v19/types";
+
+// TxResult is the value stored in eth tx indexer
+message TxResult {
+  option (gogoproto.goproto_getters) = false;
+
+  // height of the blockchain
+  int64 height = 1;
+  // tx_index of the cosmos transaction
+  uint32 tx_index = 2;
+  // msg_index in a batch transaction
+  uint32 msg_index = 3;
+
+  // eth_tx_index is the index in the list of valid eth tx in the block,
+  // aka. the transaction list returned by eth_getBlock api.
+  int32 eth_tx_index = 4;
+  // failed is true if the eth transaction did not go succeed
+  bool failed = 5;
+  // gas_used by the transaction. If it exceeds the block gas limit,
+  // it's set to gas limit, which is what's actually deducted by ante handler.
+  uint64 gas_used = 6;
+  // cumulative_gas_used specifies the cumulated amount of gas used for all
+  // processed messages within the current batch transaction.
+  uint64 cumulative_gas_used = 7;
+}

--- a/wardenjs/proto/ethermint/types/v1/web3.proto
+++ b/wardenjs/proto/ethermint/types/v1/web3.proto
@@ -1,0 +1,27 @@
+// Copyright Tharsis Labs Ltd.(Evmos)
+// SPDX-License-Identifier:ENCL-1.0(https://github.com/evmos/evmos/blob/main/LICENSE)
+syntax = "proto3";
+package ethermint.types.v1;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/evmos/evmos/v19/types";
+
+// ExtensionOptionsWeb3Tx is an extension option that specifies the typed chain id,
+// the fee payer as well as its signature data.
+message ExtensionOptionsWeb3Tx {
+  option (gogoproto.goproto_getters) = false;
+
+  // typed_data_chain_id is used only in EIP712 Domain and should match
+  // Ethereum network ID in a Web3 provider (e.g. Metamask).
+  uint64 typed_data_chain_id = 1
+      [(gogoproto.jsontag) = "typedDataChainID,omitempty", (gogoproto.customname) = "TypedDataChainID"];
+
+  // fee_payer is an account address for the fee payer. It will be validated
+  // during EIP712 signature checking.
+  string fee_payer = 2 [(gogoproto.jsontag) = "feePayer,omitempty"];
+
+  // fee_payer_sig is a signature data from the fee paying account,
+  // allows to perform fee delegation when using EIP712 Domain.
+  bytes fee_payer_sig = 3 [(gogoproto.jsontag) = "feePayerSig,omitempty"];
+}

--- a/wardenjs/src/codegen/cosmos/bundle.ts
+++ b/wardenjs/src/codegen/cosmos/bundle.ts
@@ -63,75 +63,75 @@ import * as _62 from "./upgrade/v1beta1/tx.js";
 import * as _63 from "./upgrade/v1beta1/upgrade.js";
 import * as _64 from "./vesting/v1beta1/tx.js";
 import * as _65 from "./vesting/v1beta1/vesting.js";
-import * as _118 from "./authz/v1beta1/tx.amino.js";
-import * as _119 from "./bank/v1beta1/tx.amino.js";
-import * as _120 from "./distribution/v1beta1/tx.amino.js";
-import * as _121 from "./feegrant/v1beta1/tx.amino.js";
-import * as _122 from "./gov/v1/tx.amino.js";
-import * as _123 from "./gov/v1beta1/tx.amino.js";
-import * as _124 from "./group/v1/tx.amino.js";
-import * as _125 from "./staking/v1beta1/tx.amino.js";
-import * as _126 from "./upgrade/v1beta1/tx.amino.js";
-import * as _127 from "./vesting/v1beta1/tx.amino.js";
-import * as _128 from "./authz/v1beta1/tx.registry.js";
-import * as _129 from "./bank/v1beta1/tx.registry.js";
-import * as _130 from "./distribution/v1beta1/tx.registry.js";
-import * as _131 from "./feegrant/v1beta1/tx.registry.js";
-import * as _132 from "./gov/v1/tx.registry.js";
-import * as _133 from "./gov/v1beta1/tx.registry.js";
-import * as _134 from "./group/v1/tx.registry.js";
-import * as _135 from "./staking/v1beta1/tx.registry.js";
-import * as _136 from "./upgrade/v1beta1/tx.registry.js";
-import * as _137 from "./vesting/v1beta1/tx.registry.js";
-import * as _138 from "./auth/v1beta1/query.lcd.js";
-import * as _139 from "./authz/v1beta1/query.lcd.js";
-import * as _140 from "./bank/v1beta1/query.lcd.js";
-import * as _141 from "./base/tendermint/v1beta1/query.lcd.js";
-import * as _142 from "./distribution/v1beta1/query.lcd.js";
-import * as _143 from "./feegrant/v1beta1/query.lcd.js";
-import * as _144 from "./gov/v1/query.lcd.js";
-import * as _145 from "./gov/v1beta1/query.lcd.js";
-import * as _146 from "./group/v1/query.lcd.js";
-import * as _147 from "./mint/v1beta1/query.lcd.js";
-import * as _148 from "./params/v1beta1/query.lcd.js";
-import * as _149 from "./staking/v1beta1/query.lcd.js";
-import * as _150 from "./tx/v1beta1/service.lcd.js";
-import * as _151 from "./upgrade/v1beta1/query.lcd.js";
-import * as _152 from "./auth/v1beta1/query.rpc.Query.js";
-import * as _153 from "./authz/v1beta1/query.rpc.Query.js";
-import * as _154 from "./bank/v1beta1/query.rpc.Query.js";
-import * as _155 from "./base/tendermint/v1beta1/query.rpc.Service.js";
-import * as _156 from "./distribution/v1beta1/query.rpc.Query.js";
-import * as _157 from "./feegrant/v1beta1/query.rpc.Query.js";
-import * as _158 from "./gov/v1/query.rpc.Query.js";
-import * as _159 from "./gov/v1beta1/query.rpc.Query.js";
-import * as _160 from "./group/v1/query.rpc.Query.js";
-import * as _161 from "./mint/v1beta1/query.rpc.Query.js";
-import * as _162 from "./params/v1beta1/query.rpc.Query.js";
-import * as _163 from "./staking/v1beta1/query.rpc.Query.js";
-import * as _164 from "./tx/v1beta1/service.rpc.Service.js";
-import * as _165 from "./upgrade/v1beta1/query.rpc.Query.js";
-import * as _166 from "./authz/v1beta1/tx.rpc.msg.js";
-import * as _167 from "./bank/v1beta1/tx.rpc.msg.js";
-import * as _168 from "./distribution/v1beta1/tx.rpc.msg.js";
-import * as _169 from "./feegrant/v1beta1/tx.rpc.msg.js";
-import * as _170 from "./gov/v1/tx.rpc.msg.js";
-import * as _171 from "./gov/v1beta1/tx.rpc.msg.js";
-import * as _172 from "./group/v1/tx.rpc.msg.js";
-import * as _173 from "./staking/v1beta1/tx.rpc.msg.js";
-import * as _174 from "./upgrade/v1beta1/tx.rpc.msg.js";
-import * as _175 from "./vesting/v1beta1/tx.rpc.msg.js";
-import * as _201 from "./lcd.js";
-import * as _202 from "./rpc.query.js";
-import * as _203 from "./rpc.tx.js";
+import * as _132 from "./authz/v1beta1/tx.amino.js";
+import * as _133 from "./bank/v1beta1/tx.amino.js";
+import * as _134 from "./distribution/v1beta1/tx.amino.js";
+import * as _135 from "./feegrant/v1beta1/tx.amino.js";
+import * as _136 from "./gov/v1/tx.amino.js";
+import * as _137 from "./gov/v1beta1/tx.amino.js";
+import * as _138 from "./group/v1/tx.amino.js";
+import * as _139 from "./staking/v1beta1/tx.amino.js";
+import * as _140 from "./upgrade/v1beta1/tx.amino.js";
+import * as _141 from "./vesting/v1beta1/tx.amino.js";
+import * as _142 from "./authz/v1beta1/tx.registry.js";
+import * as _143 from "./bank/v1beta1/tx.registry.js";
+import * as _144 from "./distribution/v1beta1/tx.registry.js";
+import * as _145 from "./feegrant/v1beta1/tx.registry.js";
+import * as _146 from "./gov/v1/tx.registry.js";
+import * as _147 from "./gov/v1beta1/tx.registry.js";
+import * as _148 from "./group/v1/tx.registry.js";
+import * as _149 from "./staking/v1beta1/tx.registry.js";
+import * as _150 from "./upgrade/v1beta1/tx.registry.js";
+import * as _151 from "./vesting/v1beta1/tx.registry.js";
+import * as _152 from "./auth/v1beta1/query.lcd.js";
+import * as _153 from "./authz/v1beta1/query.lcd.js";
+import * as _154 from "./bank/v1beta1/query.lcd.js";
+import * as _155 from "./base/tendermint/v1beta1/query.lcd.js";
+import * as _156 from "./distribution/v1beta1/query.lcd.js";
+import * as _157 from "./feegrant/v1beta1/query.lcd.js";
+import * as _158 from "./gov/v1/query.lcd.js";
+import * as _159 from "./gov/v1beta1/query.lcd.js";
+import * as _160 from "./group/v1/query.lcd.js";
+import * as _161 from "./mint/v1beta1/query.lcd.js";
+import * as _162 from "./params/v1beta1/query.lcd.js";
+import * as _163 from "./staking/v1beta1/query.lcd.js";
+import * as _164 from "./tx/v1beta1/service.lcd.js";
+import * as _165 from "./upgrade/v1beta1/query.lcd.js";
+import * as _166 from "./auth/v1beta1/query.rpc.Query.js";
+import * as _167 from "./authz/v1beta1/query.rpc.Query.js";
+import * as _168 from "./bank/v1beta1/query.rpc.Query.js";
+import * as _169 from "./base/tendermint/v1beta1/query.rpc.Service.js";
+import * as _170 from "./distribution/v1beta1/query.rpc.Query.js";
+import * as _171 from "./feegrant/v1beta1/query.rpc.Query.js";
+import * as _172 from "./gov/v1/query.rpc.Query.js";
+import * as _173 from "./gov/v1beta1/query.rpc.Query.js";
+import * as _174 from "./group/v1/query.rpc.Query.js";
+import * as _175 from "./mint/v1beta1/query.rpc.Query.js";
+import * as _176 from "./params/v1beta1/query.rpc.Query.js";
+import * as _177 from "./staking/v1beta1/query.rpc.Query.js";
+import * as _178 from "./tx/v1beta1/service.rpc.Service.js";
+import * as _179 from "./upgrade/v1beta1/query.rpc.Query.js";
+import * as _180 from "./authz/v1beta1/tx.rpc.msg.js";
+import * as _181 from "./bank/v1beta1/tx.rpc.msg.js";
+import * as _182 from "./distribution/v1beta1/tx.rpc.msg.js";
+import * as _183 from "./feegrant/v1beta1/tx.rpc.msg.js";
+import * as _184 from "./gov/v1/tx.rpc.msg.js";
+import * as _185 from "./gov/v1beta1/tx.rpc.msg.js";
+import * as _186 from "./group/v1/tx.rpc.msg.js";
+import * as _187 from "./staking/v1beta1/tx.rpc.msg.js";
+import * as _188 from "./upgrade/v1beta1/tx.rpc.msg.js";
+import * as _189 from "./vesting/v1beta1/tx.rpc.msg.js";
+import * as _225 from "./lcd.js";
+import * as _226 from "./rpc.query.js";
+import * as _227 from "./rpc.tx.js";
 export namespace cosmos {
   export namespace auth {
     export const v1beta1 = {
       ..._2,
       ..._3,
       ..._4,
-      ..._138,
-      ..._152
+      ..._152,
+      ..._166
     };
   }
   export namespace authz {
@@ -141,11 +141,11 @@ export namespace cosmos {
       ..._7,
       ..._8,
       ..._9,
-      ..._118,
-      ..._128,
-      ..._139,
+      ..._132,
+      ..._142,
       ..._153,
-      ..._166
+      ..._167,
+      ..._180
     };
   }
   export namespace bank {
@@ -155,11 +155,11 @@ export namespace cosmos {
       ..._12,
       ..._13,
       ..._14,
-      ..._119,
-      ..._129,
-      ..._140,
+      ..._133,
+      ..._143,
       ..._154,
-      ..._167
+      ..._168,
+      ..._181
     };
   }
   export namespace base {
@@ -181,8 +181,8 @@ export namespace cosmos {
     export namespace tendermint {
       export const v1beta1 = {
         ..._18,
-        ..._141,
-        ..._155
+        ..._155,
+        ..._169
       };
     }
     export const v1beta1 = {
@@ -219,11 +219,11 @@ export namespace cosmos {
       ..._27,
       ..._28,
       ..._29,
-      ..._120,
-      ..._130,
-      ..._142,
+      ..._134,
+      ..._144,
       ..._156,
-      ..._168
+      ..._170,
+      ..._182
     };
   }
   export namespace feegrant {
@@ -232,11 +232,11 @@ export namespace cosmos {
       ..._31,
       ..._32,
       ..._33,
-      ..._121,
-      ..._131,
-      ..._143,
+      ..._135,
+      ..._145,
       ..._157,
-      ..._169
+      ..._171,
+      ..._183
     };
   }
   export namespace gov {
@@ -250,22 +250,22 @@ export namespace cosmos {
       ..._36,
       ..._37,
       ..._38,
-      ..._122,
-      ..._132,
-      ..._144,
+      ..._136,
+      ..._146,
       ..._158,
-      ..._170
+      ..._172,
+      ..._184
     };
     export const v1beta1 = {
       ..._39,
       ..._40,
       ..._41,
       ..._42,
-      ..._123,
-      ..._133,
-      ..._145,
+      ..._137,
+      ..._147,
       ..._159,
-      ..._171
+      ..._173,
+      ..._185
     };
   }
   export namespace group {
@@ -275,11 +275,11 @@ export namespace cosmos {
       ..._45,
       ..._46,
       ..._47,
-      ..._124,
-      ..._134,
-      ..._146,
+      ..._138,
+      ..._148,
       ..._160,
-      ..._172
+      ..._174,
+      ..._186
     };
   }
   export namespace mint {
@@ -287,16 +287,16 @@ export namespace cosmos {
       ..._48,
       ..._49,
       ..._50,
-      ..._147,
-      ..._161
+      ..._161,
+      ..._175
     };
   }
   export namespace params {
     export const v1beta1 = {
       ..._51,
       ..._52,
-      ..._148,
-      ..._162
+      ..._162,
+      ..._176
     };
   }
   export namespace staking {
@@ -306,11 +306,11 @@ export namespace cosmos {
       ..._55,
       ..._56,
       ..._57,
-      ..._125,
-      ..._135,
+      ..._139,
       ..._149,
       ..._163,
-      ..._173
+      ..._177,
+      ..._187
     };
   }
   export namespace tx {
@@ -322,8 +322,8 @@ export namespace cosmos {
     export const v1beta1 = {
       ..._59,
       ..._60,
-      ..._150,
-      ..._164
+      ..._164,
+      ..._178
     };
   }
   export namespace upgrade {
@@ -331,25 +331,25 @@ export namespace cosmos {
       ..._61,
       ..._62,
       ..._63,
-      ..._126,
-      ..._136,
-      ..._151,
+      ..._140,
+      ..._150,
       ..._165,
-      ..._174
+      ..._179,
+      ..._188
     };
   }
   export namespace vesting {
     export const v1beta1 = {
       ..._64,
       ..._65,
-      ..._127,
-      ..._137,
-      ..._175
+      ..._141,
+      ..._151,
+      ..._189
     };
   }
   export const ClientFactory = {
-    ..._201,
-    ..._202,
-    ..._203
+    ..._225,
+    ..._226,
+    ..._227
   };
 }

--- a/wardenjs/src/codegen/ethermint/bundle.ts
+++ b/wardenjs/src/codegen/ethermint/bundle.ts
@@ -1,0 +1,77 @@
+//@ts-nocheck
+import * as _66 from "./crypto/v1/ethsecp256k1/keys.js";
+import * as _67 from "./evm/v1/events.js";
+import * as _68 from "./evm/v1/evm.js";
+import * as _69 from "./evm/v1/genesis.js";
+import * as _70 from "./evm/v1/query.js";
+import * as _71 from "./evm/v1/tx.js";
+import * as _72 from "./feemarket/v1/events.js";
+import * as _73 from "./feemarket/v1/feemarket.js";
+import * as _74 from "./feemarket/v1/genesis.js";
+import * as _75 from "./feemarket/v1/query.js";
+import * as _76 from "./feemarket/v1/tx.js";
+import * as _77 from "./types/v1/dynamic_fee.js";
+import * as _78 from "./types/v1/indexer.js";
+import * as _79 from "./types/v1/web3.js";
+import * as _190 from "./evm/v1/tx.amino.js";
+import * as _191 from "./feemarket/v1/tx.amino.js";
+import * as _192 from "./evm/v1/tx.registry.js";
+import * as _193 from "./feemarket/v1/tx.registry.js";
+import * as _194 from "./evm/v1/query.lcd.js";
+import * as _195 from "./feemarket/v1/query.lcd.js";
+import * as _196 from "./evm/v1/query.rpc.Query.js";
+import * as _197 from "./feemarket/v1/query.rpc.Query.js";
+import * as _198 from "./evm/v1/tx.rpc.msg.js";
+import * as _199 from "./feemarket/v1/tx.rpc.msg.js";
+import * as _228 from "./lcd.js";
+import * as _229 from "./rpc.query.js";
+import * as _230 from "./rpc.tx.js";
+export namespace ethermint {
+  export namespace crypto {
+    export namespace v1 {
+      export const ethsecp256k1 = {
+        ..._66
+      };
+    }
+  }
+  export namespace evm {
+    export const v1 = {
+      ..._67,
+      ..._68,
+      ..._69,
+      ..._70,
+      ..._71,
+      ..._190,
+      ..._192,
+      ..._194,
+      ..._196,
+      ..._198
+    };
+  }
+  export namespace feemarket {
+    export const v1 = {
+      ..._72,
+      ..._73,
+      ..._74,
+      ..._75,
+      ..._76,
+      ..._191,
+      ..._193,
+      ..._195,
+      ..._197,
+      ..._199
+    };
+  }
+  export namespace types {
+    export const v1 = {
+      ..._77,
+      ..._78,
+      ..._79
+    };
+  }
+  export const ClientFactory = {
+    ..._228,
+    ..._229,
+    ..._230
+  };
+}

--- a/wardenjs/src/codegen/ethermint/client.ts
+++ b/wardenjs/src/codegen/ethermint/client.ts
@@ -1,0 +1,51 @@
+//@ts-nocheck
+import { GeneratedType, Registry, OfflineSigner } from "@cosmjs/proto-signing";
+import { defaultRegistryTypes, AminoTypes, SigningStargateClient } from "@cosmjs/stargate";
+import { HttpEndpoint } from "@cosmjs/tendermint-rpc";
+import * as ethermintEvmV1TxRegistry from "./evm/v1/tx.registry.js";
+import * as ethermintFeemarketV1TxRegistry from "./feemarket/v1/tx.registry.js";
+import * as ethermintEvmV1TxAmino from "./evm/v1/tx.amino.js";
+import * as ethermintFeemarketV1TxAmino from "./feemarket/v1/tx.amino.js";
+export const ethermintAminoConverters = {
+  ...ethermintEvmV1TxAmino.AminoConverter,
+  ...ethermintFeemarketV1TxAmino.AminoConverter
+};
+export const ethermintProtoRegistry: ReadonlyArray<[string, GeneratedType]> = [...ethermintEvmV1TxRegistry.registry, ...ethermintFeemarketV1TxRegistry.registry];
+export const getSigningEthermintClientOptions = ({
+  defaultTypes = defaultRegistryTypes
+}: {
+  defaultTypes?: ReadonlyArray<[string, GeneratedType]>;
+} = {}): {
+  registry: Registry;
+  aminoTypes: AminoTypes;
+} => {
+  const registry = new Registry([...defaultTypes, ...ethermintProtoRegistry]);
+  const aminoTypes = new AminoTypes({
+    ...ethermintAminoConverters
+  });
+  return {
+    registry,
+    aminoTypes
+  };
+};
+export const getSigningEthermintClient = async ({
+  rpcEndpoint,
+  signer,
+  defaultTypes = defaultRegistryTypes
+}: {
+  rpcEndpoint: string | HttpEndpoint;
+  signer: OfflineSigner;
+  defaultTypes?: ReadonlyArray<[string, GeneratedType]>;
+}) => {
+  const {
+    registry,
+    aminoTypes
+  } = getSigningEthermintClientOptions({
+    defaultTypes
+  });
+  const client = await SigningStargateClient.connectWithSigner(rpcEndpoint, signer, {
+    registry: (registry as any),
+    aminoTypes
+  });
+  return client;
+};

--- a/wardenjs/src/codegen/ethermint/crypto/v1/ethsecp256k1/keys.ts
+++ b/wardenjs/src/codegen/ethermint/crypto/v1/ethsecp256k1/keys.ts
@@ -1,0 +1,215 @@
+//@ts-nocheck
+import { BinaryReader, BinaryWriter } from "../../../../binary.js";
+import { isSet, bytesFromBase64, base64FromBytes } from "../../../../helpers.js";
+import { JsonSafe } from "../../../../json-safe.js";
+/**
+ * PubKey defines a type alias for an ecdsa.PublicKey that implements
+ * Tendermint's PubKey interface. It represents the 33-byte compressed public
+ * key format.
+ */
+export interface PubKey {
+  /** key is the public key in byte form */
+  key: Uint8Array;
+}
+export interface PubKeyProtoMsg {
+  typeUrl: "/ethermint.crypto.v1.ethsecp256k1.PubKey";
+  value: Uint8Array;
+}
+/**
+ * PubKey defines a type alias for an ecdsa.PublicKey that implements
+ * Tendermint's PubKey interface. It represents the 33-byte compressed public
+ * key format.
+ */
+export interface PubKeyAmino {
+  /** key is the public key in byte form */
+  key?: string;
+}
+export interface PubKeyAminoMsg {
+  type: "/ethermint.crypto.v1.ethsecp256k1.PubKey";
+  value: PubKeyAmino;
+}
+/**
+ * PubKey defines a type alias for an ecdsa.PublicKey that implements
+ * Tendermint's PubKey interface. It represents the 33-byte compressed public
+ * key format.
+ */
+export interface PubKeySDKType {
+  key: Uint8Array;
+}
+/**
+ * PrivKey defines a type alias for an ecdsa.PrivateKey that implements
+ * Tendermint's PrivateKey interface.
+ */
+export interface PrivKey {
+  /** key is the private key in byte form */
+  key: Uint8Array;
+}
+export interface PrivKeyProtoMsg {
+  typeUrl: "/ethermint.crypto.v1.ethsecp256k1.PrivKey";
+  value: Uint8Array;
+}
+/**
+ * PrivKey defines a type alias for an ecdsa.PrivateKey that implements
+ * Tendermint's PrivateKey interface.
+ */
+export interface PrivKeyAmino {
+  /** key is the private key in byte form */
+  key?: string;
+}
+export interface PrivKeyAminoMsg {
+  type: "/ethermint.crypto.v1.ethsecp256k1.PrivKey";
+  value: PrivKeyAmino;
+}
+/**
+ * PrivKey defines a type alias for an ecdsa.PrivateKey that implements
+ * Tendermint's PrivateKey interface.
+ */
+export interface PrivKeySDKType {
+  key: Uint8Array;
+}
+function createBasePubKey(): PubKey {
+  return {
+    key: new Uint8Array()
+  };
+}
+export const PubKey = {
+  typeUrl: "/ethermint.crypto.v1.ethsecp256k1.PubKey",
+  encode(message: PubKey, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): PubKey {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePubKey();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): PubKey {
+    return {
+      key: isSet(object.key) ? bytesFromBase64(object.key) : new Uint8Array()
+    };
+  },
+  toJSON(message: PubKey): JsonSafe<PubKey> {
+    const obj: any = {};
+    message.key !== undefined && (obj.key = base64FromBytes(message.key !== undefined ? message.key : new Uint8Array()));
+    return obj;
+  },
+  fromPartial(object: Partial<PubKey>): PubKey {
+    const message = createBasePubKey();
+    message.key = object.key ?? new Uint8Array();
+    return message;
+  },
+  fromAmino(object: PubKeyAmino): PubKey {
+    const message = createBasePubKey();
+    if (object.key !== undefined && object.key !== null) {
+      message.key = bytesFromBase64(object.key);
+    }
+    return message;
+  },
+  toAmino(message: PubKey): PubKeyAmino {
+    const obj: any = {};
+    obj.key = message.key ? base64FromBytes(message.key) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: PubKeyAminoMsg): PubKey {
+    return PubKey.fromAmino(object.value);
+  },
+  fromProtoMsg(message: PubKeyProtoMsg): PubKey {
+    return PubKey.decode(message.value);
+  },
+  toProto(message: PubKey): Uint8Array {
+    return PubKey.encode(message).finish();
+  },
+  toProtoMsg(message: PubKey): PubKeyProtoMsg {
+    return {
+      typeUrl: "/ethermint.crypto.v1.ethsecp256k1.PubKey",
+      value: PubKey.encode(message).finish()
+    };
+  }
+};
+function createBasePrivKey(): PrivKey {
+  return {
+    key: new Uint8Array()
+  };
+}
+export const PrivKey = {
+  typeUrl: "/ethermint.crypto.v1.ethsecp256k1.PrivKey",
+  encode(message: PrivKey, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): PrivKey {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePrivKey();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): PrivKey {
+    return {
+      key: isSet(object.key) ? bytesFromBase64(object.key) : new Uint8Array()
+    };
+  },
+  toJSON(message: PrivKey): JsonSafe<PrivKey> {
+    const obj: any = {};
+    message.key !== undefined && (obj.key = base64FromBytes(message.key !== undefined ? message.key : new Uint8Array()));
+    return obj;
+  },
+  fromPartial(object: Partial<PrivKey>): PrivKey {
+    const message = createBasePrivKey();
+    message.key = object.key ?? new Uint8Array();
+    return message;
+  },
+  fromAmino(object: PrivKeyAmino): PrivKey {
+    const message = createBasePrivKey();
+    if (object.key !== undefined && object.key !== null) {
+      message.key = bytesFromBase64(object.key);
+    }
+    return message;
+  },
+  toAmino(message: PrivKey): PrivKeyAmino {
+    const obj: any = {};
+    obj.key = message.key ? base64FromBytes(message.key) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: PrivKeyAminoMsg): PrivKey {
+    return PrivKey.fromAmino(object.value);
+  },
+  fromProtoMsg(message: PrivKeyProtoMsg): PrivKey {
+    return PrivKey.decode(message.value);
+  },
+  toProto(message: PrivKey): Uint8Array {
+    return PrivKey.encode(message).finish();
+  },
+  toProtoMsg(message: PrivKey): PrivKeyProtoMsg {
+    return {
+      typeUrl: "/ethermint.crypto.v1.ethsecp256k1.PrivKey",
+      value: PrivKey.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/evm/v1/events.ts
+++ b/wardenjs/src/codegen/ethermint/evm/v1/events.ts
@@ -1,0 +1,542 @@
+//@ts-nocheck
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** EventEthereumTx defines the event for an Ethereum transaction */
+export interface EventEthereumTx {
+  /** amount */
+  amount: string;
+  /** eth_hash is the Ethereum hash of the transaction */
+  ethHash: string;
+  /** index of the transaction in the block */
+  index: string;
+  /** gas_used is the amount of gas used by the transaction */
+  gasUsed: string;
+  /** hash is the Tendermint hash of the transaction */
+  hash: string;
+  /** recipient of the transaction */
+  recipient: string;
+  /** eth_tx_failed contains a VM error should it occur */
+  ethTxFailed: string;
+}
+export interface EventEthereumTxProtoMsg {
+  typeUrl: "/ethermint.evm.v1.EventEthereumTx";
+  value: Uint8Array;
+}
+/** EventEthereumTx defines the event for an Ethereum transaction */
+export interface EventEthereumTxAmino {
+  /** amount */
+  amount?: string;
+  /** eth_hash is the Ethereum hash of the transaction */
+  eth_hash?: string;
+  /** index of the transaction in the block */
+  index?: string;
+  /** gas_used is the amount of gas used by the transaction */
+  gas_used?: string;
+  /** hash is the Tendermint hash of the transaction */
+  hash?: string;
+  /** recipient of the transaction */
+  recipient?: string;
+  /** eth_tx_failed contains a VM error should it occur */
+  eth_tx_failed?: string;
+}
+export interface EventEthereumTxAminoMsg {
+  type: "/ethermint.evm.v1.EventEthereumTx";
+  value: EventEthereumTxAmino;
+}
+/** EventEthereumTx defines the event for an Ethereum transaction */
+export interface EventEthereumTxSDKType {
+  amount: string;
+  eth_hash: string;
+  index: string;
+  gas_used: string;
+  hash: string;
+  recipient: string;
+  eth_tx_failed: string;
+}
+/** EventTxLog defines the event for an Ethereum transaction log */
+export interface EventTxLog {
+  /** tx_logs is an array of transaction logs */
+  txLogs: string[];
+}
+export interface EventTxLogProtoMsg {
+  typeUrl: "/ethermint.evm.v1.EventTxLog";
+  value: Uint8Array;
+}
+/** EventTxLog defines the event for an Ethereum transaction log */
+export interface EventTxLogAmino {
+  /** tx_logs is an array of transaction logs */
+  tx_logs?: string[];
+}
+export interface EventTxLogAminoMsg {
+  type: "/ethermint.evm.v1.EventTxLog";
+  value: EventTxLogAmino;
+}
+/** EventTxLog defines the event for an Ethereum transaction log */
+export interface EventTxLogSDKType {
+  tx_logs: string[];
+}
+/** EventMessage */
+export interface EventMessage {
+  /** module which emits the event */
+  module: string;
+  /** sender of the message */
+  sender: string;
+  /** tx_type is the type of the message */
+  txType: string;
+}
+export interface EventMessageProtoMsg {
+  typeUrl: "/ethermint.evm.v1.EventMessage";
+  value: Uint8Array;
+}
+/** EventMessage */
+export interface EventMessageAmino {
+  /** module which emits the event */
+  module?: string;
+  /** sender of the message */
+  sender?: string;
+  /** tx_type is the type of the message */
+  tx_type?: string;
+}
+export interface EventMessageAminoMsg {
+  type: "/ethermint.evm.v1.EventMessage";
+  value: EventMessageAmino;
+}
+/** EventMessage */
+export interface EventMessageSDKType {
+  module: string;
+  sender: string;
+  tx_type: string;
+}
+/** EventBlockBloom defines an Ethereum block bloom filter event */
+export interface EventBlockBloom {
+  /** bloom is the bloom filter of the block */
+  bloom: string;
+}
+export interface EventBlockBloomProtoMsg {
+  typeUrl: "/ethermint.evm.v1.EventBlockBloom";
+  value: Uint8Array;
+}
+/** EventBlockBloom defines an Ethereum block bloom filter event */
+export interface EventBlockBloomAmino {
+  /** bloom is the bloom filter of the block */
+  bloom?: string;
+}
+export interface EventBlockBloomAminoMsg {
+  type: "/ethermint.evm.v1.EventBlockBloom";
+  value: EventBlockBloomAmino;
+}
+/** EventBlockBloom defines an Ethereum block bloom filter event */
+export interface EventBlockBloomSDKType {
+  bloom: string;
+}
+function createBaseEventEthereumTx(): EventEthereumTx {
+  return {
+    amount: "",
+    ethHash: "",
+    index: "",
+    gasUsed: "",
+    hash: "",
+    recipient: "",
+    ethTxFailed: ""
+  };
+}
+export const EventEthereumTx = {
+  typeUrl: "/ethermint.evm.v1.EventEthereumTx",
+  encode(message: EventEthereumTx, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.amount !== "") {
+      writer.uint32(10).string(message.amount);
+    }
+    if (message.ethHash !== "") {
+      writer.uint32(18).string(message.ethHash);
+    }
+    if (message.index !== "") {
+      writer.uint32(26).string(message.index);
+    }
+    if (message.gasUsed !== "") {
+      writer.uint32(34).string(message.gasUsed);
+    }
+    if (message.hash !== "") {
+      writer.uint32(42).string(message.hash);
+    }
+    if (message.recipient !== "") {
+      writer.uint32(50).string(message.recipient);
+    }
+    if (message.ethTxFailed !== "") {
+      writer.uint32(58).string(message.ethTxFailed);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EventEthereumTx {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventEthereumTx();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.amount = reader.string();
+          break;
+        case 2:
+          message.ethHash = reader.string();
+          break;
+        case 3:
+          message.index = reader.string();
+          break;
+        case 4:
+          message.gasUsed = reader.string();
+          break;
+        case 5:
+          message.hash = reader.string();
+          break;
+        case 6:
+          message.recipient = reader.string();
+          break;
+        case 7:
+          message.ethTxFailed = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EventEthereumTx {
+    return {
+      amount: isSet(object.amount) ? String(object.amount) : "",
+      ethHash: isSet(object.ethHash) ? String(object.ethHash) : "",
+      index: isSet(object.index) ? String(object.index) : "",
+      gasUsed: isSet(object.gasUsed) ? String(object.gasUsed) : "",
+      hash: isSet(object.hash) ? String(object.hash) : "",
+      recipient: isSet(object.recipient) ? String(object.recipient) : "",
+      ethTxFailed: isSet(object.ethTxFailed) ? String(object.ethTxFailed) : ""
+    };
+  },
+  toJSON(message: EventEthereumTx): JsonSafe<EventEthereumTx> {
+    const obj: any = {};
+    message.amount !== undefined && (obj.amount = message.amount);
+    message.ethHash !== undefined && (obj.ethHash = message.ethHash);
+    message.index !== undefined && (obj.index = message.index);
+    message.gasUsed !== undefined && (obj.gasUsed = message.gasUsed);
+    message.hash !== undefined && (obj.hash = message.hash);
+    message.recipient !== undefined && (obj.recipient = message.recipient);
+    message.ethTxFailed !== undefined && (obj.ethTxFailed = message.ethTxFailed);
+    return obj;
+  },
+  fromPartial(object: Partial<EventEthereumTx>): EventEthereumTx {
+    const message = createBaseEventEthereumTx();
+    message.amount = object.amount ?? "";
+    message.ethHash = object.ethHash ?? "";
+    message.index = object.index ?? "";
+    message.gasUsed = object.gasUsed ?? "";
+    message.hash = object.hash ?? "";
+    message.recipient = object.recipient ?? "";
+    message.ethTxFailed = object.ethTxFailed ?? "";
+    return message;
+  },
+  fromAmino(object: EventEthereumTxAmino): EventEthereumTx {
+    const message = createBaseEventEthereumTx();
+    if (object.amount !== undefined && object.amount !== null) {
+      message.amount = object.amount;
+    }
+    if (object.eth_hash !== undefined && object.eth_hash !== null) {
+      message.ethHash = object.eth_hash;
+    }
+    if (object.index !== undefined && object.index !== null) {
+      message.index = object.index;
+    }
+    if (object.gas_used !== undefined && object.gas_used !== null) {
+      message.gasUsed = object.gas_used;
+    }
+    if (object.hash !== undefined && object.hash !== null) {
+      message.hash = object.hash;
+    }
+    if (object.recipient !== undefined && object.recipient !== null) {
+      message.recipient = object.recipient;
+    }
+    if (object.eth_tx_failed !== undefined && object.eth_tx_failed !== null) {
+      message.ethTxFailed = object.eth_tx_failed;
+    }
+    return message;
+  },
+  toAmino(message: EventEthereumTx): EventEthereumTxAmino {
+    const obj: any = {};
+    obj.amount = message.amount === "" ? undefined : message.amount;
+    obj.eth_hash = message.ethHash === "" ? undefined : message.ethHash;
+    obj.index = message.index === "" ? undefined : message.index;
+    obj.gas_used = message.gasUsed === "" ? undefined : message.gasUsed;
+    obj.hash = message.hash === "" ? undefined : message.hash;
+    obj.recipient = message.recipient === "" ? undefined : message.recipient;
+    obj.eth_tx_failed = message.ethTxFailed === "" ? undefined : message.ethTxFailed;
+    return obj;
+  },
+  fromAminoMsg(object: EventEthereumTxAminoMsg): EventEthereumTx {
+    return EventEthereumTx.fromAmino(object.value);
+  },
+  fromProtoMsg(message: EventEthereumTxProtoMsg): EventEthereumTx {
+    return EventEthereumTx.decode(message.value);
+  },
+  toProto(message: EventEthereumTx): Uint8Array {
+    return EventEthereumTx.encode(message).finish();
+  },
+  toProtoMsg(message: EventEthereumTx): EventEthereumTxProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.EventEthereumTx",
+      value: EventEthereumTx.encode(message).finish()
+    };
+  }
+};
+function createBaseEventTxLog(): EventTxLog {
+  return {
+    txLogs: []
+  };
+}
+export const EventTxLog = {
+  typeUrl: "/ethermint.evm.v1.EventTxLog",
+  encode(message: EventTxLog, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    for (const v of message.txLogs) {
+      writer.uint32(10).string(v!);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EventTxLog {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventTxLog();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.txLogs.push(reader.string());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EventTxLog {
+    return {
+      txLogs: Array.isArray(object?.txLogs) ? object.txLogs.map((e: any) => String(e)) : []
+    };
+  },
+  toJSON(message: EventTxLog): JsonSafe<EventTxLog> {
+    const obj: any = {};
+    if (message.txLogs) {
+      obj.txLogs = message.txLogs.map(e => e);
+    } else {
+      obj.txLogs = [];
+    }
+    return obj;
+  },
+  fromPartial(object: Partial<EventTxLog>): EventTxLog {
+    const message = createBaseEventTxLog();
+    message.txLogs = object.txLogs?.map(e => e) || [];
+    return message;
+  },
+  fromAmino(object: EventTxLogAmino): EventTxLog {
+    const message = createBaseEventTxLog();
+    message.txLogs = object.tx_logs?.map(e => e) || [];
+    return message;
+  },
+  toAmino(message: EventTxLog): EventTxLogAmino {
+    const obj: any = {};
+    if (message.txLogs) {
+      obj.tx_logs = message.txLogs.map(e => e);
+    } else {
+      obj.tx_logs = message.txLogs;
+    }
+    return obj;
+  },
+  fromAminoMsg(object: EventTxLogAminoMsg): EventTxLog {
+    return EventTxLog.fromAmino(object.value);
+  },
+  fromProtoMsg(message: EventTxLogProtoMsg): EventTxLog {
+    return EventTxLog.decode(message.value);
+  },
+  toProto(message: EventTxLog): Uint8Array {
+    return EventTxLog.encode(message).finish();
+  },
+  toProtoMsg(message: EventTxLog): EventTxLogProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.EventTxLog",
+      value: EventTxLog.encode(message).finish()
+    };
+  }
+};
+function createBaseEventMessage(): EventMessage {
+  return {
+    module: "",
+    sender: "",
+    txType: ""
+  };
+}
+export const EventMessage = {
+  typeUrl: "/ethermint.evm.v1.EventMessage",
+  encode(message: EventMessage, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.module !== "") {
+      writer.uint32(10).string(message.module);
+    }
+    if (message.sender !== "") {
+      writer.uint32(18).string(message.sender);
+    }
+    if (message.txType !== "") {
+      writer.uint32(26).string(message.txType);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EventMessage {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventMessage();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.module = reader.string();
+          break;
+        case 2:
+          message.sender = reader.string();
+          break;
+        case 3:
+          message.txType = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EventMessage {
+    return {
+      module: isSet(object.module) ? String(object.module) : "",
+      sender: isSet(object.sender) ? String(object.sender) : "",
+      txType: isSet(object.txType) ? String(object.txType) : ""
+    };
+  },
+  toJSON(message: EventMessage): JsonSafe<EventMessage> {
+    const obj: any = {};
+    message.module !== undefined && (obj.module = message.module);
+    message.sender !== undefined && (obj.sender = message.sender);
+    message.txType !== undefined && (obj.txType = message.txType);
+    return obj;
+  },
+  fromPartial(object: Partial<EventMessage>): EventMessage {
+    const message = createBaseEventMessage();
+    message.module = object.module ?? "";
+    message.sender = object.sender ?? "";
+    message.txType = object.txType ?? "";
+    return message;
+  },
+  fromAmino(object: EventMessageAmino): EventMessage {
+    const message = createBaseEventMessage();
+    if (object.module !== undefined && object.module !== null) {
+      message.module = object.module;
+    }
+    if (object.sender !== undefined && object.sender !== null) {
+      message.sender = object.sender;
+    }
+    if (object.tx_type !== undefined && object.tx_type !== null) {
+      message.txType = object.tx_type;
+    }
+    return message;
+  },
+  toAmino(message: EventMessage): EventMessageAmino {
+    const obj: any = {};
+    obj.module = message.module === "" ? undefined : message.module;
+    obj.sender = message.sender === "" ? undefined : message.sender;
+    obj.tx_type = message.txType === "" ? undefined : message.txType;
+    return obj;
+  },
+  fromAminoMsg(object: EventMessageAminoMsg): EventMessage {
+    return EventMessage.fromAmino(object.value);
+  },
+  fromProtoMsg(message: EventMessageProtoMsg): EventMessage {
+    return EventMessage.decode(message.value);
+  },
+  toProto(message: EventMessage): Uint8Array {
+    return EventMessage.encode(message).finish();
+  },
+  toProtoMsg(message: EventMessage): EventMessageProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.EventMessage",
+      value: EventMessage.encode(message).finish()
+    };
+  }
+};
+function createBaseEventBlockBloom(): EventBlockBloom {
+  return {
+    bloom: ""
+  };
+}
+export const EventBlockBloom = {
+  typeUrl: "/ethermint.evm.v1.EventBlockBloom",
+  encode(message: EventBlockBloom, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.bloom !== "") {
+      writer.uint32(10).string(message.bloom);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EventBlockBloom {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventBlockBloom();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.bloom = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EventBlockBloom {
+    return {
+      bloom: isSet(object.bloom) ? String(object.bloom) : ""
+    };
+  },
+  toJSON(message: EventBlockBloom): JsonSafe<EventBlockBloom> {
+    const obj: any = {};
+    message.bloom !== undefined && (obj.bloom = message.bloom);
+    return obj;
+  },
+  fromPartial(object: Partial<EventBlockBloom>): EventBlockBloom {
+    const message = createBaseEventBlockBloom();
+    message.bloom = object.bloom ?? "";
+    return message;
+  },
+  fromAmino(object: EventBlockBloomAmino): EventBlockBloom {
+    const message = createBaseEventBlockBloom();
+    if (object.bloom !== undefined && object.bloom !== null) {
+      message.bloom = object.bloom;
+    }
+    return message;
+  },
+  toAmino(message: EventBlockBloom): EventBlockBloomAmino {
+    const obj: any = {};
+    obj.bloom = message.bloom === "" ? undefined : message.bloom;
+    return obj;
+  },
+  fromAminoMsg(object: EventBlockBloomAminoMsg): EventBlockBloom {
+    return EventBlockBloom.fromAmino(object.value);
+  },
+  fromProtoMsg(message: EventBlockBloomProtoMsg): EventBlockBloom {
+    return EventBlockBloom.decode(message.value);
+  },
+  toProto(message: EventBlockBloom): Uint8Array {
+    return EventBlockBloom.encode(message).finish();
+  },
+  toProtoMsg(message: EventBlockBloom): EventBlockBloomProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.EventBlockBloom",
+      value: EventBlockBloom.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/evm/v1/evm.ts
+++ b/wardenjs/src/codegen/ethermint/evm/v1/evm.ts
@@ -1,0 +1,2139 @@
+//@ts-nocheck
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet, bytesFromBase64, base64FromBytes } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** AccessType defines the types of permissions for the operations */
+export enum AccessType {
+  /** ACCESS_TYPE_PERMISSIONLESS - ACCESS_TYPE_PERMISSIONLESS does not restrict the operation to anyone */
+  ACCESS_TYPE_PERMISSIONLESS = 0,
+  /** ACCESS_TYPE_RESTRICTED - ACCESS_TYPE_RESTRICTED restrict the operation to anyone */
+  ACCESS_TYPE_RESTRICTED = 1,
+  /** ACCESS_TYPE_PERMISSIONED - ACCESS_TYPE_PERMISSIONED only allows the operation for specific addresses */
+  ACCESS_TYPE_PERMISSIONED = 2,
+  UNRECOGNIZED = -1,
+}
+export const AccessTypeSDKType = AccessType;
+export const AccessTypeAmino = AccessType;
+export function accessTypeFromJSON(object: any): AccessType {
+  switch (object) {
+    case 0:
+    case "ACCESS_TYPE_PERMISSIONLESS":
+      return AccessType.ACCESS_TYPE_PERMISSIONLESS;
+    case 1:
+    case "ACCESS_TYPE_RESTRICTED":
+      return AccessType.ACCESS_TYPE_RESTRICTED;
+    case 2:
+    case "ACCESS_TYPE_PERMISSIONED":
+      return AccessType.ACCESS_TYPE_PERMISSIONED;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return AccessType.UNRECOGNIZED;
+  }
+}
+export function accessTypeToJSON(object: AccessType): string {
+  switch (object) {
+    case AccessType.ACCESS_TYPE_PERMISSIONLESS:
+      return "ACCESS_TYPE_PERMISSIONLESS";
+    case AccessType.ACCESS_TYPE_RESTRICTED:
+      return "ACCESS_TYPE_RESTRICTED";
+    case AccessType.ACCESS_TYPE_PERMISSIONED:
+      return "ACCESS_TYPE_PERMISSIONED";
+    case AccessType.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+/** Params defines the EVM module parameters */
+export interface Params {
+  /**
+   * evm_denom represents the token denomination used to run the EVM state
+   * transitions.
+   */
+  evmDenom: string;
+  /** extra_eips defines the additional EIPs for the vm.Config */
+  extraEips: string[];
+  /** chain_config defines the EVM chain configuration parameters */
+  chainConfig: ChainConfig;
+  /**
+   * allow_unprotected_txs defines if replay-protected (i.e non EIP155
+   * signed) transactions can be executed on the state machine.
+   */
+  allowUnprotectedTxs: boolean;
+  /** evm_channels is the list of channel identifiers from EVM compatible chains */
+  evmChannels: string[];
+  /** access_control defines the permission policy of the EVM */
+  accessControl: AccessControl;
+  /**
+   * active_static_precompiles defines the slice of hex addresses of the precompiled
+   * contracts that are active
+   */
+  activeStaticPrecompiles: string[];
+}
+export interface ParamsProtoMsg {
+  typeUrl: "/ethermint.evm.v1.Params";
+  value: Uint8Array;
+}
+/** Params defines the EVM module parameters */
+export interface ParamsAmino {
+  /**
+   * evm_denom represents the token denomination used to run the EVM state
+   * transitions.
+   */
+  evm_denom?: string;
+  /** extra_eips defines the additional EIPs for the vm.Config */
+  extra_eips?: string[];
+  /** chain_config defines the EVM chain configuration parameters */
+  chain_config?: ChainConfigAmino;
+  /**
+   * allow_unprotected_txs defines if replay-protected (i.e non EIP155
+   * signed) transactions can be executed on the state machine.
+   */
+  allow_unprotected_txs?: boolean;
+  /** evm_channels is the list of channel identifiers from EVM compatible chains */
+  evm_channels?: string[];
+  /** access_control defines the permission policy of the EVM */
+  access_control?: AccessControlAmino;
+  /**
+   * active_static_precompiles defines the slice of hex addresses of the precompiled
+   * contracts that are active
+   */
+  active_static_precompiles?: string[];
+}
+export interface ParamsAminoMsg {
+  type: "/ethermint.evm.v1.Params";
+  value: ParamsAmino;
+}
+/** Params defines the EVM module parameters */
+export interface ParamsSDKType {
+  evm_denom: string;
+  extra_eips: string[];
+  chain_config: ChainConfigSDKType;
+  allow_unprotected_txs: boolean;
+  evm_channels: string[];
+  access_control: AccessControlSDKType;
+  active_static_precompiles: string[];
+}
+/**
+ * AccessControl defines the permission policy of the EVM
+ * for creating and calling contracts
+ */
+export interface AccessControl {
+  /** create defines the permission policy for creating contracts */
+  create: AccessControlType;
+  /** call defines the permission policy for calling contracts */
+  call: AccessControlType;
+}
+export interface AccessControlProtoMsg {
+  typeUrl: "/ethermint.evm.v1.AccessControl";
+  value: Uint8Array;
+}
+/**
+ * AccessControl defines the permission policy of the EVM
+ * for creating and calling contracts
+ */
+export interface AccessControlAmino {
+  /** create defines the permission policy for creating contracts */
+  create?: AccessControlTypeAmino;
+  /** call defines the permission policy for calling contracts */
+  call?: AccessControlTypeAmino;
+}
+export interface AccessControlAminoMsg {
+  type: "/ethermint.evm.v1.AccessControl";
+  value: AccessControlAmino;
+}
+/**
+ * AccessControl defines the permission policy of the EVM
+ * for creating and calling contracts
+ */
+export interface AccessControlSDKType {
+  create: AccessControlTypeSDKType;
+  call: AccessControlTypeSDKType;
+}
+/** AccessControlType defines the permission type for policies */
+export interface AccessControlType {
+  /** access_type defines which type of permission is required for the operation */
+  accessType: AccessType;
+  /**
+   * access_control_list defines defines different things depending on the AccessType:
+   * - ACCESS_TYPE_PERMISSIONLESS: list of addresses that are blocked from performing the operation
+   * - ACCESS_TYPE_RESTRICTED: ignored
+   * - ACCESS_TYPE_PERMISSIONED: list of addresses that are allowed to perform the operation
+   */
+  accessControlList: string[];
+}
+export interface AccessControlTypeProtoMsg {
+  typeUrl: "/ethermint.evm.v1.AccessControlType";
+  value: Uint8Array;
+}
+/** AccessControlType defines the permission type for policies */
+export interface AccessControlTypeAmino {
+  /** access_type defines which type of permission is required for the operation */
+  access_type?: AccessType;
+  /**
+   * access_control_list defines defines different things depending on the AccessType:
+   * - ACCESS_TYPE_PERMISSIONLESS: list of addresses that are blocked from performing the operation
+   * - ACCESS_TYPE_RESTRICTED: ignored
+   * - ACCESS_TYPE_PERMISSIONED: list of addresses that are allowed to perform the operation
+   */
+  access_control_list?: string[];
+}
+export interface AccessControlTypeAminoMsg {
+  type: "/ethermint.evm.v1.AccessControlType";
+  value: AccessControlTypeAmino;
+}
+/** AccessControlType defines the permission type for policies */
+export interface AccessControlTypeSDKType {
+  access_type: AccessType;
+  access_control_list: string[];
+}
+/**
+ * ChainConfig defines the Ethereum ChainConfig parameters using *sdk.Int values
+ * instead of *big.Int.
+ */
+export interface ChainConfig {
+  /** homestead_block switch (nil no fork, 0 = already homestead) */
+  homesteadBlock: string;
+  /** dao_fork_block corresponds to TheDAO hard-fork switch block (nil no fork) */
+  daoForkBlock: string;
+  /** dao_fork_support defines whether the nodes supports or opposes the DAO hard-fork */
+  daoForkSupport: boolean;
+  /**
+   * eip150_block: EIP150 implements the Gas price changes
+   * (https://github.com/ethereum/EIPs/issues/150) EIP150 HF block (nil no fork)
+   */
+  eip150Block: string;
+  /** eip150_hash: EIP150 HF hash (needed for header only clients as only gas pricing changed) */
+  eip150Hash: string;
+  /** eip155_block: EIP155Block HF block */
+  eip155Block: string;
+  /** eip158_block: EIP158 HF block */
+  eip158Block: string;
+  /** byzantium_block: Byzantium switch block (nil no fork, 0 = already on byzantium) */
+  byzantiumBlock: string;
+  /** constantinople_block: Constantinople switch block (nil no fork, 0 = already activated) */
+  constantinopleBlock: string;
+  /** petersburg_block: Petersburg switch block (nil same as Constantinople) */
+  petersburgBlock: string;
+  /** istanbul_block: Istanbul switch block (nil no fork, 0 = already on istanbul) */
+  istanbulBlock: string;
+  /** muir_glacier_block: Eip-2384 (bomb delay) switch block (nil no fork, 0 = already activated) */
+  muirGlacierBlock: string;
+  /** berlin_block: Berlin switch block (nil = no fork, 0 = already on berlin) */
+  berlinBlock: string;
+  /** london_block: London switch block (nil = no fork, 0 = already on london) */
+  londonBlock: string;
+  /** arrow_glacier_block: Eip-4345 (bomb delay) switch block (nil = no fork, 0 = already activated) */
+  arrowGlacierBlock: string;
+  /** gray_glacier_block: EIP-5133 (bomb delay) switch block (nil = no fork, 0 = already activated) */
+  grayGlacierBlock: string;
+  /** merge_netsplit_block: Virtual fork after The Merge to use as a network splitter */
+  mergeNetsplitBlock: string;
+  /** shanghai_block switch block (nil = no fork, 0 = already on shanghai) */
+  shanghaiBlock: string;
+  /** cancun_block switch block (nil = no fork, 0 = already on cancun) */
+  cancunBlock: string;
+}
+export interface ChainConfigProtoMsg {
+  typeUrl: "/ethermint.evm.v1.ChainConfig";
+  value: Uint8Array;
+}
+/**
+ * ChainConfig defines the Ethereum ChainConfig parameters using *sdk.Int values
+ * instead of *big.Int.
+ */
+export interface ChainConfigAmino {
+  /** homestead_block switch (nil no fork, 0 = already homestead) */
+  homestead_block?: string;
+  /** dao_fork_block corresponds to TheDAO hard-fork switch block (nil no fork) */
+  dao_fork_block?: string;
+  /** dao_fork_support defines whether the nodes supports or opposes the DAO hard-fork */
+  dao_fork_support?: boolean;
+  /**
+   * eip150_block: EIP150 implements the Gas price changes
+   * (https://github.com/ethereum/EIPs/issues/150) EIP150 HF block (nil no fork)
+   */
+  eip150_block?: string;
+  /** eip150_hash: EIP150 HF hash (needed for header only clients as only gas pricing changed) */
+  eip150_hash?: string;
+  /** eip155_block: EIP155Block HF block */
+  eip155_block?: string;
+  /** eip158_block: EIP158 HF block */
+  eip158_block?: string;
+  /** byzantium_block: Byzantium switch block (nil no fork, 0 = already on byzantium) */
+  byzantium_block?: string;
+  /** constantinople_block: Constantinople switch block (nil no fork, 0 = already activated) */
+  constantinople_block?: string;
+  /** petersburg_block: Petersburg switch block (nil same as Constantinople) */
+  petersburg_block?: string;
+  /** istanbul_block: Istanbul switch block (nil no fork, 0 = already on istanbul) */
+  istanbul_block?: string;
+  /** muir_glacier_block: Eip-2384 (bomb delay) switch block (nil no fork, 0 = already activated) */
+  muir_glacier_block?: string;
+  /** berlin_block: Berlin switch block (nil = no fork, 0 = already on berlin) */
+  berlin_block?: string;
+  /** london_block: London switch block (nil = no fork, 0 = already on london) */
+  london_block?: string;
+  /** arrow_glacier_block: Eip-4345 (bomb delay) switch block (nil = no fork, 0 = already activated) */
+  arrow_glacier_block?: string;
+  /** gray_glacier_block: EIP-5133 (bomb delay) switch block (nil = no fork, 0 = already activated) */
+  gray_glacier_block?: string;
+  /** merge_netsplit_block: Virtual fork after The Merge to use as a network splitter */
+  merge_netsplit_block?: string;
+  /** shanghai_block switch block (nil = no fork, 0 = already on shanghai) */
+  shanghai_block?: string;
+  /** cancun_block switch block (nil = no fork, 0 = already on cancun) */
+  cancun_block?: string;
+}
+export interface ChainConfigAminoMsg {
+  type: "/ethermint.evm.v1.ChainConfig";
+  value: ChainConfigAmino;
+}
+/**
+ * ChainConfig defines the Ethereum ChainConfig parameters using *sdk.Int values
+ * instead of *big.Int.
+ */
+export interface ChainConfigSDKType {
+  homestead_block: string;
+  dao_fork_block: string;
+  dao_fork_support: boolean;
+  eip150_block: string;
+  eip150_hash: string;
+  eip155_block: string;
+  eip158_block: string;
+  byzantium_block: string;
+  constantinople_block: string;
+  petersburg_block: string;
+  istanbul_block: string;
+  muir_glacier_block: string;
+  berlin_block: string;
+  london_block: string;
+  arrow_glacier_block: string;
+  gray_glacier_block: string;
+  merge_netsplit_block: string;
+  shanghai_block: string;
+  cancun_block: string;
+}
+/** State represents a single Storage key value pair item. */
+export interface State {
+  /** key is the stored key */
+  key: string;
+  /** value is the stored value for the given key */
+  value: string;
+}
+export interface StateProtoMsg {
+  typeUrl: "/ethermint.evm.v1.State";
+  value: Uint8Array;
+}
+/** State represents a single Storage key value pair item. */
+export interface StateAmino {
+  /** key is the stored key */
+  key?: string;
+  /** value is the stored value for the given key */
+  value?: string;
+}
+export interface StateAminoMsg {
+  type: "/ethermint.evm.v1.State";
+  value: StateAmino;
+}
+/** State represents a single Storage key value pair item. */
+export interface StateSDKType {
+  key: string;
+  value: string;
+}
+/**
+ * TransactionLogs define the logs generated from a transaction execution
+ * with a given hash. It it used for import/export data as transactions are not
+ * persisted on blockchain state after an upgrade.
+ */
+export interface TransactionLogs {
+  /** hash of the transaction */
+  hash: string;
+  /** logs is an array of Logs for the given transaction hash */
+  logs: Log[];
+}
+export interface TransactionLogsProtoMsg {
+  typeUrl: "/ethermint.evm.v1.TransactionLogs";
+  value: Uint8Array;
+}
+/**
+ * TransactionLogs define the logs generated from a transaction execution
+ * with a given hash. It it used for import/export data as transactions are not
+ * persisted on blockchain state after an upgrade.
+ */
+export interface TransactionLogsAmino {
+  /** hash of the transaction */
+  hash?: string;
+  /** logs is an array of Logs for the given transaction hash */
+  logs?: LogAmino[];
+}
+export interface TransactionLogsAminoMsg {
+  type: "/ethermint.evm.v1.TransactionLogs";
+  value: TransactionLogsAmino;
+}
+/**
+ * TransactionLogs define the logs generated from a transaction execution
+ * with a given hash. It it used for import/export data as transactions are not
+ * persisted on blockchain state after an upgrade.
+ */
+export interface TransactionLogsSDKType {
+  hash: string;
+  logs: LogSDKType[];
+}
+/**
+ * Log represents an protobuf compatible Ethereum Log that defines a contract
+ * log event. These events are generated by the LOG opcode and stored/indexed by
+ * the node.
+ * 
+ * NOTE: address, topics and data are consensus fields. The rest of the fields
+ * are derived, i.e. filled in by the nodes, but not secured by consensus.
+ */
+export interface Log {
+  /** address of the contract that generated the event */
+  address: string;
+  /** topics is a list of topics provided by the contract. */
+  topics: string[];
+  /** data which is supplied by the contract, usually ABI-encoded */
+  data: Uint8Array;
+  /** block_number of the block in which the transaction was included */
+  blockNumber: bigint;
+  /** tx_hash is the transaction hash */
+  txHash: string;
+  /** tx_index of the transaction in the block */
+  txIndex: bigint;
+  /** block_hash of the block in which the transaction was included */
+  blockHash: string;
+  /** index of the log in the block */
+  index: bigint;
+  /**
+   * removed is true if this log was reverted due to a chain
+   * reorganisation. You must pay attention to this field if you receive logs
+   * through a filter query.
+   */
+  removed: boolean;
+}
+export interface LogProtoMsg {
+  typeUrl: "/ethermint.evm.v1.Log";
+  value: Uint8Array;
+}
+/**
+ * Log represents an protobuf compatible Ethereum Log that defines a contract
+ * log event. These events are generated by the LOG opcode and stored/indexed by
+ * the node.
+ * 
+ * NOTE: address, topics and data are consensus fields. The rest of the fields
+ * are derived, i.e. filled in by the nodes, but not secured by consensus.
+ */
+export interface LogAmino {
+  /** address of the contract that generated the event */
+  address?: string;
+  /** topics is a list of topics provided by the contract. */
+  topics?: string[];
+  /** data which is supplied by the contract, usually ABI-encoded */
+  data?: string;
+  /** block_number of the block in which the transaction was included */
+  block_number: string;
+  /** tx_hash is the transaction hash */
+  tx_hash: string;
+  /** tx_index of the transaction in the block */
+  tx_index: string;
+  /** block_hash of the block in which the transaction was included */
+  block_hash: string;
+  /** index of the log in the block */
+  index: string;
+  /**
+   * removed is true if this log was reverted due to a chain
+   * reorganisation. You must pay attention to this field if you receive logs
+   * through a filter query.
+   */
+  removed?: boolean;
+}
+export interface LogAminoMsg {
+  type: "/ethermint.evm.v1.Log";
+  value: LogAmino;
+}
+/**
+ * Log represents an protobuf compatible Ethereum Log that defines a contract
+ * log event. These events are generated by the LOG opcode and stored/indexed by
+ * the node.
+ * 
+ * NOTE: address, topics and data are consensus fields. The rest of the fields
+ * are derived, i.e. filled in by the nodes, but not secured by consensus.
+ */
+export interface LogSDKType {
+  address: string;
+  topics: string[];
+  data: Uint8Array;
+  block_number: bigint;
+  tx_hash: string;
+  tx_index: bigint;
+  block_hash: string;
+  index: bigint;
+  removed: boolean;
+}
+/** TxResult stores results of Tx execution. */
+export interface TxResult {
+  /**
+   * contract_address contains the ethereum address of the created contract (if
+   * any). If the state transition is an evm.Call, the contract address will be
+   * empty.
+   */
+  contractAddress: string;
+  /** bloom represents the bloom filter bytes */
+  bloom: Uint8Array;
+  /**
+   * tx_logs contains the transaction hash and the proto-compatible ethereum
+   * logs.
+   */
+  txLogs: TransactionLogs;
+  /** ret defines the bytes from the execution. */
+  ret: Uint8Array;
+  /** reverted flag is set to true when the call has been reverted */
+  reverted: boolean;
+  /** gas_used notes the amount of gas consumed while execution */
+  gasUsed: bigint;
+}
+export interface TxResultProtoMsg {
+  typeUrl: "/ethermint.evm.v1.TxResult";
+  value: Uint8Array;
+}
+/** TxResult stores results of Tx execution. */
+export interface TxResultAmino {
+  /**
+   * contract_address contains the ethereum address of the created contract (if
+   * any). If the state transition is an evm.Call, the contract address will be
+   * empty.
+   */
+  contract_address?: string;
+  /** bloom represents the bloom filter bytes */
+  bloom?: string;
+  /**
+   * tx_logs contains the transaction hash and the proto-compatible ethereum
+   * logs.
+   */
+  tx_logs?: TransactionLogsAmino;
+  /** ret defines the bytes from the execution. */
+  ret?: string;
+  /** reverted flag is set to true when the call has been reverted */
+  reverted?: boolean;
+  /** gas_used notes the amount of gas consumed while execution */
+  gas_used?: string;
+}
+export interface TxResultAminoMsg {
+  type: "/ethermint.evm.v1.TxResult";
+  value: TxResultAmino;
+}
+/** TxResult stores results of Tx execution. */
+export interface TxResultSDKType {
+  contract_address: string;
+  bloom: Uint8Array;
+  tx_logs: TransactionLogsSDKType;
+  ret: Uint8Array;
+  reverted: boolean;
+  gas_used: bigint;
+}
+/** AccessTuple is the element type of an access list. */
+export interface AccessTuple {
+  /** address is a hex formatted ethereum address */
+  address: string;
+  /** storage_keys are hex formatted hashes of the storage keys */
+  storageKeys: string[];
+}
+export interface AccessTupleProtoMsg {
+  typeUrl: "/ethermint.evm.v1.AccessTuple";
+  value: Uint8Array;
+}
+/** AccessTuple is the element type of an access list. */
+export interface AccessTupleAmino {
+  /** address is a hex formatted ethereum address */
+  address?: string;
+  /** storage_keys are hex formatted hashes of the storage keys */
+  storage_keys: string[];
+}
+export interface AccessTupleAminoMsg {
+  type: "/ethermint.evm.v1.AccessTuple";
+  value: AccessTupleAmino;
+}
+/** AccessTuple is the element type of an access list. */
+export interface AccessTupleSDKType {
+  address: string;
+  storage_keys: string[];
+}
+/** TraceConfig holds extra parameters to trace functions. */
+export interface TraceConfig {
+  /** tracer is a custom javascript tracer */
+  tracer: string;
+  /**
+   * timeout overrides the default timeout of 5 seconds for JavaScript-based tracing
+   * calls
+   */
+  timeout: string;
+  /** reexec defines the number of blocks the tracer is willing to go back */
+  reexec: bigint;
+  /** disable_stack switches stack capture */
+  disableStack: boolean;
+  /** disable_storage switches storage capture */
+  disableStorage: boolean;
+  /** debug can be used to print output during capture end */
+  debug: boolean;
+  /** limit defines the maximum length of output, but zero means unlimited */
+  limit: number;
+  /** overrides can be used to execute a trace using future fork rules */
+  overrides?: ChainConfig;
+  /** enable_memory switches memory capture */
+  enableMemory: boolean;
+  /** enable_return_data switches the capture of return data */
+  enableReturnData: boolean;
+  /** tracer_json_config configures the tracer using a JSON string */
+  tracerJsonConfig: string;
+}
+export interface TraceConfigProtoMsg {
+  typeUrl: "/ethermint.evm.v1.TraceConfig";
+  value: Uint8Array;
+}
+/** TraceConfig holds extra parameters to trace functions. */
+export interface TraceConfigAmino {
+  /** tracer is a custom javascript tracer */
+  tracer?: string;
+  /**
+   * timeout overrides the default timeout of 5 seconds for JavaScript-based tracing
+   * calls
+   */
+  timeout?: string;
+  /** reexec defines the number of blocks the tracer is willing to go back */
+  reexec?: string;
+  /** disable_stack switches stack capture */
+  disable_stack: boolean;
+  /** disable_storage switches storage capture */
+  disable_storage: boolean;
+  /** debug can be used to print output during capture end */
+  debug?: boolean;
+  /** limit defines the maximum length of output, but zero means unlimited */
+  limit?: number;
+  /** overrides can be used to execute a trace using future fork rules */
+  overrides?: ChainConfigAmino;
+  /** enable_memory switches memory capture */
+  enable_memory: boolean;
+  /** enable_return_data switches the capture of return data */
+  enable_return_data: boolean;
+  /** tracer_json_config configures the tracer using a JSON string */
+  tracer_json_config: string;
+}
+export interface TraceConfigAminoMsg {
+  type: "/ethermint.evm.v1.TraceConfig";
+  value: TraceConfigAmino;
+}
+/** TraceConfig holds extra parameters to trace functions. */
+export interface TraceConfigSDKType {
+  tracer: string;
+  timeout: string;
+  reexec: bigint;
+  disable_stack: boolean;
+  disable_storage: boolean;
+  debug: boolean;
+  limit: number;
+  overrides?: ChainConfigSDKType;
+  enable_memory: boolean;
+  enable_return_data: boolean;
+  tracer_json_config: string;
+}
+function createBaseParams(): Params {
+  return {
+    evmDenom: "",
+    extraEips: [],
+    chainConfig: ChainConfig.fromPartial({}),
+    allowUnprotectedTxs: false,
+    evmChannels: [],
+    accessControl: AccessControl.fromPartial({}),
+    activeStaticPrecompiles: []
+  };
+}
+export const Params = {
+  typeUrl: "/ethermint.evm.v1.Params",
+  encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.evmDenom !== "") {
+      writer.uint32(10).string(message.evmDenom);
+    }
+    for (const v of message.extraEips) {
+      writer.uint32(34).string(v!);
+    }
+    if (message.chainConfig !== undefined) {
+      ChainConfig.encode(message.chainConfig, writer.uint32(42).fork()).ldelim();
+    }
+    if (message.allowUnprotectedTxs === true) {
+      writer.uint32(48).bool(message.allowUnprotectedTxs);
+    }
+    for (const v of message.evmChannels) {
+      writer.uint32(66).string(v!);
+    }
+    if (message.accessControl !== undefined) {
+      AccessControl.encode(message.accessControl, writer.uint32(74).fork()).ldelim();
+    }
+    for (const v of message.activeStaticPrecompiles) {
+      writer.uint32(82).string(v!);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): Params {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseParams();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.evmDenom = reader.string();
+          break;
+        case 4:
+          message.extraEips.push(reader.string());
+          break;
+        case 5:
+          message.chainConfig = ChainConfig.decode(reader, reader.uint32());
+          break;
+        case 6:
+          message.allowUnprotectedTxs = reader.bool();
+          break;
+        case 8:
+          message.evmChannels.push(reader.string());
+          break;
+        case 9:
+          message.accessControl = AccessControl.decode(reader, reader.uint32());
+          break;
+        case 10:
+          message.activeStaticPrecompiles.push(reader.string());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): Params {
+    return {
+      evmDenom: isSet(object.evmDenom) ? String(object.evmDenom) : "",
+      extraEips: Array.isArray(object?.extraEips) ? object.extraEips.map((e: any) => String(e)) : [],
+      chainConfig: isSet(object.chainConfig) ? ChainConfig.fromJSON(object.chainConfig) : undefined,
+      allowUnprotectedTxs: isSet(object.allowUnprotectedTxs) ? Boolean(object.allowUnprotectedTxs) : false,
+      evmChannels: Array.isArray(object?.evmChannels) ? object.evmChannels.map((e: any) => String(e)) : [],
+      accessControl: isSet(object.accessControl) ? AccessControl.fromJSON(object.accessControl) : undefined,
+      activeStaticPrecompiles: Array.isArray(object?.activeStaticPrecompiles) ? object.activeStaticPrecompiles.map((e: any) => String(e)) : []
+    };
+  },
+  toJSON(message: Params): JsonSafe<Params> {
+    const obj: any = {};
+    message.evmDenom !== undefined && (obj.evmDenom = message.evmDenom);
+    if (message.extraEips) {
+      obj.extraEips = message.extraEips.map(e => e);
+    } else {
+      obj.extraEips = [];
+    }
+    message.chainConfig !== undefined && (obj.chainConfig = message.chainConfig ? ChainConfig.toJSON(message.chainConfig) : undefined);
+    message.allowUnprotectedTxs !== undefined && (obj.allowUnprotectedTxs = message.allowUnprotectedTxs);
+    if (message.evmChannels) {
+      obj.evmChannels = message.evmChannels.map(e => e);
+    } else {
+      obj.evmChannels = [];
+    }
+    message.accessControl !== undefined && (obj.accessControl = message.accessControl ? AccessControl.toJSON(message.accessControl) : undefined);
+    if (message.activeStaticPrecompiles) {
+      obj.activeStaticPrecompiles = message.activeStaticPrecompiles.map(e => e);
+    } else {
+      obj.activeStaticPrecompiles = [];
+    }
+    return obj;
+  },
+  fromPartial(object: Partial<Params>): Params {
+    const message = createBaseParams();
+    message.evmDenom = object.evmDenom ?? "";
+    message.extraEips = object.extraEips?.map(e => e) || [];
+    message.chainConfig = object.chainConfig !== undefined && object.chainConfig !== null ? ChainConfig.fromPartial(object.chainConfig) : undefined;
+    message.allowUnprotectedTxs = object.allowUnprotectedTxs ?? false;
+    message.evmChannels = object.evmChannels?.map(e => e) || [];
+    message.accessControl = object.accessControl !== undefined && object.accessControl !== null ? AccessControl.fromPartial(object.accessControl) : undefined;
+    message.activeStaticPrecompiles = object.activeStaticPrecompiles?.map(e => e) || [];
+    return message;
+  },
+  fromAmino(object: ParamsAmino): Params {
+    const message = createBaseParams();
+    if (object.evm_denom !== undefined && object.evm_denom !== null) {
+      message.evmDenom = object.evm_denom;
+    }
+    message.extraEips = object.extra_eips?.map(e => e) || [];
+    if (object.chain_config !== undefined && object.chain_config !== null) {
+      message.chainConfig = ChainConfig.fromAmino(object.chain_config);
+    }
+    if (object.allow_unprotected_txs !== undefined && object.allow_unprotected_txs !== null) {
+      message.allowUnprotectedTxs = object.allow_unprotected_txs;
+    }
+    message.evmChannels = object.evm_channels?.map(e => e) || [];
+    if (object.access_control !== undefined && object.access_control !== null) {
+      message.accessControl = AccessControl.fromAmino(object.access_control);
+    }
+    message.activeStaticPrecompiles = object.active_static_precompiles?.map(e => e) || [];
+    return message;
+  },
+  toAmino(message: Params): ParamsAmino {
+    const obj: any = {};
+    obj.evm_denom = message.evmDenom === "" ? undefined : message.evmDenom;
+    if (message.extraEips) {
+      obj.extra_eips = message.extraEips.map(e => e);
+    } else {
+      obj.extra_eips = message.extraEips;
+    }
+    obj.chain_config = message.chainConfig ? ChainConfig.toAmino(message.chainConfig) : undefined;
+    obj.allow_unprotected_txs = message.allowUnprotectedTxs === false ? undefined : message.allowUnprotectedTxs;
+    if (message.evmChannels) {
+      obj.evm_channels = message.evmChannels.map(e => e);
+    } else {
+      obj.evm_channels = message.evmChannels;
+    }
+    obj.access_control = message.accessControl ? AccessControl.toAmino(message.accessControl) : undefined;
+    if (message.activeStaticPrecompiles) {
+      obj.active_static_precompiles = message.activeStaticPrecompiles.map(e => e);
+    } else {
+      obj.active_static_precompiles = message.activeStaticPrecompiles;
+    }
+    return obj;
+  },
+  fromAminoMsg(object: ParamsAminoMsg): Params {
+    return Params.fromAmino(object.value);
+  },
+  fromProtoMsg(message: ParamsProtoMsg): Params {
+    return Params.decode(message.value);
+  },
+  toProto(message: Params): Uint8Array {
+    return Params.encode(message).finish();
+  },
+  toProtoMsg(message: Params): ParamsProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.Params",
+      value: Params.encode(message).finish()
+    };
+  }
+};
+function createBaseAccessControl(): AccessControl {
+  return {
+    create: AccessControlType.fromPartial({}),
+    call: AccessControlType.fromPartial({})
+  };
+}
+export const AccessControl = {
+  typeUrl: "/ethermint.evm.v1.AccessControl",
+  encode(message: AccessControl, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.create !== undefined) {
+      AccessControlType.encode(message.create, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.call !== undefined) {
+      AccessControlType.encode(message.call, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): AccessControl {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAccessControl();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.create = AccessControlType.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.call = AccessControlType.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): AccessControl {
+    return {
+      create: isSet(object.create) ? AccessControlType.fromJSON(object.create) : undefined,
+      call: isSet(object.call) ? AccessControlType.fromJSON(object.call) : undefined
+    };
+  },
+  toJSON(message: AccessControl): JsonSafe<AccessControl> {
+    const obj: any = {};
+    message.create !== undefined && (obj.create = message.create ? AccessControlType.toJSON(message.create) : undefined);
+    message.call !== undefined && (obj.call = message.call ? AccessControlType.toJSON(message.call) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<AccessControl>): AccessControl {
+    const message = createBaseAccessControl();
+    message.create = object.create !== undefined && object.create !== null ? AccessControlType.fromPartial(object.create) : undefined;
+    message.call = object.call !== undefined && object.call !== null ? AccessControlType.fromPartial(object.call) : undefined;
+    return message;
+  },
+  fromAmino(object: AccessControlAmino): AccessControl {
+    const message = createBaseAccessControl();
+    if (object.create !== undefined && object.create !== null) {
+      message.create = AccessControlType.fromAmino(object.create);
+    }
+    if (object.call !== undefined && object.call !== null) {
+      message.call = AccessControlType.fromAmino(object.call);
+    }
+    return message;
+  },
+  toAmino(message: AccessControl): AccessControlAmino {
+    const obj: any = {};
+    obj.create = message.create ? AccessControlType.toAmino(message.create) : undefined;
+    obj.call = message.call ? AccessControlType.toAmino(message.call) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: AccessControlAminoMsg): AccessControl {
+    return AccessControl.fromAmino(object.value);
+  },
+  fromProtoMsg(message: AccessControlProtoMsg): AccessControl {
+    return AccessControl.decode(message.value);
+  },
+  toProto(message: AccessControl): Uint8Array {
+    return AccessControl.encode(message).finish();
+  },
+  toProtoMsg(message: AccessControl): AccessControlProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.AccessControl",
+      value: AccessControl.encode(message).finish()
+    };
+  }
+};
+function createBaseAccessControlType(): AccessControlType {
+  return {
+    accessType: 0,
+    accessControlList: []
+  };
+}
+export const AccessControlType = {
+  typeUrl: "/ethermint.evm.v1.AccessControlType",
+  encode(message: AccessControlType, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.accessType !== 0) {
+      writer.uint32(8).int32(message.accessType);
+    }
+    for (const v of message.accessControlList) {
+      writer.uint32(18).string(v!);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): AccessControlType {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAccessControlType();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.accessType = (reader.int32() as any);
+          break;
+        case 2:
+          message.accessControlList.push(reader.string());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): AccessControlType {
+    return {
+      accessType: isSet(object.accessType) ? accessTypeFromJSON(object.accessType) : -1,
+      accessControlList: Array.isArray(object?.accessControlList) ? object.accessControlList.map((e: any) => String(e)) : []
+    };
+  },
+  toJSON(message: AccessControlType): JsonSafe<AccessControlType> {
+    const obj: any = {};
+    message.accessType !== undefined && (obj.accessType = accessTypeToJSON(message.accessType));
+    if (message.accessControlList) {
+      obj.accessControlList = message.accessControlList.map(e => e);
+    } else {
+      obj.accessControlList = [];
+    }
+    return obj;
+  },
+  fromPartial(object: Partial<AccessControlType>): AccessControlType {
+    const message = createBaseAccessControlType();
+    message.accessType = object.accessType ?? 0;
+    message.accessControlList = object.accessControlList?.map(e => e) || [];
+    return message;
+  },
+  fromAmino(object: AccessControlTypeAmino): AccessControlType {
+    const message = createBaseAccessControlType();
+    if (object.access_type !== undefined && object.access_type !== null) {
+      message.accessType = object.access_type;
+    }
+    message.accessControlList = object.access_control_list?.map(e => e) || [];
+    return message;
+  },
+  toAmino(message: AccessControlType): AccessControlTypeAmino {
+    const obj: any = {};
+    obj.access_type = message.accessType === 0 ? undefined : message.accessType;
+    if (message.accessControlList) {
+      obj.access_control_list = message.accessControlList.map(e => e);
+    } else {
+      obj.access_control_list = message.accessControlList;
+    }
+    return obj;
+  },
+  fromAminoMsg(object: AccessControlTypeAminoMsg): AccessControlType {
+    return AccessControlType.fromAmino(object.value);
+  },
+  fromProtoMsg(message: AccessControlTypeProtoMsg): AccessControlType {
+    return AccessControlType.decode(message.value);
+  },
+  toProto(message: AccessControlType): Uint8Array {
+    return AccessControlType.encode(message).finish();
+  },
+  toProtoMsg(message: AccessControlType): AccessControlTypeProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.AccessControlType",
+      value: AccessControlType.encode(message).finish()
+    };
+  }
+};
+function createBaseChainConfig(): ChainConfig {
+  return {
+    homesteadBlock: "",
+    daoForkBlock: "",
+    daoForkSupport: false,
+    eip150Block: "",
+    eip150Hash: "",
+    eip155Block: "",
+    eip158Block: "",
+    byzantiumBlock: "",
+    constantinopleBlock: "",
+    petersburgBlock: "",
+    istanbulBlock: "",
+    muirGlacierBlock: "",
+    berlinBlock: "",
+    londonBlock: "",
+    arrowGlacierBlock: "",
+    grayGlacierBlock: "",
+    mergeNetsplitBlock: "",
+    shanghaiBlock: "",
+    cancunBlock: ""
+  };
+}
+export const ChainConfig = {
+  typeUrl: "/ethermint.evm.v1.ChainConfig",
+  encode(message: ChainConfig, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.homesteadBlock !== "") {
+      writer.uint32(10).string(message.homesteadBlock);
+    }
+    if (message.daoForkBlock !== "") {
+      writer.uint32(18).string(message.daoForkBlock);
+    }
+    if (message.daoForkSupport === true) {
+      writer.uint32(24).bool(message.daoForkSupport);
+    }
+    if (message.eip150Block !== "") {
+      writer.uint32(34).string(message.eip150Block);
+    }
+    if (message.eip150Hash !== "") {
+      writer.uint32(42).string(message.eip150Hash);
+    }
+    if (message.eip155Block !== "") {
+      writer.uint32(50).string(message.eip155Block);
+    }
+    if (message.eip158Block !== "") {
+      writer.uint32(58).string(message.eip158Block);
+    }
+    if (message.byzantiumBlock !== "") {
+      writer.uint32(66).string(message.byzantiumBlock);
+    }
+    if (message.constantinopleBlock !== "") {
+      writer.uint32(74).string(message.constantinopleBlock);
+    }
+    if (message.petersburgBlock !== "") {
+      writer.uint32(82).string(message.petersburgBlock);
+    }
+    if (message.istanbulBlock !== "") {
+      writer.uint32(90).string(message.istanbulBlock);
+    }
+    if (message.muirGlacierBlock !== "") {
+      writer.uint32(98).string(message.muirGlacierBlock);
+    }
+    if (message.berlinBlock !== "") {
+      writer.uint32(106).string(message.berlinBlock);
+    }
+    if (message.londonBlock !== "") {
+      writer.uint32(138).string(message.londonBlock);
+    }
+    if (message.arrowGlacierBlock !== "") {
+      writer.uint32(146).string(message.arrowGlacierBlock);
+    }
+    if (message.grayGlacierBlock !== "") {
+      writer.uint32(162).string(message.grayGlacierBlock);
+    }
+    if (message.mergeNetsplitBlock !== "") {
+      writer.uint32(170).string(message.mergeNetsplitBlock);
+    }
+    if (message.shanghaiBlock !== "") {
+      writer.uint32(178).string(message.shanghaiBlock);
+    }
+    if (message.cancunBlock !== "") {
+      writer.uint32(186).string(message.cancunBlock);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): ChainConfig {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseChainConfig();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.homesteadBlock = reader.string();
+          break;
+        case 2:
+          message.daoForkBlock = reader.string();
+          break;
+        case 3:
+          message.daoForkSupport = reader.bool();
+          break;
+        case 4:
+          message.eip150Block = reader.string();
+          break;
+        case 5:
+          message.eip150Hash = reader.string();
+          break;
+        case 6:
+          message.eip155Block = reader.string();
+          break;
+        case 7:
+          message.eip158Block = reader.string();
+          break;
+        case 8:
+          message.byzantiumBlock = reader.string();
+          break;
+        case 9:
+          message.constantinopleBlock = reader.string();
+          break;
+        case 10:
+          message.petersburgBlock = reader.string();
+          break;
+        case 11:
+          message.istanbulBlock = reader.string();
+          break;
+        case 12:
+          message.muirGlacierBlock = reader.string();
+          break;
+        case 13:
+          message.berlinBlock = reader.string();
+          break;
+        case 17:
+          message.londonBlock = reader.string();
+          break;
+        case 18:
+          message.arrowGlacierBlock = reader.string();
+          break;
+        case 20:
+          message.grayGlacierBlock = reader.string();
+          break;
+        case 21:
+          message.mergeNetsplitBlock = reader.string();
+          break;
+        case 22:
+          message.shanghaiBlock = reader.string();
+          break;
+        case 23:
+          message.cancunBlock = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): ChainConfig {
+    return {
+      homesteadBlock: isSet(object.homesteadBlock) ? String(object.homesteadBlock) : "",
+      daoForkBlock: isSet(object.daoForkBlock) ? String(object.daoForkBlock) : "",
+      daoForkSupport: isSet(object.daoForkSupport) ? Boolean(object.daoForkSupport) : false,
+      eip150Block: isSet(object.eip150Block) ? String(object.eip150Block) : "",
+      eip150Hash: isSet(object.eip150Hash) ? String(object.eip150Hash) : "",
+      eip155Block: isSet(object.eip155Block) ? String(object.eip155Block) : "",
+      eip158Block: isSet(object.eip158Block) ? String(object.eip158Block) : "",
+      byzantiumBlock: isSet(object.byzantiumBlock) ? String(object.byzantiumBlock) : "",
+      constantinopleBlock: isSet(object.constantinopleBlock) ? String(object.constantinopleBlock) : "",
+      petersburgBlock: isSet(object.petersburgBlock) ? String(object.petersburgBlock) : "",
+      istanbulBlock: isSet(object.istanbulBlock) ? String(object.istanbulBlock) : "",
+      muirGlacierBlock: isSet(object.muirGlacierBlock) ? String(object.muirGlacierBlock) : "",
+      berlinBlock: isSet(object.berlinBlock) ? String(object.berlinBlock) : "",
+      londonBlock: isSet(object.londonBlock) ? String(object.londonBlock) : "",
+      arrowGlacierBlock: isSet(object.arrowGlacierBlock) ? String(object.arrowGlacierBlock) : "",
+      grayGlacierBlock: isSet(object.grayGlacierBlock) ? String(object.grayGlacierBlock) : "",
+      mergeNetsplitBlock: isSet(object.mergeNetsplitBlock) ? String(object.mergeNetsplitBlock) : "",
+      shanghaiBlock: isSet(object.shanghaiBlock) ? String(object.shanghaiBlock) : "",
+      cancunBlock: isSet(object.cancunBlock) ? String(object.cancunBlock) : ""
+    };
+  },
+  toJSON(message: ChainConfig): JsonSafe<ChainConfig> {
+    const obj: any = {};
+    message.homesteadBlock !== undefined && (obj.homesteadBlock = message.homesteadBlock);
+    message.daoForkBlock !== undefined && (obj.daoForkBlock = message.daoForkBlock);
+    message.daoForkSupport !== undefined && (obj.daoForkSupport = message.daoForkSupport);
+    message.eip150Block !== undefined && (obj.eip150Block = message.eip150Block);
+    message.eip150Hash !== undefined && (obj.eip150Hash = message.eip150Hash);
+    message.eip155Block !== undefined && (obj.eip155Block = message.eip155Block);
+    message.eip158Block !== undefined && (obj.eip158Block = message.eip158Block);
+    message.byzantiumBlock !== undefined && (obj.byzantiumBlock = message.byzantiumBlock);
+    message.constantinopleBlock !== undefined && (obj.constantinopleBlock = message.constantinopleBlock);
+    message.petersburgBlock !== undefined && (obj.petersburgBlock = message.petersburgBlock);
+    message.istanbulBlock !== undefined && (obj.istanbulBlock = message.istanbulBlock);
+    message.muirGlacierBlock !== undefined && (obj.muirGlacierBlock = message.muirGlacierBlock);
+    message.berlinBlock !== undefined && (obj.berlinBlock = message.berlinBlock);
+    message.londonBlock !== undefined && (obj.londonBlock = message.londonBlock);
+    message.arrowGlacierBlock !== undefined && (obj.arrowGlacierBlock = message.arrowGlacierBlock);
+    message.grayGlacierBlock !== undefined && (obj.grayGlacierBlock = message.grayGlacierBlock);
+    message.mergeNetsplitBlock !== undefined && (obj.mergeNetsplitBlock = message.mergeNetsplitBlock);
+    message.shanghaiBlock !== undefined && (obj.shanghaiBlock = message.shanghaiBlock);
+    message.cancunBlock !== undefined && (obj.cancunBlock = message.cancunBlock);
+    return obj;
+  },
+  fromPartial(object: Partial<ChainConfig>): ChainConfig {
+    const message = createBaseChainConfig();
+    message.homesteadBlock = object.homesteadBlock ?? "";
+    message.daoForkBlock = object.daoForkBlock ?? "";
+    message.daoForkSupport = object.daoForkSupport ?? false;
+    message.eip150Block = object.eip150Block ?? "";
+    message.eip150Hash = object.eip150Hash ?? "";
+    message.eip155Block = object.eip155Block ?? "";
+    message.eip158Block = object.eip158Block ?? "";
+    message.byzantiumBlock = object.byzantiumBlock ?? "";
+    message.constantinopleBlock = object.constantinopleBlock ?? "";
+    message.petersburgBlock = object.petersburgBlock ?? "";
+    message.istanbulBlock = object.istanbulBlock ?? "";
+    message.muirGlacierBlock = object.muirGlacierBlock ?? "";
+    message.berlinBlock = object.berlinBlock ?? "";
+    message.londonBlock = object.londonBlock ?? "";
+    message.arrowGlacierBlock = object.arrowGlacierBlock ?? "";
+    message.grayGlacierBlock = object.grayGlacierBlock ?? "";
+    message.mergeNetsplitBlock = object.mergeNetsplitBlock ?? "";
+    message.shanghaiBlock = object.shanghaiBlock ?? "";
+    message.cancunBlock = object.cancunBlock ?? "";
+    return message;
+  },
+  fromAmino(object: ChainConfigAmino): ChainConfig {
+    const message = createBaseChainConfig();
+    if (object.homestead_block !== undefined && object.homestead_block !== null) {
+      message.homesteadBlock = object.homestead_block;
+    }
+    if (object.dao_fork_block !== undefined && object.dao_fork_block !== null) {
+      message.daoForkBlock = object.dao_fork_block;
+    }
+    if (object.dao_fork_support !== undefined && object.dao_fork_support !== null) {
+      message.daoForkSupport = object.dao_fork_support;
+    }
+    if (object.eip150_block !== undefined && object.eip150_block !== null) {
+      message.eip150Block = object.eip150_block;
+    }
+    if (object.eip150_hash !== undefined && object.eip150_hash !== null) {
+      message.eip150Hash = object.eip150_hash;
+    }
+    if (object.eip155_block !== undefined && object.eip155_block !== null) {
+      message.eip155Block = object.eip155_block;
+    }
+    if (object.eip158_block !== undefined && object.eip158_block !== null) {
+      message.eip158Block = object.eip158_block;
+    }
+    if (object.byzantium_block !== undefined && object.byzantium_block !== null) {
+      message.byzantiumBlock = object.byzantium_block;
+    }
+    if (object.constantinople_block !== undefined && object.constantinople_block !== null) {
+      message.constantinopleBlock = object.constantinople_block;
+    }
+    if (object.petersburg_block !== undefined && object.petersburg_block !== null) {
+      message.petersburgBlock = object.petersburg_block;
+    }
+    if (object.istanbul_block !== undefined && object.istanbul_block !== null) {
+      message.istanbulBlock = object.istanbul_block;
+    }
+    if (object.muir_glacier_block !== undefined && object.muir_glacier_block !== null) {
+      message.muirGlacierBlock = object.muir_glacier_block;
+    }
+    if (object.berlin_block !== undefined && object.berlin_block !== null) {
+      message.berlinBlock = object.berlin_block;
+    }
+    if (object.london_block !== undefined && object.london_block !== null) {
+      message.londonBlock = object.london_block;
+    }
+    if (object.arrow_glacier_block !== undefined && object.arrow_glacier_block !== null) {
+      message.arrowGlacierBlock = object.arrow_glacier_block;
+    }
+    if (object.gray_glacier_block !== undefined && object.gray_glacier_block !== null) {
+      message.grayGlacierBlock = object.gray_glacier_block;
+    }
+    if (object.merge_netsplit_block !== undefined && object.merge_netsplit_block !== null) {
+      message.mergeNetsplitBlock = object.merge_netsplit_block;
+    }
+    if (object.shanghai_block !== undefined && object.shanghai_block !== null) {
+      message.shanghaiBlock = object.shanghai_block;
+    }
+    if (object.cancun_block !== undefined && object.cancun_block !== null) {
+      message.cancunBlock = object.cancun_block;
+    }
+    return message;
+  },
+  toAmino(message: ChainConfig): ChainConfigAmino {
+    const obj: any = {};
+    obj.homestead_block = message.homesteadBlock === "" ? undefined : message.homesteadBlock;
+    obj.dao_fork_block = message.daoForkBlock === "" ? undefined : message.daoForkBlock;
+    obj.dao_fork_support = message.daoForkSupport === false ? undefined : message.daoForkSupport;
+    obj.eip150_block = message.eip150Block === "" ? undefined : message.eip150Block;
+    obj.eip150_hash = message.eip150Hash === "" ? undefined : message.eip150Hash;
+    obj.eip155_block = message.eip155Block === "" ? undefined : message.eip155Block;
+    obj.eip158_block = message.eip158Block === "" ? undefined : message.eip158Block;
+    obj.byzantium_block = message.byzantiumBlock === "" ? undefined : message.byzantiumBlock;
+    obj.constantinople_block = message.constantinopleBlock === "" ? undefined : message.constantinopleBlock;
+    obj.petersburg_block = message.petersburgBlock === "" ? undefined : message.petersburgBlock;
+    obj.istanbul_block = message.istanbulBlock === "" ? undefined : message.istanbulBlock;
+    obj.muir_glacier_block = message.muirGlacierBlock === "" ? undefined : message.muirGlacierBlock;
+    obj.berlin_block = message.berlinBlock === "" ? undefined : message.berlinBlock;
+    obj.london_block = message.londonBlock === "" ? undefined : message.londonBlock;
+    obj.arrow_glacier_block = message.arrowGlacierBlock === "" ? undefined : message.arrowGlacierBlock;
+    obj.gray_glacier_block = message.grayGlacierBlock === "" ? undefined : message.grayGlacierBlock;
+    obj.merge_netsplit_block = message.mergeNetsplitBlock === "" ? undefined : message.mergeNetsplitBlock;
+    obj.shanghai_block = message.shanghaiBlock === "" ? undefined : message.shanghaiBlock;
+    obj.cancun_block = message.cancunBlock === "" ? undefined : message.cancunBlock;
+    return obj;
+  },
+  fromAminoMsg(object: ChainConfigAminoMsg): ChainConfig {
+    return ChainConfig.fromAmino(object.value);
+  },
+  fromProtoMsg(message: ChainConfigProtoMsg): ChainConfig {
+    return ChainConfig.decode(message.value);
+  },
+  toProto(message: ChainConfig): Uint8Array {
+    return ChainConfig.encode(message).finish();
+  },
+  toProtoMsg(message: ChainConfig): ChainConfigProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.ChainConfig",
+      value: ChainConfig.encode(message).finish()
+    };
+  }
+};
+function createBaseState(): State {
+  return {
+    key: "",
+    value: ""
+  };
+}
+export const State = {
+  typeUrl: "/ethermint.evm.v1.State",
+  encode(message: State, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== "") {
+      writer.uint32(18).string(message.value);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): State {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseState();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.string();
+          break;
+        case 2:
+          message.value = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): State {
+    return {
+      key: isSet(object.key) ? String(object.key) : "",
+      value: isSet(object.value) ? String(object.value) : ""
+    };
+  },
+  toJSON(message: State): JsonSafe<State> {
+    const obj: any = {};
+    message.key !== undefined && (obj.key = message.key);
+    message.value !== undefined && (obj.value = message.value);
+    return obj;
+  },
+  fromPartial(object: Partial<State>): State {
+    const message = createBaseState();
+    message.key = object.key ?? "";
+    message.value = object.value ?? "";
+    return message;
+  },
+  fromAmino(object: StateAmino): State {
+    const message = createBaseState();
+    if (object.key !== undefined && object.key !== null) {
+      message.key = object.key;
+    }
+    if (object.value !== undefined && object.value !== null) {
+      message.value = object.value;
+    }
+    return message;
+  },
+  toAmino(message: State): StateAmino {
+    const obj: any = {};
+    obj.key = message.key === "" ? undefined : message.key;
+    obj.value = message.value === "" ? undefined : message.value;
+    return obj;
+  },
+  fromAminoMsg(object: StateAminoMsg): State {
+    return State.fromAmino(object.value);
+  },
+  fromProtoMsg(message: StateProtoMsg): State {
+    return State.decode(message.value);
+  },
+  toProto(message: State): Uint8Array {
+    return State.encode(message).finish();
+  },
+  toProtoMsg(message: State): StateProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.State",
+      value: State.encode(message).finish()
+    };
+  }
+};
+function createBaseTransactionLogs(): TransactionLogs {
+  return {
+    hash: "",
+    logs: []
+  };
+}
+export const TransactionLogs = {
+  typeUrl: "/ethermint.evm.v1.TransactionLogs",
+  encode(message: TransactionLogs, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.hash !== "") {
+      writer.uint32(10).string(message.hash);
+    }
+    for (const v of message.logs) {
+      Log.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): TransactionLogs {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTransactionLogs();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.hash = reader.string();
+          break;
+        case 2:
+          message.logs.push(Log.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): TransactionLogs {
+    return {
+      hash: isSet(object.hash) ? String(object.hash) : "",
+      logs: Array.isArray(object?.logs) ? object.logs.map((e: any) => Log.fromJSON(e)) : []
+    };
+  },
+  toJSON(message: TransactionLogs): JsonSafe<TransactionLogs> {
+    const obj: any = {};
+    message.hash !== undefined && (obj.hash = message.hash);
+    if (message.logs) {
+      obj.logs = message.logs.map(e => e ? Log.toJSON(e) : undefined);
+    } else {
+      obj.logs = [];
+    }
+    return obj;
+  },
+  fromPartial(object: Partial<TransactionLogs>): TransactionLogs {
+    const message = createBaseTransactionLogs();
+    message.hash = object.hash ?? "";
+    message.logs = object.logs?.map(e => Log.fromPartial(e)) || [];
+    return message;
+  },
+  fromAmino(object: TransactionLogsAmino): TransactionLogs {
+    const message = createBaseTransactionLogs();
+    if (object.hash !== undefined && object.hash !== null) {
+      message.hash = object.hash;
+    }
+    message.logs = object.logs?.map(e => Log.fromAmino(e)) || [];
+    return message;
+  },
+  toAmino(message: TransactionLogs): TransactionLogsAmino {
+    const obj: any = {};
+    obj.hash = message.hash === "" ? undefined : message.hash;
+    if (message.logs) {
+      obj.logs = message.logs.map(e => e ? Log.toAmino(e) : undefined);
+    } else {
+      obj.logs = message.logs;
+    }
+    return obj;
+  },
+  fromAminoMsg(object: TransactionLogsAminoMsg): TransactionLogs {
+    return TransactionLogs.fromAmino(object.value);
+  },
+  fromProtoMsg(message: TransactionLogsProtoMsg): TransactionLogs {
+    return TransactionLogs.decode(message.value);
+  },
+  toProto(message: TransactionLogs): Uint8Array {
+    return TransactionLogs.encode(message).finish();
+  },
+  toProtoMsg(message: TransactionLogs): TransactionLogsProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.TransactionLogs",
+      value: TransactionLogs.encode(message).finish()
+    };
+  }
+};
+function createBaseLog(): Log {
+  return {
+    address: "",
+    topics: [],
+    data: new Uint8Array(),
+    blockNumber: BigInt(0),
+    txHash: "",
+    txIndex: BigInt(0),
+    blockHash: "",
+    index: BigInt(0),
+    removed: false
+  };
+}
+export const Log = {
+  typeUrl: "/ethermint.evm.v1.Log",
+  encode(message: Log, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    for (const v of message.topics) {
+      writer.uint32(18).string(v!);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(26).bytes(message.data);
+    }
+    if (message.blockNumber !== BigInt(0)) {
+      writer.uint32(32).uint64(message.blockNumber);
+    }
+    if (message.txHash !== "") {
+      writer.uint32(42).string(message.txHash);
+    }
+    if (message.txIndex !== BigInt(0)) {
+      writer.uint32(48).uint64(message.txIndex);
+    }
+    if (message.blockHash !== "") {
+      writer.uint32(58).string(message.blockHash);
+    }
+    if (message.index !== BigInt(0)) {
+      writer.uint32(64).uint64(message.index);
+    }
+    if (message.removed === true) {
+      writer.uint32(72).bool(message.removed);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): Log {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLog();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        case 2:
+          message.topics.push(reader.string());
+          break;
+        case 3:
+          message.data = reader.bytes();
+          break;
+        case 4:
+          message.blockNumber = reader.uint64();
+          break;
+        case 5:
+          message.txHash = reader.string();
+          break;
+        case 6:
+          message.txIndex = reader.uint64();
+          break;
+        case 7:
+          message.blockHash = reader.string();
+          break;
+        case 8:
+          message.index = reader.uint64();
+          break;
+        case 9:
+          message.removed = reader.bool();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): Log {
+    return {
+      address: isSet(object.address) ? String(object.address) : "",
+      topics: Array.isArray(object?.topics) ? object.topics.map((e: any) => String(e)) : [],
+      data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(),
+      blockNumber: isSet(object.blockNumber) ? BigInt(object.blockNumber.toString()) : BigInt(0),
+      txHash: isSet(object.txHash) ? String(object.txHash) : "",
+      txIndex: isSet(object.txIndex) ? BigInt(object.txIndex.toString()) : BigInt(0),
+      blockHash: isSet(object.blockHash) ? String(object.blockHash) : "",
+      index: isSet(object.index) ? BigInt(object.index.toString()) : BigInt(0),
+      removed: isSet(object.removed) ? Boolean(object.removed) : false
+    };
+  },
+  toJSON(message: Log): JsonSafe<Log> {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    if (message.topics) {
+      obj.topics = message.topics.map(e => e);
+    } else {
+      obj.topics = [];
+    }
+    message.data !== undefined && (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+    message.blockNumber !== undefined && (obj.blockNumber = (message.blockNumber || BigInt(0)).toString());
+    message.txHash !== undefined && (obj.txHash = message.txHash);
+    message.txIndex !== undefined && (obj.txIndex = (message.txIndex || BigInt(0)).toString());
+    message.blockHash !== undefined && (obj.blockHash = message.blockHash);
+    message.index !== undefined && (obj.index = (message.index || BigInt(0)).toString());
+    message.removed !== undefined && (obj.removed = message.removed);
+    return obj;
+  },
+  fromPartial(object: Partial<Log>): Log {
+    const message = createBaseLog();
+    message.address = object.address ?? "";
+    message.topics = object.topics?.map(e => e) || [];
+    message.data = object.data ?? new Uint8Array();
+    message.blockNumber = object.blockNumber !== undefined && object.blockNumber !== null ? BigInt(object.blockNumber.toString()) : BigInt(0);
+    message.txHash = object.txHash ?? "";
+    message.txIndex = object.txIndex !== undefined && object.txIndex !== null ? BigInt(object.txIndex.toString()) : BigInt(0);
+    message.blockHash = object.blockHash ?? "";
+    message.index = object.index !== undefined && object.index !== null ? BigInt(object.index.toString()) : BigInt(0);
+    message.removed = object.removed ?? false;
+    return message;
+  },
+  fromAmino(object: LogAmino): Log {
+    const message = createBaseLog();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    }
+    message.topics = object.topics?.map(e => e) || [];
+    if (object.data !== undefined && object.data !== null) {
+      message.data = bytesFromBase64(object.data);
+    }
+    if (object.block_number !== undefined && object.block_number !== null) {
+      message.blockNumber = BigInt(object.block_number);
+    }
+    if (object.tx_hash !== undefined && object.tx_hash !== null) {
+      message.txHash = object.tx_hash;
+    }
+    if (object.tx_index !== undefined && object.tx_index !== null) {
+      message.txIndex = BigInt(object.tx_index);
+    }
+    if (object.block_hash !== undefined && object.block_hash !== null) {
+      message.blockHash = object.block_hash;
+    }
+    if (object.index !== undefined && object.index !== null) {
+      message.index = BigInt(object.index);
+    }
+    if (object.removed !== undefined && object.removed !== null) {
+      message.removed = object.removed;
+    }
+    return message;
+  },
+  toAmino(message: Log): LogAmino {
+    const obj: any = {};
+    obj.address = message.address === "" ? undefined : message.address;
+    if (message.topics) {
+      obj.topics = message.topics.map(e => e);
+    } else {
+      obj.topics = message.topics;
+    }
+    obj.data = message.data ? base64FromBytes(message.data) : undefined;
+    obj.block_number = message.blockNumber ? message.blockNumber.toString() : "0";
+    obj.tx_hash = message.txHash ?? "";
+    obj.tx_index = message.txIndex ? message.txIndex.toString() : "0";
+    obj.block_hash = message.blockHash ?? "";
+    obj.index = message.index ? message.index.toString() : "0";
+    obj.removed = message.removed === false ? undefined : message.removed;
+    return obj;
+  },
+  fromAminoMsg(object: LogAminoMsg): Log {
+    return Log.fromAmino(object.value);
+  },
+  fromProtoMsg(message: LogProtoMsg): Log {
+    return Log.decode(message.value);
+  },
+  toProto(message: Log): Uint8Array {
+    return Log.encode(message).finish();
+  },
+  toProtoMsg(message: Log): LogProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.Log",
+      value: Log.encode(message).finish()
+    };
+  }
+};
+function createBaseTxResult(): TxResult {
+  return {
+    contractAddress: "",
+    bloom: new Uint8Array(),
+    txLogs: TransactionLogs.fromPartial({}),
+    ret: new Uint8Array(),
+    reverted: false,
+    gasUsed: BigInt(0)
+  };
+}
+export const TxResult = {
+  typeUrl: "/ethermint.evm.v1.TxResult",
+  encode(message: TxResult, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.contractAddress !== "") {
+      writer.uint32(10).string(message.contractAddress);
+    }
+    if (message.bloom.length !== 0) {
+      writer.uint32(18).bytes(message.bloom);
+    }
+    if (message.txLogs !== undefined) {
+      TransactionLogs.encode(message.txLogs, writer.uint32(26).fork()).ldelim();
+    }
+    if (message.ret.length !== 0) {
+      writer.uint32(34).bytes(message.ret);
+    }
+    if (message.reverted === true) {
+      writer.uint32(40).bool(message.reverted);
+    }
+    if (message.gasUsed !== BigInt(0)) {
+      writer.uint32(48).uint64(message.gasUsed);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): TxResult {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTxResult();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.contractAddress = reader.string();
+          break;
+        case 2:
+          message.bloom = reader.bytes();
+          break;
+        case 3:
+          message.txLogs = TransactionLogs.decode(reader, reader.uint32());
+          break;
+        case 4:
+          message.ret = reader.bytes();
+          break;
+        case 5:
+          message.reverted = reader.bool();
+          break;
+        case 6:
+          message.gasUsed = reader.uint64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): TxResult {
+    return {
+      contractAddress: isSet(object.contractAddress) ? String(object.contractAddress) : "",
+      bloom: isSet(object.bloom) ? bytesFromBase64(object.bloom) : new Uint8Array(),
+      txLogs: isSet(object.txLogs) ? TransactionLogs.fromJSON(object.txLogs) : undefined,
+      ret: isSet(object.ret) ? bytesFromBase64(object.ret) : new Uint8Array(),
+      reverted: isSet(object.reverted) ? Boolean(object.reverted) : false,
+      gasUsed: isSet(object.gasUsed) ? BigInt(object.gasUsed.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: TxResult): JsonSafe<TxResult> {
+    const obj: any = {};
+    message.contractAddress !== undefined && (obj.contractAddress = message.contractAddress);
+    message.bloom !== undefined && (obj.bloom = base64FromBytes(message.bloom !== undefined ? message.bloom : new Uint8Array()));
+    message.txLogs !== undefined && (obj.txLogs = message.txLogs ? TransactionLogs.toJSON(message.txLogs) : undefined);
+    message.ret !== undefined && (obj.ret = base64FromBytes(message.ret !== undefined ? message.ret : new Uint8Array()));
+    message.reverted !== undefined && (obj.reverted = message.reverted);
+    message.gasUsed !== undefined && (obj.gasUsed = (message.gasUsed || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<TxResult>): TxResult {
+    const message = createBaseTxResult();
+    message.contractAddress = object.contractAddress ?? "";
+    message.bloom = object.bloom ?? new Uint8Array();
+    message.txLogs = object.txLogs !== undefined && object.txLogs !== null ? TransactionLogs.fromPartial(object.txLogs) : undefined;
+    message.ret = object.ret ?? new Uint8Array();
+    message.reverted = object.reverted ?? false;
+    message.gasUsed = object.gasUsed !== undefined && object.gasUsed !== null ? BigInt(object.gasUsed.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: TxResultAmino): TxResult {
+    const message = createBaseTxResult();
+    if (object.contract_address !== undefined && object.contract_address !== null) {
+      message.contractAddress = object.contract_address;
+    }
+    if (object.bloom !== undefined && object.bloom !== null) {
+      message.bloom = bytesFromBase64(object.bloom);
+    }
+    if (object.tx_logs !== undefined && object.tx_logs !== null) {
+      message.txLogs = TransactionLogs.fromAmino(object.tx_logs);
+    }
+    if (object.ret !== undefined && object.ret !== null) {
+      message.ret = bytesFromBase64(object.ret);
+    }
+    if (object.reverted !== undefined && object.reverted !== null) {
+      message.reverted = object.reverted;
+    }
+    if (object.gas_used !== undefined && object.gas_used !== null) {
+      message.gasUsed = BigInt(object.gas_used);
+    }
+    return message;
+  },
+  toAmino(message: TxResult): TxResultAmino {
+    const obj: any = {};
+    obj.contract_address = message.contractAddress === "" ? undefined : message.contractAddress;
+    obj.bloom = message.bloom ? base64FromBytes(message.bloom) : undefined;
+    obj.tx_logs = message.txLogs ? TransactionLogs.toAmino(message.txLogs) : undefined;
+    obj.ret = message.ret ? base64FromBytes(message.ret) : undefined;
+    obj.reverted = message.reverted === false ? undefined : message.reverted;
+    obj.gas_used = message.gasUsed !== BigInt(0) ? message.gasUsed.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: TxResultAminoMsg): TxResult {
+    return TxResult.fromAmino(object.value);
+  },
+  fromProtoMsg(message: TxResultProtoMsg): TxResult {
+    return TxResult.decode(message.value);
+  },
+  toProto(message: TxResult): Uint8Array {
+    return TxResult.encode(message).finish();
+  },
+  toProtoMsg(message: TxResult): TxResultProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.TxResult",
+      value: TxResult.encode(message).finish()
+    };
+  }
+};
+function createBaseAccessTuple(): AccessTuple {
+  return {
+    address: "",
+    storageKeys: []
+  };
+}
+export const AccessTuple = {
+  typeUrl: "/ethermint.evm.v1.AccessTuple",
+  encode(message: AccessTuple, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    for (const v of message.storageKeys) {
+      writer.uint32(18).string(v!);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): AccessTuple {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAccessTuple();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        case 2:
+          message.storageKeys.push(reader.string());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): AccessTuple {
+    return {
+      address: isSet(object.address) ? String(object.address) : "",
+      storageKeys: Array.isArray(object?.storageKeys) ? object.storageKeys.map((e: any) => String(e)) : []
+    };
+  },
+  toJSON(message: AccessTuple): JsonSafe<AccessTuple> {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    if (message.storageKeys) {
+      obj.storageKeys = message.storageKeys.map(e => e);
+    } else {
+      obj.storageKeys = [];
+    }
+    return obj;
+  },
+  fromPartial(object: Partial<AccessTuple>): AccessTuple {
+    const message = createBaseAccessTuple();
+    message.address = object.address ?? "";
+    message.storageKeys = object.storageKeys?.map(e => e) || [];
+    return message;
+  },
+  fromAmino(object: AccessTupleAmino): AccessTuple {
+    const message = createBaseAccessTuple();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    }
+    message.storageKeys = object.storage_keys?.map(e => e) || [];
+    return message;
+  },
+  toAmino(message: AccessTuple): AccessTupleAmino {
+    const obj: any = {};
+    obj.address = message.address === "" ? undefined : message.address;
+    if (message.storageKeys) {
+      obj.storage_keys = message.storageKeys.map(e => e);
+    } else {
+      obj.storage_keys = message.storageKeys;
+    }
+    return obj;
+  },
+  fromAminoMsg(object: AccessTupleAminoMsg): AccessTuple {
+    return AccessTuple.fromAmino(object.value);
+  },
+  fromProtoMsg(message: AccessTupleProtoMsg): AccessTuple {
+    return AccessTuple.decode(message.value);
+  },
+  toProto(message: AccessTuple): Uint8Array {
+    return AccessTuple.encode(message).finish();
+  },
+  toProtoMsg(message: AccessTuple): AccessTupleProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.AccessTuple",
+      value: AccessTuple.encode(message).finish()
+    };
+  }
+};
+function createBaseTraceConfig(): TraceConfig {
+  return {
+    tracer: "",
+    timeout: "",
+    reexec: BigInt(0),
+    disableStack: false,
+    disableStorage: false,
+    debug: false,
+    limit: 0,
+    overrides: undefined,
+    enableMemory: false,
+    enableReturnData: false,
+    tracerJsonConfig: ""
+  };
+}
+export const TraceConfig = {
+  typeUrl: "/ethermint.evm.v1.TraceConfig",
+  encode(message: TraceConfig, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.tracer !== "") {
+      writer.uint32(10).string(message.tracer);
+    }
+    if (message.timeout !== "") {
+      writer.uint32(18).string(message.timeout);
+    }
+    if (message.reexec !== BigInt(0)) {
+      writer.uint32(24).uint64(message.reexec);
+    }
+    if (message.disableStack === true) {
+      writer.uint32(40).bool(message.disableStack);
+    }
+    if (message.disableStorage === true) {
+      writer.uint32(48).bool(message.disableStorage);
+    }
+    if (message.debug === true) {
+      writer.uint32(64).bool(message.debug);
+    }
+    if (message.limit !== 0) {
+      writer.uint32(72).int32(message.limit);
+    }
+    if (message.overrides !== undefined) {
+      ChainConfig.encode(message.overrides, writer.uint32(82).fork()).ldelim();
+    }
+    if (message.enableMemory === true) {
+      writer.uint32(88).bool(message.enableMemory);
+    }
+    if (message.enableReturnData === true) {
+      writer.uint32(96).bool(message.enableReturnData);
+    }
+    if (message.tracerJsonConfig !== "") {
+      writer.uint32(106).string(message.tracerJsonConfig);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): TraceConfig {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTraceConfig();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.tracer = reader.string();
+          break;
+        case 2:
+          message.timeout = reader.string();
+          break;
+        case 3:
+          message.reexec = reader.uint64();
+          break;
+        case 5:
+          message.disableStack = reader.bool();
+          break;
+        case 6:
+          message.disableStorage = reader.bool();
+          break;
+        case 8:
+          message.debug = reader.bool();
+          break;
+        case 9:
+          message.limit = reader.int32();
+          break;
+        case 10:
+          message.overrides = ChainConfig.decode(reader, reader.uint32());
+          break;
+        case 11:
+          message.enableMemory = reader.bool();
+          break;
+        case 12:
+          message.enableReturnData = reader.bool();
+          break;
+        case 13:
+          message.tracerJsonConfig = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): TraceConfig {
+    return {
+      tracer: isSet(object.tracer) ? String(object.tracer) : "",
+      timeout: isSet(object.timeout) ? String(object.timeout) : "",
+      reexec: isSet(object.reexec) ? BigInt(object.reexec.toString()) : BigInt(0),
+      disableStack: isSet(object.disableStack) ? Boolean(object.disableStack) : false,
+      disableStorage: isSet(object.disableStorage) ? Boolean(object.disableStorage) : false,
+      debug: isSet(object.debug) ? Boolean(object.debug) : false,
+      limit: isSet(object.limit) ? Number(object.limit) : 0,
+      overrides: isSet(object.overrides) ? ChainConfig.fromJSON(object.overrides) : undefined,
+      enableMemory: isSet(object.enableMemory) ? Boolean(object.enableMemory) : false,
+      enableReturnData: isSet(object.enableReturnData) ? Boolean(object.enableReturnData) : false,
+      tracerJsonConfig: isSet(object.tracerJsonConfig) ? String(object.tracerJsonConfig) : ""
+    };
+  },
+  toJSON(message: TraceConfig): JsonSafe<TraceConfig> {
+    const obj: any = {};
+    message.tracer !== undefined && (obj.tracer = message.tracer);
+    message.timeout !== undefined && (obj.timeout = message.timeout);
+    message.reexec !== undefined && (obj.reexec = (message.reexec || BigInt(0)).toString());
+    message.disableStack !== undefined && (obj.disableStack = message.disableStack);
+    message.disableStorage !== undefined && (obj.disableStorage = message.disableStorage);
+    message.debug !== undefined && (obj.debug = message.debug);
+    message.limit !== undefined && (obj.limit = Math.round(message.limit));
+    message.overrides !== undefined && (obj.overrides = message.overrides ? ChainConfig.toJSON(message.overrides) : undefined);
+    message.enableMemory !== undefined && (obj.enableMemory = message.enableMemory);
+    message.enableReturnData !== undefined && (obj.enableReturnData = message.enableReturnData);
+    message.tracerJsonConfig !== undefined && (obj.tracerJsonConfig = message.tracerJsonConfig);
+    return obj;
+  },
+  fromPartial(object: Partial<TraceConfig>): TraceConfig {
+    const message = createBaseTraceConfig();
+    message.tracer = object.tracer ?? "";
+    message.timeout = object.timeout ?? "";
+    message.reexec = object.reexec !== undefined && object.reexec !== null ? BigInt(object.reexec.toString()) : BigInt(0);
+    message.disableStack = object.disableStack ?? false;
+    message.disableStorage = object.disableStorage ?? false;
+    message.debug = object.debug ?? false;
+    message.limit = object.limit ?? 0;
+    message.overrides = object.overrides !== undefined && object.overrides !== null ? ChainConfig.fromPartial(object.overrides) : undefined;
+    message.enableMemory = object.enableMemory ?? false;
+    message.enableReturnData = object.enableReturnData ?? false;
+    message.tracerJsonConfig = object.tracerJsonConfig ?? "";
+    return message;
+  },
+  fromAmino(object: TraceConfigAmino): TraceConfig {
+    const message = createBaseTraceConfig();
+    if (object.tracer !== undefined && object.tracer !== null) {
+      message.tracer = object.tracer;
+    }
+    if (object.timeout !== undefined && object.timeout !== null) {
+      message.timeout = object.timeout;
+    }
+    if (object.reexec !== undefined && object.reexec !== null) {
+      message.reexec = BigInt(object.reexec);
+    }
+    if (object.disable_stack !== undefined && object.disable_stack !== null) {
+      message.disableStack = object.disable_stack;
+    }
+    if (object.disable_storage !== undefined && object.disable_storage !== null) {
+      message.disableStorage = object.disable_storage;
+    }
+    if (object.debug !== undefined && object.debug !== null) {
+      message.debug = object.debug;
+    }
+    if (object.limit !== undefined && object.limit !== null) {
+      message.limit = object.limit;
+    }
+    if (object.overrides !== undefined && object.overrides !== null) {
+      message.overrides = ChainConfig.fromAmino(object.overrides);
+    }
+    if (object.enable_memory !== undefined && object.enable_memory !== null) {
+      message.enableMemory = object.enable_memory;
+    }
+    if (object.enable_return_data !== undefined && object.enable_return_data !== null) {
+      message.enableReturnData = object.enable_return_data;
+    }
+    if (object.tracer_json_config !== undefined && object.tracer_json_config !== null) {
+      message.tracerJsonConfig = object.tracer_json_config;
+    }
+    return message;
+  },
+  toAmino(message: TraceConfig): TraceConfigAmino {
+    const obj: any = {};
+    obj.tracer = message.tracer === "" ? undefined : message.tracer;
+    obj.timeout = message.timeout === "" ? undefined : message.timeout;
+    obj.reexec = message.reexec !== BigInt(0) ? message.reexec.toString() : undefined;
+    obj.disable_stack = message.disableStack ?? false;
+    obj.disable_storage = message.disableStorage ?? false;
+    obj.debug = message.debug === false ? undefined : message.debug;
+    obj.limit = message.limit === 0 ? undefined : message.limit;
+    obj.overrides = message.overrides ? ChainConfig.toAmino(message.overrides) : undefined;
+    obj.enable_memory = message.enableMemory ?? false;
+    obj.enable_return_data = message.enableReturnData ?? false;
+    obj.tracer_json_config = message.tracerJsonConfig ?? "";
+    return obj;
+  },
+  fromAminoMsg(object: TraceConfigAminoMsg): TraceConfig {
+    return TraceConfig.fromAmino(object.value);
+  },
+  fromProtoMsg(message: TraceConfigProtoMsg): TraceConfig {
+    return TraceConfig.decode(message.value);
+  },
+  toProto(message: TraceConfig): Uint8Array {
+    return TraceConfig.encode(message).finish();
+  },
+  toProtoMsg(message: TraceConfig): TraceConfigProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.TraceConfig",
+      value: TraceConfig.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/evm/v1/genesis.ts
+++ b/wardenjs/src/codegen/ethermint/evm/v1/genesis.ts
@@ -1,0 +1,276 @@
+//@ts-nocheck
+import { Params, ParamsAmino, ParamsSDKType, State, StateAmino, StateSDKType } from "./evm.js";
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** GenesisState defines the evm module's genesis state. */
+export interface GenesisState {
+  /** accounts is an array containing the ethereum genesis accounts. */
+  accounts: GenesisAccount[];
+  /** params defines all the parameters of the module. */
+  params: Params;
+}
+export interface GenesisStateProtoMsg {
+  typeUrl: "/ethermint.evm.v1.GenesisState";
+  value: Uint8Array;
+}
+/** GenesisState defines the evm module's genesis state. */
+export interface GenesisStateAmino {
+  /** accounts is an array containing the ethereum genesis accounts. */
+  accounts?: GenesisAccountAmino[];
+  /** params defines all the parameters of the module. */
+  params?: ParamsAmino;
+}
+export interface GenesisStateAminoMsg {
+  type: "/ethermint.evm.v1.GenesisState";
+  value: GenesisStateAmino;
+}
+/** GenesisState defines the evm module's genesis state. */
+export interface GenesisStateSDKType {
+  accounts: GenesisAccountSDKType[];
+  params: ParamsSDKType;
+}
+/**
+ * GenesisAccount defines an account to be initialized in the genesis state.
+ * Its main difference between with Geth's GenesisAccount is that it uses a
+ * custom storage type and that it doesn't contain the private key field.
+ */
+export interface GenesisAccount {
+  /** address defines an ethereum hex formated address of an account */
+  address: string;
+  /** code defines the hex bytes of the account code. */
+  code: string;
+  /** storage defines the set of state key values for the account. */
+  storage: State[];
+}
+export interface GenesisAccountProtoMsg {
+  typeUrl: "/ethermint.evm.v1.GenesisAccount";
+  value: Uint8Array;
+}
+/**
+ * GenesisAccount defines an account to be initialized in the genesis state.
+ * Its main difference between with Geth's GenesisAccount is that it uses a
+ * custom storage type and that it doesn't contain the private key field.
+ */
+export interface GenesisAccountAmino {
+  /** address defines an ethereum hex formated address of an account */
+  address?: string;
+  /** code defines the hex bytes of the account code. */
+  code?: string;
+  /** storage defines the set of state key values for the account. */
+  storage?: StateAmino[];
+}
+export interface GenesisAccountAminoMsg {
+  type: "/ethermint.evm.v1.GenesisAccount";
+  value: GenesisAccountAmino;
+}
+/**
+ * GenesisAccount defines an account to be initialized in the genesis state.
+ * Its main difference between with Geth's GenesisAccount is that it uses a
+ * custom storage type and that it doesn't contain the private key field.
+ */
+export interface GenesisAccountSDKType {
+  address: string;
+  code: string;
+  storage: StateSDKType[];
+}
+function createBaseGenesisState(): GenesisState {
+  return {
+    accounts: [],
+    params: Params.fromPartial({})
+  };
+}
+export const GenesisState = {
+  typeUrl: "/ethermint.evm.v1.GenesisState",
+  encode(message: GenesisState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    for (const v of message.accounts) {
+      GenesisAccount.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.params !== undefined) {
+      Params.encode(message.params, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): GenesisState {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGenesisState();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.accounts.push(GenesisAccount.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.params = Params.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): GenesisState {
+    return {
+      accounts: Array.isArray(object?.accounts) ? object.accounts.map((e: any) => GenesisAccount.fromJSON(e)) : [],
+      params: isSet(object.params) ? Params.fromJSON(object.params) : undefined
+    };
+  },
+  toJSON(message: GenesisState): JsonSafe<GenesisState> {
+    const obj: any = {};
+    if (message.accounts) {
+      obj.accounts = message.accounts.map(e => e ? GenesisAccount.toJSON(e) : undefined);
+    } else {
+      obj.accounts = [];
+    }
+    message.params !== undefined && (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<GenesisState>): GenesisState {
+    const message = createBaseGenesisState();
+    message.accounts = object.accounts?.map(e => GenesisAccount.fromPartial(e)) || [];
+    message.params = object.params !== undefined && object.params !== null ? Params.fromPartial(object.params) : undefined;
+    return message;
+  },
+  fromAmino(object: GenesisStateAmino): GenesisState {
+    const message = createBaseGenesisState();
+    message.accounts = object.accounts?.map(e => GenesisAccount.fromAmino(e)) || [];
+    if (object.params !== undefined && object.params !== null) {
+      message.params = Params.fromAmino(object.params);
+    }
+    return message;
+  },
+  toAmino(message: GenesisState): GenesisStateAmino {
+    const obj: any = {};
+    if (message.accounts) {
+      obj.accounts = message.accounts.map(e => e ? GenesisAccount.toAmino(e) : undefined);
+    } else {
+      obj.accounts = message.accounts;
+    }
+    obj.params = message.params ? Params.toAmino(message.params) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: GenesisStateAminoMsg): GenesisState {
+    return GenesisState.fromAmino(object.value);
+  },
+  fromProtoMsg(message: GenesisStateProtoMsg): GenesisState {
+    return GenesisState.decode(message.value);
+  },
+  toProto(message: GenesisState): Uint8Array {
+    return GenesisState.encode(message).finish();
+  },
+  toProtoMsg(message: GenesisState): GenesisStateProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.GenesisState",
+      value: GenesisState.encode(message).finish()
+    };
+  }
+};
+function createBaseGenesisAccount(): GenesisAccount {
+  return {
+    address: "",
+    code: "",
+    storage: []
+  };
+}
+export const GenesisAccount = {
+  typeUrl: "/ethermint.evm.v1.GenesisAccount",
+  encode(message: GenesisAccount, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    if (message.code !== "") {
+      writer.uint32(18).string(message.code);
+    }
+    for (const v of message.storage) {
+      State.encode(v!, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): GenesisAccount {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGenesisAccount();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        case 2:
+          message.code = reader.string();
+          break;
+        case 3:
+          message.storage.push(State.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): GenesisAccount {
+    return {
+      address: isSet(object.address) ? String(object.address) : "",
+      code: isSet(object.code) ? String(object.code) : "",
+      storage: Array.isArray(object?.storage) ? object.storage.map((e: any) => State.fromJSON(e)) : []
+    };
+  },
+  toJSON(message: GenesisAccount): JsonSafe<GenesisAccount> {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    message.code !== undefined && (obj.code = message.code);
+    if (message.storage) {
+      obj.storage = message.storage.map(e => e ? State.toJSON(e) : undefined);
+    } else {
+      obj.storage = [];
+    }
+    return obj;
+  },
+  fromPartial(object: Partial<GenesisAccount>): GenesisAccount {
+    const message = createBaseGenesisAccount();
+    message.address = object.address ?? "";
+    message.code = object.code ?? "";
+    message.storage = object.storage?.map(e => State.fromPartial(e)) || [];
+    return message;
+  },
+  fromAmino(object: GenesisAccountAmino): GenesisAccount {
+    const message = createBaseGenesisAccount();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    }
+    if (object.code !== undefined && object.code !== null) {
+      message.code = object.code;
+    }
+    message.storage = object.storage?.map(e => State.fromAmino(e)) || [];
+    return message;
+  },
+  toAmino(message: GenesisAccount): GenesisAccountAmino {
+    const obj: any = {};
+    obj.address = message.address === "" ? undefined : message.address;
+    obj.code = message.code === "" ? undefined : message.code;
+    if (message.storage) {
+      obj.storage = message.storage.map(e => e ? State.toAmino(e) : undefined);
+    } else {
+      obj.storage = message.storage;
+    }
+    return obj;
+  },
+  fromAminoMsg(object: GenesisAccountAminoMsg): GenesisAccount {
+    return GenesisAccount.fromAmino(object.value);
+  },
+  fromProtoMsg(message: GenesisAccountProtoMsg): GenesisAccount {
+    return GenesisAccount.decode(message.value);
+  },
+  toProto(message: GenesisAccount): Uint8Array {
+    return GenesisAccount.encode(message).finish();
+  },
+  toProtoMsg(message: GenesisAccount): GenesisAccountProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.GenesisAccount",
+      value: GenesisAccount.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/evm/v1/query.lcd.ts
+++ b/wardenjs/src/codegen/ethermint/evm/v1/query.lcd.ts
@@ -1,0 +1,176 @@
+//@ts-nocheck
+import { MsgEthereumTxResponseSDKType } from "./tx.js";
+import { LCDClient } from "@cosmology/lcd";
+import { QueryAccountRequest, QueryAccountResponseSDKType, QueryCosmosAccountRequest, QueryCosmosAccountResponseSDKType, QueryValidatorAccountRequest, QueryValidatorAccountResponseSDKType, QueryBalanceRequest, QueryBalanceResponseSDKType, QueryStorageRequest, QueryStorageResponseSDKType, QueryCodeRequest, QueryCodeResponseSDKType, QueryParamsRequest, QueryParamsResponseSDKType, EthCallRequest, EstimateGasResponseSDKType, QueryTraceTxRequest, QueryTraceTxResponseSDKType, QueryTraceBlockRequest, QueryTraceBlockResponseSDKType, QueryBaseFeeRequest, QueryBaseFeeResponseSDKType } from "./query.js";
+export class LCDQueryClient {
+  req: LCDClient;
+  constructor({
+    requestClient
+  }: {
+    requestClient: LCDClient;
+  }) {
+    this.req = requestClient;
+    this.account = this.account.bind(this);
+    this.cosmosAccount = this.cosmosAccount.bind(this);
+    this.validatorAccount = this.validatorAccount.bind(this);
+    this.balance = this.balance.bind(this);
+    this.storage = this.storage.bind(this);
+    this.code = this.code.bind(this);
+    this.params = this.params.bind(this);
+    this.ethCall = this.ethCall.bind(this);
+    this.estimateGas = this.estimateGas.bind(this);
+    this.traceTx = this.traceTx.bind(this);
+    this.traceBlock = this.traceBlock.bind(this);
+    this.baseFee = this.baseFee.bind(this);
+  }
+  /* Account queries an Ethereum account. */
+  async account(params: QueryAccountRequest): Promise<QueryAccountResponseSDKType> {
+    const endpoint = `evmos/evm/v1/account/${params.address}`;
+    return await this.req.get<QueryAccountResponseSDKType>(endpoint);
+  }
+  /* CosmosAccount queries an Ethereum account's Cosmos Address. */
+  async cosmosAccount(params: QueryCosmosAccountRequest): Promise<QueryCosmosAccountResponseSDKType> {
+    const endpoint = `evmos/evm/v1/cosmos_account/${params.address}`;
+    return await this.req.get<QueryCosmosAccountResponseSDKType>(endpoint);
+  }
+  /* ValidatorAccount queries an Ethereum account's from a validator consensus
+   Address. */
+  async validatorAccount(params: QueryValidatorAccountRequest): Promise<QueryValidatorAccountResponseSDKType> {
+    const endpoint = `evmos/evm/v1/validator_account/${params.consAddress}`;
+    return await this.req.get<QueryValidatorAccountResponseSDKType>(endpoint);
+  }
+  /* Balance queries the balance of a the EVM denomination for a single
+   account. */
+  async balance(params: QueryBalanceRequest): Promise<QueryBalanceResponseSDKType> {
+    const endpoint = `evmos/evm/v1/balances/${params.address}`;
+    return await this.req.get<QueryBalanceResponseSDKType>(endpoint);
+  }
+  /* Storage queries the balance of all coins for a single account. */
+  async storage(params: QueryStorageRequest): Promise<QueryStorageResponseSDKType> {
+    const endpoint = `evmos/evm/v1/storage/${params.address}/${params.key}`;
+    return await this.req.get<QueryStorageResponseSDKType>(endpoint);
+  }
+  /* Code queries the balance of all coins for a single account. */
+  async code(params: QueryCodeRequest): Promise<QueryCodeResponseSDKType> {
+    const endpoint = `evmos/evm/v1/codes/${params.address}`;
+    return await this.req.get<QueryCodeResponseSDKType>(endpoint);
+  }
+  /* Params queries the parameters of x/evm module. */
+  async params(_params: QueryParamsRequest = {}): Promise<QueryParamsResponseSDKType> {
+    const endpoint = `evmos/evm/v1/params`;
+    return await this.req.get<QueryParamsResponseSDKType>(endpoint);
+  }
+  /* EthCall implements the `eth_call` rpc api */
+  async ethCall(params: EthCallRequest): Promise<MsgEthereumTxResponseSDKType> {
+    const options: any = {
+      params: {}
+    };
+    if (typeof params?.args !== "undefined") {
+      options.params.args = params.args;
+    }
+    if (typeof params?.gasCap !== "undefined") {
+      options.params.gas_cap = params.gasCap;
+    }
+    if (typeof params?.proposerAddress !== "undefined") {
+      options.params.proposer_address = params.proposerAddress;
+    }
+    if (typeof params?.chainId !== "undefined") {
+      options.params.chain_id = params.chainId;
+    }
+    const endpoint = `evmos/evm/v1/eth_call`;
+    return await this.req.get<MsgEthereumTxResponseSDKType>(endpoint, options);
+  }
+  /* EstimateGas implements the `eth_estimateGas` rpc api */
+  async estimateGas(params: EthCallRequest): Promise<EstimateGasResponseSDKType> {
+    const options: any = {
+      params: {}
+    };
+    if (typeof params?.args !== "undefined") {
+      options.params.args = params.args;
+    }
+    if (typeof params?.gasCap !== "undefined") {
+      options.params.gas_cap = params.gasCap;
+    }
+    if (typeof params?.proposerAddress !== "undefined") {
+      options.params.proposer_address = params.proposerAddress;
+    }
+    if (typeof params?.chainId !== "undefined") {
+      options.params.chain_id = params.chainId;
+    }
+    const endpoint = `evmos/evm/v1/estimate_gas`;
+    return await this.req.get<EstimateGasResponseSDKType>(endpoint, options);
+  }
+  /* TraceTx implements the `debug_traceTransaction` rpc api */
+  async traceTx(params: QueryTraceTxRequest): Promise<QueryTraceTxResponseSDKType> {
+    const options: any = {
+      params: {}
+    };
+    if (typeof params?.msg !== "undefined") {
+      options.params.msg = params.msg;
+    }
+    if (typeof params?.traceConfig !== "undefined") {
+      options.params.trace_config = params.traceConfig;
+    }
+    if (typeof params?.predecessors !== "undefined") {
+      options.params.predecessors = params.predecessors;
+    }
+    if (typeof params?.blockNumber !== "undefined") {
+      options.params.block_number = params.blockNumber;
+    }
+    if (typeof params?.blockHash !== "undefined") {
+      options.params.block_hash = params.blockHash;
+    }
+    if (typeof params?.blockTime !== "undefined") {
+      options.params.block_time = params.blockTime;
+    }
+    if (typeof params?.proposerAddress !== "undefined") {
+      options.params.proposer_address = params.proposerAddress;
+    }
+    if (typeof params?.chainId !== "undefined") {
+      options.params.chain_id = params.chainId;
+    }
+    if (typeof params?.blockMaxGas !== "undefined") {
+      options.params.block_max_gas = params.blockMaxGas;
+    }
+    const endpoint = `evmos/evm/v1/trace_tx`;
+    return await this.req.get<QueryTraceTxResponseSDKType>(endpoint, options);
+  }
+  /* TraceBlock implements the `debug_traceBlockByNumber` and `debug_traceBlockByHash` rpc api */
+  async traceBlock(params: QueryTraceBlockRequest): Promise<QueryTraceBlockResponseSDKType> {
+    const options: any = {
+      params: {}
+    };
+    if (typeof params?.txs !== "undefined") {
+      options.params.txs = params.txs;
+    }
+    if (typeof params?.traceConfig !== "undefined") {
+      options.params.trace_config = params.traceConfig;
+    }
+    if (typeof params?.blockNumber !== "undefined") {
+      options.params.block_number = params.blockNumber;
+    }
+    if (typeof params?.blockHash !== "undefined") {
+      options.params.block_hash = params.blockHash;
+    }
+    if (typeof params?.blockTime !== "undefined") {
+      options.params.block_time = params.blockTime;
+    }
+    if (typeof params?.proposerAddress !== "undefined") {
+      options.params.proposer_address = params.proposerAddress;
+    }
+    if (typeof params?.chainId !== "undefined") {
+      options.params.chain_id = params.chainId;
+    }
+    if (typeof params?.blockMaxGas !== "undefined") {
+      options.params.block_max_gas = params.blockMaxGas;
+    }
+    const endpoint = `evmos/evm/v1/trace_block`;
+    return await this.req.get<QueryTraceBlockResponseSDKType>(endpoint, options);
+  }
+  /* BaseFee queries the base fee of the parent block of the current block,
+   it's similar to feemarket module's method, but also checks london hardfork status. */
+  async baseFee(_params: QueryBaseFeeRequest = {}): Promise<QueryBaseFeeResponseSDKType> {
+    const endpoint = `evmos/evm/v1/base_fee`;
+    return await this.req.get<QueryBaseFeeResponseSDKType>(endpoint);
+  }
+}

--- a/wardenjs/src/codegen/ethermint/evm/v1/query.rpc.Query.ts
+++ b/wardenjs/src/codegen/ethermint/evm/v1/query.rpc.Query.ts
@@ -1,0 +1,347 @@
+//@ts-nocheck
+import { MsgEthereumTxResponse } from "./tx.js";
+import { Rpc } from "../../../helpers.js";
+import { BinaryReader } from "../../../binary.js";
+import { QueryClient, createProtobufRpcClient, ProtobufRpcClient } from "@cosmjs/stargate";
+import { ReactQueryParams } from "../../../react-query.js";
+import { useQuery } from "@tanstack/react-query";
+import { QueryAccountRequest, QueryAccountResponse, QueryCosmosAccountRequest, QueryCosmosAccountResponse, QueryValidatorAccountRequest, QueryValidatorAccountResponse, QueryBalanceRequest, QueryBalanceResponse, QueryStorageRequest, QueryStorageResponse, QueryCodeRequest, QueryCodeResponse, QueryParamsRequest, QueryParamsResponse, EthCallRequest, EstimateGasResponse, QueryTraceTxRequest, QueryTraceTxResponse, QueryTraceBlockRequest, QueryTraceBlockResponse, QueryBaseFeeRequest, QueryBaseFeeResponse } from "./query.js";
+/** Query defines the gRPC querier service. */
+export interface Query {
+  /** Account queries an Ethereum account. */
+  account(request: QueryAccountRequest): Promise<QueryAccountResponse>;
+  /** CosmosAccount queries an Ethereum account's Cosmos Address. */
+  cosmosAccount(request: QueryCosmosAccountRequest): Promise<QueryCosmosAccountResponse>;
+  /**
+   * ValidatorAccount queries an Ethereum account's from a validator consensus
+   * Address.
+   */
+  validatorAccount(request: QueryValidatorAccountRequest): Promise<QueryValidatorAccountResponse>;
+  /**
+   * Balance queries the balance of a the EVM denomination for a single
+   * account.
+   */
+  balance(request: QueryBalanceRequest): Promise<QueryBalanceResponse>;
+  /** Storage queries the balance of all coins for a single account. */
+  storage(request: QueryStorageRequest): Promise<QueryStorageResponse>;
+  /** Code queries the balance of all coins for a single account. */
+  code(request: QueryCodeRequest): Promise<QueryCodeResponse>;
+  /** Params queries the parameters of x/evm module. */
+  params(request?: QueryParamsRequest): Promise<QueryParamsResponse>;
+  /** EthCall implements the `eth_call` rpc api */
+  ethCall(request: EthCallRequest): Promise<MsgEthereumTxResponse>;
+  /** EstimateGas implements the `eth_estimateGas` rpc api */
+  estimateGas(request: EthCallRequest): Promise<EstimateGasResponse>;
+  /** TraceTx implements the `debug_traceTransaction` rpc api */
+  traceTx(request: QueryTraceTxRequest): Promise<QueryTraceTxResponse>;
+  /** TraceBlock implements the `debug_traceBlockByNumber` and `debug_traceBlockByHash` rpc api */
+  traceBlock(request: QueryTraceBlockRequest): Promise<QueryTraceBlockResponse>;
+  /**
+   * BaseFee queries the base fee of the parent block of the current block,
+   * it's similar to feemarket module's method, but also checks london hardfork status.
+   */
+  baseFee(request?: QueryBaseFeeRequest): Promise<QueryBaseFeeResponse>;
+}
+export class QueryClientImpl implements Query {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.account = this.account.bind(this);
+    this.cosmosAccount = this.cosmosAccount.bind(this);
+    this.validatorAccount = this.validatorAccount.bind(this);
+    this.balance = this.balance.bind(this);
+    this.storage = this.storage.bind(this);
+    this.code = this.code.bind(this);
+    this.params = this.params.bind(this);
+    this.ethCall = this.ethCall.bind(this);
+    this.estimateGas = this.estimateGas.bind(this);
+    this.traceTx = this.traceTx.bind(this);
+    this.traceBlock = this.traceBlock.bind(this);
+    this.baseFee = this.baseFee.bind(this);
+  }
+  account(request: QueryAccountRequest): Promise<QueryAccountResponse> {
+    const data = QueryAccountRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "Account", data);
+    return promise.then(data => QueryAccountResponse.decode(new BinaryReader(data)));
+  }
+  cosmosAccount(request: QueryCosmosAccountRequest): Promise<QueryCosmosAccountResponse> {
+    const data = QueryCosmosAccountRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "CosmosAccount", data);
+    return promise.then(data => QueryCosmosAccountResponse.decode(new BinaryReader(data)));
+  }
+  validatorAccount(request: QueryValidatorAccountRequest): Promise<QueryValidatorAccountResponse> {
+    const data = QueryValidatorAccountRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "ValidatorAccount", data);
+    return promise.then(data => QueryValidatorAccountResponse.decode(new BinaryReader(data)));
+  }
+  balance(request: QueryBalanceRequest): Promise<QueryBalanceResponse> {
+    const data = QueryBalanceRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "Balance", data);
+    return promise.then(data => QueryBalanceResponse.decode(new BinaryReader(data)));
+  }
+  storage(request: QueryStorageRequest): Promise<QueryStorageResponse> {
+    const data = QueryStorageRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "Storage", data);
+    return promise.then(data => QueryStorageResponse.decode(new BinaryReader(data)));
+  }
+  code(request: QueryCodeRequest): Promise<QueryCodeResponse> {
+    const data = QueryCodeRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "Code", data);
+    return promise.then(data => QueryCodeResponse.decode(new BinaryReader(data)));
+  }
+  params(request: QueryParamsRequest = {}): Promise<QueryParamsResponse> {
+    const data = QueryParamsRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "Params", data);
+    return promise.then(data => QueryParamsResponse.decode(new BinaryReader(data)));
+  }
+  ethCall(request: EthCallRequest): Promise<MsgEthereumTxResponse> {
+    const data = EthCallRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "EthCall", data);
+    return promise.then(data => MsgEthereumTxResponse.decode(new BinaryReader(data)));
+  }
+  estimateGas(request: EthCallRequest): Promise<EstimateGasResponse> {
+    const data = EthCallRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "EstimateGas", data);
+    return promise.then(data => EstimateGasResponse.decode(new BinaryReader(data)));
+  }
+  traceTx(request: QueryTraceTxRequest): Promise<QueryTraceTxResponse> {
+    const data = QueryTraceTxRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "TraceTx", data);
+    return promise.then(data => QueryTraceTxResponse.decode(new BinaryReader(data)));
+  }
+  traceBlock(request: QueryTraceBlockRequest): Promise<QueryTraceBlockResponse> {
+    const data = QueryTraceBlockRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "TraceBlock", data);
+    return promise.then(data => QueryTraceBlockResponse.decode(new BinaryReader(data)));
+  }
+  baseFee(request: QueryBaseFeeRequest = {}): Promise<QueryBaseFeeResponse> {
+    const data = QueryBaseFeeRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Query", "BaseFee", data);
+    return promise.then(data => QueryBaseFeeResponse.decode(new BinaryReader(data)));
+  }
+}
+export const createRpcQueryExtension = (base: QueryClient) => {
+  const rpc = createProtobufRpcClient(base);
+  const queryService = new QueryClientImpl(rpc);
+  return {
+    account(request: QueryAccountRequest): Promise<QueryAccountResponse> {
+      return queryService.account(request);
+    },
+    cosmosAccount(request: QueryCosmosAccountRequest): Promise<QueryCosmosAccountResponse> {
+      return queryService.cosmosAccount(request);
+    },
+    validatorAccount(request: QueryValidatorAccountRequest): Promise<QueryValidatorAccountResponse> {
+      return queryService.validatorAccount(request);
+    },
+    balance(request: QueryBalanceRequest): Promise<QueryBalanceResponse> {
+      return queryService.balance(request);
+    },
+    storage(request: QueryStorageRequest): Promise<QueryStorageResponse> {
+      return queryService.storage(request);
+    },
+    code(request: QueryCodeRequest): Promise<QueryCodeResponse> {
+      return queryService.code(request);
+    },
+    params(request?: QueryParamsRequest): Promise<QueryParamsResponse> {
+      return queryService.params(request);
+    },
+    ethCall(request: EthCallRequest): Promise<MsgEthereumTxResponse> {
+      return queryService.ethCall(request);
+    },
+    estimateGas(request: EthCallRequest): Promise<EstimateGasResponse> {
+      return queryService.estimateGas(request);
+    },
+    traceTx(request: QueryTraceTxRequest): Promise<QueryTraceTxResponse> {
+      return queryService.traceTx(request);
+    },
+    traceBlock(request: QueryTraceBlockRequest): Promise<QueryTraceBlockResponse> {
+      return queryService.traceBlock(request);
+    },
+    baseFee(request?: QueryBaseFeeRequest): Promise<QueryBaseFeeResponse> {
+      return queryService.baseFee(request);
+    }
+  };
+};
+export interface UseAccountQuery<TData> extends ReactQueryParams<QueryAccountResponse, TData> {
+  request: QueryAccountRequest;
+}
+export interface UseCosmosAccountQuery<TData> extends ReactQueryParams<QueryCosmosAccountResponse, TData> {
+  request: QueryCosmosAccountRequest;
+}
+export interface UseValidatorAccountQuery<TData> extends ReactQueryParams<QueryValidatorAccountResponse, TData> {
+  request: QueryValidatorAccountRequest;
+}
+export interface UseBalanceQuery<TData> extends ReactQueryParams<QueryBalanceResponse, TData> {
+  request: QueryBalanceRequest;
+}
+export interface UseStorageQuery<TData> extends ReactQueryParams<QueryStorageResponse, TData> {
+  request: QueryStorageRequest;
+}
+export interface UseCodeQuery<TData> extends ReactQueryParams<QueryCodeResponse, TData> {
+  request: QueryCodeRequest;
+}
+export interface UseParamsQuery<TData> extends ReactQueryParams<QueryParamsResponse, TData> {
+  request?: QueryParamsRequest;
+}
+export interface UseEthCallQuery<TData> extends ReactQueryParams<MsgEthereumTxResponse, TData> {
+  request: EthCallRequest;
+}
+export interface UseEstimateGasQuery<TData> extends ReactQueryParams<EstimateGasResponse, TData> {
+  request: EthCallRequest;
+}
+export interface UseTraceTxQuery<TData> extends ReactQueryParams<QueryTraceTxResponse, TData> {
+  request: QueryTraceTxRequest;
+}
+export interface UseTraceBlockQuery<TData> extends ReactQueryParams<QueryTraceBlockResponse, TData> {
+  request: QueryTraceBlockRequest;
+}
+export interface UseBaseFeeQuery<TData> extends ReactQueryParams<QueryBaseFeeResponse, TData> {
+  request?: QueryBaseFeeRequest;
+}
+const _queryClients: WeakMap<ProtobufRpcClient, QueryClientImpl> = new WeakMap();
+const getQueryService = (rpc: ProtobufRpcClient | undefined): QueryClientImpl | undefined => {
+  if (!rpc) return;
+  if (_queryClients.has(rpc)) {
+    return _queryClients.get(rpc);
+  }
+  const queryService = new QueryClientImpl(rpc);
+  _queryClients.set(rpc, queryService);
+  return queryService;
+};
+export const createRpcQueryHooks = (rpc: ProtobufRpcClient | undefined) => {
+  const queryService = getQueryService(rpc);
+  const useAccount = <TData = QueryAccountResponse,>({
+    request,
+    options
+  }: UseAccountQuery<TData>) => {
+    return useQuery<QueryAccountResponse, Error, TData>(["accountQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.account(request);
+    }, options);
+  };
+  const useCosmosAccount = <TData = QueryCosmosAccountResponse,>({
+    request,
+    options
+  }: UseCosmosAccountQuery<TData>) => {
+    return useQuery<QueryCosmosAccountResponse, Error, TData>(["cosmosAccountQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.cosmosAccount(request);
+    }, options);
+  };
+  const useValidatorAccount = <TData = QueryValidatorAccountResponse,>({
+    request,
+    options
+  }: UseValidatorAccountQuery<TData>) => {
+    return useQuery<QueryValidatorAccountResponse, Error, TData>(["validatorAccountQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.validatorAccount(request);
+    }, options);
+  };
+  const useBalance = <TData = QueryBalanceResponse,>({
+    request,
+    options
+  }: UseBalanceQuery<TData>) => {
+    return useQuery<QueryBalanceResponse, Error, TData>(["balanceQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.balance(request);
+    }, options);
+  };
+  const useStorage = <TData = QueryStorageResponse,>({
+    request,
+    options
+  }: UseStorageQuery<TData>) => {
+    return useQuery<QueryStorageResponse, Error, TData>(["storageQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.storage(request);
+    }, options);
+  };
+  const useCode = <TData = QueryCodeResponse,>({
+    request,
+    options
+  }: UseCodeQuery<TData>) => {
+    return useQuery<QueryCodeResponse, Error, TData>(["codeQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.code(request);
+    }, options);
+  };
+  const useParams = <TData = QueryParamsResponse,>({
+    request,
+    options
+  }: UseParamsQuery<TData>) => {
+    return useQuery<QueryParamsResponse, Error, TData>(["paramsQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.params(request);
+    }, options);
+  };
+  const useEthCall = <TData = MsgEthereumTxResponse,>({
+    request,
+    options
+  }: UseEthCallQuery<TData>) => {
+    return useQuery<MsgEthereumTxResponse, Error, TData>(["ethCallQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.ethCall(request);
+    }, options);
+  };
+  const useEstimateGas = <TData = EstimateGasResponse,>({
+    request,
+    options
+  }: UseEstimateGasQuery<TData>) => {
+    return useQuery<EstimateGasResponse, Error, TData>(["estimateGasQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.estimateGas(request);
+    }, options);
+  };
+  const useTraceTx = <TData = QueryTraceTxResponse,>({
+    request,
+    options
+  }: UseTraceTxQuery<TData>) => {
+    return useQuery<QueryTraceTxResponse, Error, TData>(["traceTxQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.traceTx(request);
+    }, options);
+  };
+  const useTraceBlock = <TData = QueryTraceBlockResponse,>({
+    request,
+    options
+  }: UseTraceBlockQuery<TData>) => {
+    return useQuery<QueryTraceBlockResponse, Error, TData>(["traceBlockQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.traceBlock(request);
+    }, options);
+  };
+  const useBaseFee = <TData = QueryBaseFeeResponse,>({
+    request,
+    options
+  }: UseBaseFeeQuery<TData>) => {
+    return useQuery<QueryBaseFeeResponse, Error, TData>(["baseFeeQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.baseFee(request);
+    }, options);
+  };
+  return {
+    /** Account queries an Ethereum account. */useAccount,
+    /** CosmosAccount queries an Ethereum account's Cosmos Address. */useCosmosAccount,
+    /**
+     * ValidatorAccount queries an Ethereum account's from a validator consensus
+     * Address.
+     */
+    useValidatorAccount,
+    /**
+     * Balance queries the balance of a the EVM denomination for a single
+     * account.
+     */
+    useBalance,
+    /** Storage queries the balance of all coins for a single account. */useStorage,
+    /** Code queries the balance of all coins for a single account. */useCode,
+    /** Params queries the parameters of x/evm module. */useParams,
+    /** EthCall implements the `eth_call` rpc api */useEthCall,
+    /** EstimateGas implements the `eth_estimateGas` rpc api */useEstimateGas,
+    /** TraceTx implements the `debug_traceTransaction` rpc api */useTraceTx,
+    /** TraceBlock implements the `debug_traceBlockByNumber` and `debug_traceBlockByHash` rpc api */useTraceBlock,
+    /**
+     * BaseFee queries the base fee of the parent block of the current block,
+     * it's similar to feemarket module's method, but also checks london hardfork status.
+     */
+    useBaseFee
+  };
+};

--- a/wardenjs/src/codegen/ethermint/evm/v1/query.ts
+++ b/wardenjs/src/codegen/ethermint/evm/v1/query.ts
@@ -1,0 +1,2840 @@
+//@ts-nocheck
+import { MsgEthereumTx, MsgEthereumTxAmino, MsgEthereumTxSDKType } from "./tx.js";
+import { TraceConfig, TraceConfigAmino, TraceConfigSDKType, Log, LogAmino, LogSDKType, Params, ParamsAmino, ParamsSDKType } from "./evm.js";
+import { Timestamp, TimestampSDKType } from "../../../google/protobuf/timestamp.js";
+import { PageRequest, PageRequestAmino, PageRequestSDKType, PageResponse, PageResponseAmino, PageResponseSDKType } from "../../../cosmos/base/query/v1beta1/pagination.js";
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet, bytesFromBase64, base64FromBytes, fromJsonTimestamp, fromTimestamp } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** QueryAccountRequest is the request type for the Query/Account RPC method. */
+export interface QueryAccountRequest {
+  /** address is the ethereum hex address to query the account for. */
+  address: string;
+}
+export interface QueryAccountRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryAccountRequest";
+  value: Uint8Array;
+}
+/** QueryAccountRequest is the request type for the Query/Account RPC method. */
+export interface QueryAccountRequestAmino {
+  /** address is the ethereum hex address to query the account for. */
+  address?: string;
+}
+export interface QueryAccountRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryAccountRequest";
+  value: QueryAccountRequestAmino;
+}
+/** QueryAccountRequest is the request type for the Query/Account RPC method. */
+export interface QueryAccountRequestSDKType {
+  address: string;
+}
+/** QueryAccountResponse is the response type for the Query/Account RPC method. */
+export interface QueryAccountResponse {
+  /** balance is the balance of the EVM denomination. */
+  balance: string;
+  /** code_hash is the hex-formatted code bytes from the EOA. */
+  codeHash: string;
+  /** nonce is the account's sequence number. */
+  nonce: bigint;
+}
+export interface QueryAccountResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryAccountResponse";
+  value: Uint8Array;
+}
+/** QueryAccountResponse is the response type for the Query/Account RPC method. */
+export interface QueryAccountResponseAmino {
+  /** balance is the balance of the EVM denomination. */
+  balance?: string;
+  /** code_hash is the hex-formatted code bytes from the EOA. */
+  code_hash?: string;
+  /** nonce is the account's sequence number. */
+  nonce?: string;
+}
+export interface QueryAccountResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryAccountResponse";
+  value: QueryAccountResponseAmino;
+}
+/** QueryAccountResponse is the response type for the Query/Account RPC method. */
+export interface QueryAccountResponseSDKType {
+  balance: string;
+  code_hash: string;
+  nonce: bigint;
+}
+/**
+ * QueryCosmosAccountRequest is the request type for the Query/CosmosAccount RPC
+ * method.
+ */
+export interface QueryCosmosAccountRequest {
+  /** address is the ethereum hex address to query the account for. */
+  address: string;
+}
+export interface QueryCosmosAccountRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryCosmosAccountRequest";
+  value: Uint8Array;
+}
+/**
+ * QueryCosmosAccountRequest is the request type for the Query/CosmosAccount RPC
+ * method.
+ */
+export interface QueryCosmosAccountRequestAmino {
+  /** address is the ethereum hex address to query the account for. */
+  address?: string;
+}
+export interface QueryCosmosAccountRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryCosmosAccountRequest";
+  value: QueryCosmosAccountRequestAmino;
+}
+/**
+ * QueryCosmosAccountRequest is the request type for the Query/CosmosAccount RPC
+ * method.
+ */
+export interface QueryCosmosAccountRequestSDKType {
+  address: string;
+}
+/**
+ * QueryCosmosAccountResponse is the response type for the Query/CosmosAccount
+ * RPC method.
+ */
+export interface QueryCosmosAccountResponse {
+  /** cosmos_address is the cosmos address of the account. */
+  cosmosAddress: string;
+  /** sequence is the account's sequence number. */
+  sequence: bigint;
+  /** account_number is the account number */
+  accountNumber: bigint;
+}
+export interface QueryCosmosAccountResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryCosmosAccountResponse";
+  value: Uint8Array;
+}
+/**
+ * QueryCosmosAccountResponse is the response type for the Query/CosmosAccount
+ * RPC method.
+ */
+export interface QueryCosmosAccountResponseAmino {
+  /** cosmos_address is the cosmos address of the account. */
+  cosmos_address?: string;
+  /** sequence is the account's sequence number. */
+  sequence?: string;
+  /** account_number is the account number */
+  account_number?: string;
+}
+export interface QueryCosmosAccountResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryCosmosAccountResponse";
+  value: QueryCosmosAccountResponseAmino;
+}
+/**
+ * QueryCosmosAccountResponse is the response type for the Query/CosmosAccount
+ * RPC method.
+ */
+export interface QueryCosmosAccountResponseSDKType {
+  cosmos_address: string;
+  sequence: bigint;
+  account_number: bigint;
+}
+/**
+ * QueryValidatorAccountRequest is the request type for the
+ * Query/ValidatorAccount RPC method.
+ */
+export interface QueryValidatorAccountRequest {
+  /** cons_address is the validator cons address to query the account for. */
+  consAddress: string;
+}
+export interface QueryValidatorAccountRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryValidatorAccountRequest";
+  value: Uint8Array;
+}
+/**
+ * QueryValidatorAccountRequest is the request type for the
+ * Query/ValidatorAccount RPC method.
+ */
+export interface QueryValidatorAccountRequestAmino {
+  /** cons_address is the validator cons address to query the account for. */
+  cons_address?: string;
+}
+export interface QueryValidatorAccountRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryValidatorAccountRequest";
+  value: QueryValidatorAccountRequestAmino;
+}
+/**
+ * QueryValidatorAccountRequest is the request type for the
+ * Query/ValidatorAccount RPC method.
+ */
+export interface QueryValidatorAccountRequestSDKType {
+  cons_address: string;
+}
+/**
+ * QueryValidatorAccountResponse is the response type for the
+ * Query/ValidatorAccount RPC method.
+ */
+export interface QueryValidatorAccountResponse {
+  /** account_address is the cosmos address of the account in bech32 format. */
+  accountAddress: string;
+  /** sequence is the account's sequence number. */
+  sequence: bigint;
+  /** account_number is the account number */
+  accountNumber: bigint;
+}
+export interface QueryValidatorAccountResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryValidatorAccountResponse";
+  value: Uint8Array;
+}
+/**
+ * QueryValidatorAccountResponse is the response type for the
+ * Query/ValidatorAccount RPC method.
+ */
+export interface QueryValidatorAccountResponseAmino {
+  /** account_address is the cosmos address of the account in bech32 format. */
+  account_address?: string;
+  /** sequence is the account's sequence number. */
+  sequence?: string;
+  /** account_number is the account number */
+  account_number?: string;
+}
+export interface QueryValidatorAccountResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryValidatorAccountResponse";
+  value: QueryValidatorAccountResponseAmino;
+}
+/**
+ * QueryValidatorAccountResponse is the response type for the
+ * Query/ValidatorAccount RPC method.
+ */
+export interface QueryValidatorAccountResponseSDKType {
+  account_address: string;
+  sequence: bigint;
+  account_number: bigint;
+}
+/** QueryBalanceRequest is the request type for the Query/Balance RPC method. */
+export interface QueryBalanceRequest {
+  /** address is the ethereum hex address to query the balance for. */
+  address: string;
+}
+export interface QueryBalanceRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryBalanceRequest";
+  value: Uint8Array;
+}
+/** QueryBalanceRequest is the request type for the Query/Balance RPC method. */
+export interface QueryBalanceRequestAmino {
+  /** address is the ethereum hex address to query the balance for. */
+  address?: string;
+}
+export interface QueryBalanceRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryBalanceRequest";
+  value: QueryBalanceRequestAmino;
+}
+/** QueryBalanceRequest is the request type for the Query/Balance RPC method. */
+export interface QueryBalanceRequestSDKType {
+  address: string;
+}
+/** QueryBalanceResponse is the response type for the Query/Balance RPC method. */
+export interface QueryBalanceResponse {
+  /** balance is the balance of the EVM denomination. */
+  balance: string;
+}
+export interface QueryBalanceResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryBalanceResponse";
+  value: Uint8Array;
+}
+/** QueryBalanceResponse is the response type for the Query/Balance RPC method. */
+export interface QueryBalanceResponseAmino {
+  /** balance is the balance of the EVM denomination. */
+  balance?: string;
+}
+export interface QueryBalanceResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryBalanceResponse";
+  value: QueryBalanceResponseAmino;
+}
+/** QueryBalanceResponse is the response type for the Query/Balance RPC method. */
+export interface QueryBalanceResponseSDKType {
+  balance: string;
+}
+/** QueryStorageRequest is the request type for the Query/Storage RPC method. */
+export interface QueryStorageRequest {
+  /** address is the ethereum hex address to query the storage state for. */
+  address: string;
+  /** key defines the key of the storage state */
+  key: string;
+}
+export interface QueryStorageRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryStorageRequest";
+  value: Uint8Array;
+}
+/** QueryStorageRequest is the request type for the Query/Storage RPC method. */
+export interface QueryStorageRequestAmino {
+  /** address is the ethereum hex address to query the storage state for. */
+  address?: string;
+  /** key defines the key of the storage state */
+  key?: string;
+}
+export interface QueryStorageRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryStorageRequest";
+  value: QueryStorageRequestAmino;
+}
+/** QueryStorageRequest is the request type for the Query/Storage RPC method. */
+export interface QueryStorageRequestSDKType {
+  address: string;
+  key: string;
+}
+/**
+ * QueryStorageResponse is the response type for the Query/Storage RPC
+ * method.
+ */
+export interface QueryStorageResponse {
+  /** value defines the storage state value hash associated with the given key. */
+  value: string;
+}
+export interface QueryStorageResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryStorageResponse";
+  value: Uint8Array;
+}
+/**
+ * QueryStorageResponse is the response type for the Query/Storage RPC
+ * method.
+ */
+export interface QueryStorageResponseAmino {
+  /** value defines the storage state value hash associated with the given key. */
+  value?: string;
+}
+export interface QueryStorageResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryStorageResponse";
+  value: QueryStorageResponseAmino;
+}
+/**
+ * QueryStorageResponse is the response type for the Query/Storage RPC
+ * method.
+ */
+export interface QueryStorageResponseSDKType {
+  value: string;
+}
+/** QueryCodeRequest is the request type for the Query/Code RPC method. */
+export interface QueryCodeRequest {
+  /** address is the ethereum hex address to query the code for. */
+  address: string;
+}
+export interface QueryCodeRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryCodeRequest";
+  value: Uint8Array;
+}
+/** QueryCodeRequest is the request type for the Query/Code RPC method. */
+export interface QueryCodeRequestAmino {
+  /** address is the ethereum hex address to query the code for. */
+  address?: string;
+}
+export interface QueryCodeRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryCodeRequest";
+  value: QueryCodeRequestAmino;
+}
+/** QueryCodeRequest is the request type for the Query/Code RPC method. */
+export interface QueryCodeRequestSDKType {
+  address: string;
+}
+/**
+ * QueryCodeResponse is the response type for the Query/Code RPC
+ * method.
+ */
+export interface QueryCodeResponse {
+  /** code represents the code bytes from an ethereum address. */
+  code: Uint8Array;
+}
+export interface QueryCodeResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryCodeResponse";
+  value: Uint8Array;
+}
+/**
+ * QueryCodeResponse is the response type for the Query/Code RPC
+ * method.
+ */
+export interface QueryCodeResponseAmino {
+  /** code represents the code bytes from an ethereum address. */
+  code?: string;
+}
+export interface QueryCodeResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryCodeResponse";
+  value: QueryCodeResponseAmino;
+}
+/**
+ * QueryCodeResponse is the response type for the Query/Code RPC
+ * method.
+ */
+export interface QueryCodeResponseSDKType {
+  code: Uint8Array;
+}
+/** QueryTxLogsRequest is the request type for the Query/TxLogs RPC method. */
+export interface QueryTxLogsRequest {
+  /** hash is the ethereum transaction hex hash to query the logs for. */
+  hash: string;
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+export interface QueryTxLogsRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryTxLogsRequest";
+  value: Uint8Array;
+}
+/** QueryTxLogsRequest is the request type for the Query/TxLogs RPC method. */
+export interface QueryTxLogsRequestAmino {
+  /** hash is the ethereum transaction hex hash to query the logs for. */
+  hash?: string;
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequestAmino;
+}
+export interface QueryTxLogsRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryTxLogsRequest";
+  value: QueryTxLogsRequestAmino;
+}
+/** QueryTxLogsRequest is the request type for the Query/TxLogs RPC method. */
+export interface QueryTxLogsRequestSDKType {
+  hash: string;
+  pagination?: PageRequestSDKType;
+}
+/** QueryTxLogsResponse is the response type for the Query/TxLogs RPC method. */
+export interface QueryTxLogsResponse {
+  /** logs represents the ethereum logs generated from the given transaction. */
+  logs: Log[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponse;
+}
+export interface QueryTxLogsResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryTxLogsResponse";
+  value: Uint8Array;
+}
+/** QueryTxLogsResponse is the response type for the Query/TxLogs RPC method. */
+export interface QueryTxLogsResponseAmino {
+  /** logs represents the ethereum logs generated from the given transaction. */
+  logs?: LogAmino[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponseAmino;
+}
+export interface QueryTxLogsResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryTxLogsResponse";
+  value: QueryTxLogsResponseAmino;
+}
+/** QueryTxLogsResponse is the response type for the Query/TxLogs RPC method. */
+export interface QueryTxLogsResponseSDKType {
+  logs: LogSDKType[];
+  pagination?: PageResponseSDKType;
+}
+/** QueryParamsRequest defines the request type for querying x/evm parameters. */
+export interface QueryParamsRequest {}
+export interface QueryParamsRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryParamsRequest";
+  value: Uint8Array;
+}
+/** QueryParamsRequest defines the request type for querying x/evm parameters. */
+export interface QueryParamsRequestAmino {}
+export interface QueryParamsRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryParamsRequest";
+  value: QueryParamsRequestAmino;
+}
+/** QueryParamsRequest defines the request type for querying x/evm parameters. */
+export interface QueryParamsRequestSDKType {}
+/** QueryParamsResponse defines the response type for querying x/evm parameters. */
+export interface QueryParamsResponse {
+  /** params define the evm module parameters. */
+  params: Params;
+}
+export interface QueryParamsResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryParamsResponse";
+  value: Uint8Array;
+}
+/** QueryParamsResponse defines the response type for querying x/evm parameters. */
+export interface QueryParamsResponseAmino {
+  /** params define the evm module parameters. */
+  params?: ParamsAmino;
+}
+export interface QueryParamsResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryParamsResponse";
+  value: QueryParamsResponseAmino;
+}
+/** QueryParamsResponse defines the response type for querying x/evm parameters. */
+export interface QueryParamsResponseSDKType {
+  params: ParamsSDKType;
+}
+/** EthCallRequest defines EthCall request */
+export interface EthCallRequest {
+  /** args uses the same json format as the json rpc api. */
+  args: Uint8Array;
+  /** gas_cap defines the default gas cap to be used */
+  gasCap: bigint;
+  /** proposer_address of the requested block in hex format */
+  proposerAddress: Uint8Array;
+  /** chain_id is the eip155 chain id parsed from the requested block header */
+  chainId: bigint;
+}
+export interface EthCallRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.EthCallRequest";
+  value: Uint8Array;
+}
+/** EthCallRequest defines EthCall request */
+export interface EthCallRequestAmino {
+  /** args uses the same json format as the json rpc api. */
+  args?: string;
+  /** gas_cap defines the default gas cap to be used */
+  gas_cap?: string;
+  /** proposer_address of the requested block in hex format */
+  proposer_address?: string;
+  /** chain_id is the eip155 chain id parsed from the requested block header */
+  chain_id?: string;
+}
+export interface EthCallRequestAminoMsg {
+  type: "/ethermint.evm.v1.EthCallRequest";
+  value: EthCallRequestAmino;
+}
+/** EthCallRequest defines EthCall request */
+export interface EthCallRequestSDKType {
+  args: Uint8Array;
+  gas_cap: bigint;
+  proposer_address: Uint8Array;
+  chain_id: bigint;
+}
+/** EstimateGasResponse defines EstimateGas response */
+export interface EstimateGasResponse {
+  /** gas returns the estimated gas */
+  gas: bigint;
+}
+export interface EstimateGasResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.EstimateGasResponse";
+  value: Uint8Array;
+}
+/** EstimateGasResponse defines EstimateGas response */
+export interface EstimateGasResponseAmino {
+  /** gas returns the estimated gas */
+  gas?: string;
+}
+export interface EstimateGasResponseAminoMsg {
+  type: "/ethermint.evm.v1.EstimateGasResponse";
+  value: EstimateGasResponseAmino;
+}
+/** EstimateGasResponse defines EstimateGas response */
+export interface EstimateGasResponseSDKType {
+  gas: bigint;
+}
+/** QueryTraceTxRequest defines TraceTx request */
+export interface QueryTraceTxRequest {
+  /** msg is the MsgEthereumTx for the requested transaction */
+  msg?: MsgEthereumTx;
+  /** trace_config holds extra parameters to trace functions. */
+  traceConfig?: TraceConfig;
+  /**
+   * predecessors is an array of transactions included in the same block
+   * need to be replayed first to get correct context for tracing.
+   */
+  predecessors: MsgEthereumTx[];
+  /** block_number of requested transaction */
+  blockNumber: bigint;
+  /** block_hash of requested transaction */
+  blockHash: string;
+  /** block_time of requested transaction */
+  blockTime: Timestamp;
+  /** proposer_address is the proposer of the requested block */
+  proposerAddress: Uint8Array;
+  /** chain_id is the eip155 chain id parsed from the requested block header */
+  chainId: bigint;
+  /** block_max_gas of the block of the requested transaction */
+  blockMaxGas: bigint;
+}
+export interface QueryTraceTxRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryTraceTxRequest";
+  value: Uint8Array;
+}
+/** QueryTraceTxRequest defines TraceTx request */
+export interface QueryTraceTxRequestAmino {
+  /** msg is the MsgEthereumTx for the requested transaction */
+  msg?: MsgEthereumTxAmino;
+  /** trace_config holds extra parameters to trace functions. */
+  trace_config?: TraceConfigAmino;
+  /**
+   * predecessors is an array of transactions included in the same block
+   * need to be replayed first to get correct context for tracing.
+   */
+  predecessors?: MsgEthereumTxAmino[];
+  /** block_number of requested transaction */
+  block_number?: string;
+  /** block_hash of requested transaction */
+  block_hash?: string;
+  /** block_time of requested transaction */
+  block_time?: string;
+  /** proposer_address is the proposer of the requested block */
+  proposer_address?: string;
+  /** chain_id is the eip155 chain id parsed from the requested block header */
+  chain_id?: string;
+  /** block_max_gas of the block of the requested transaction */
+  block_max_gas?: string;
+}
+export interface QueryTraceTxRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryTraceTxRequest";
+  value: QueryTraceTxRequestAmino;
+}
+/** QueryTraceTxRequest defines TraceTx request */
+export interface QueryTraceTxRequestSDKType {
+  msg?: MsgEthereumTxSDKType;
+  trace_config?: TraceConfigSDKType;
+  predecessors: MsgEthereumTxSDKType[];
+  block_number: bigint;
+  block_hash: string;
+  block_time: TimestampSDKType;
+  proposer_address: Uint8Array;
+  chain_id: bigint;
+  block_max_gas: bigint;
+}
+/** QueryTraceTxResponse defines TraceTx response */
+export interface QueryTraceTxResponse {
+  /** data is the response serialized in bytes */
+  data: Uint8Array;
+}
+export interface QueryTraceTxResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryTraceTxResponse";
+  value: Uint8Array;
+}
+/** QueryTraceTxResponse defines TraceTx response */
+export interface QueryTraceTxResponseAmino {
+  /** data is the response serialized in bytes */
+  data?: string;
+}
+export interface QueryTraceTxResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryTraceTxResponse";
+  value: QueryTraceTxResponseAmino;
+}
+/** QueryTraceTxResponse defines TraceTx response */
+export interface QueryTraceTxResponseSDKType {
+  data: Uint8Array;
+}
+/** QueryTraceBlockRequest defines TraceTx request */
+export interface QueryTraceBlockRequest {
+  /** txs is an array of messages in the block */
+  txs: MsgEthereumTx[];
+  /** trace_config holds extra parameters to trace functions. */
+  traceConfig?: TraceConfig;
+  /** block_number of the traced block */
+  blockNumber: bigint;
+  /** block_hash (hex) of the traced block */
+  blockHash: string;
+  /** block_time of the traced block */
+  blockTime: Timestamp;
+  /** proposer_address is the address of the requested block */
+  proposerAddress: Uint8Array;
+  /** chain_id is the eip155 chain id parsed from the requested block header */
+  chainId: bigint;
+  /** block_max_gas of the traced block */
+  blockMaxGas: bigint;
+}
+export interface QueryTraceBlockRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryTraceBlockRequest";
+  value: Uint8Array;
+}
+/** QueryTraceBlockRequest defines TraceTx request */
+export interface QueryTraceBlockRequestAmino {
+  /** txs is an array of messages in the block */
+  txs?: MsgEthereumTxAmino[];
+  /** trace_config holds extra parameters to trace functions. */
+  trace_config?: TraceConfigAmino;
+  /** block_number of the traced block */
+  block_number?: string;
+  /** block_hash (hex) of the traced block */
+  block_hash?: string;
+  /** block_time of the traced block */
+  block_time?: string;
+  /** proposer_address is the address of the requested block */
+  proposer_address?: string;
+  /** chain_id is the eip155 chain id parsed from the requested block header */
+  chain_id?: string;
+  /** block_max_gas of the traced block */
+  block_max_gas?: string;
+}
+export interface QueryTraceBlockRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryTraceBlockRequest";
+  value: QueryTraceBlockRequestAmino;
+}
+/** QueryTraceBlockRequest defines TraceTx request */
+export interface QueryTraceBlockRequestSDKType {
+  txs: MsgEthereumTxSDKType[];
+  trace_config?: TraceConfigSDKType;
+  block_number: bigint;
+  block_hash: string;
+  block_time: TimestampSDKType;
+  proposer_address: Uint8Array;
+  chain_id: bigint;
+  block_max_gas: bigint;
+}
+/** QueryTraceBlockResponse defines TraceBlock response */
+export interface QueryTraceBlockResponse {
+  /** data is the response serialized in bytes */
+  data: Uint8Array;
+}
+export interface QueryTraceBlockResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryTraceBlockResponse";
+  value: Uint8Array;
+}
+/** QueryTraceBlockResponse defines TraceBlock response */
+export interface QueryTraceBlockResponseAmino {
+  /** data is the response serialized in bytes */
+  data?: string;
+}
+export interface QueryTraceBlockResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryTraceBlockResponse";
+  value: QueryTraceBlockResponseAmino;
+}
+/** QueryTraceBlockResponse defines TraceBlock response */
+export interface QueryTraceBlockResponseSDKType {
+  data: Uint8Array;
+}
+/**
+ * QueryBaseFeeRequest defines the request type for querying the EIP1559 base
+ * fee.
+ */
+export interface QueryBaseFeeRequest {}
+export interface QueryBaseFeeRequestProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryBaseFeeRequest";
+  value: Uint8Array;
+}
+/**
+ * QueryBaseFeeRequest defines the request type for querying the EIP1559 base
+ * fee.
+ */
+export interface QueryBaseFeeRequestAmino {}
+export interface QueryBaseFeeRequestAminoMsg {
+  type: "/ethermint.evm.v1.QueryBaseFeeRequest";
+  value: QueryBaseFeeRequestAmino;
+}
+/**
+ * QueryBaseFeeRequest defines the request type for querying the EIP1559 base
+ * fee.
+ */
+export interface QueryBaseFeeRequestSDKType {}
+/** QueryBaseFeeResponse returns the EIP1559 base fee. */
+export interface QueryBaseFeeResponse {
+  /** base_fee is the EIP1559 base fee */
+  baseFee: string;
+}
+export interface QueryBaseFeeResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.QueryBaseFeeResponse";
+  value: Uint8Array;
+}
+/** QueryBaseFeeResponse returns the EIP1559 base fee. */
+export interface QueryBaseFeeResponseAmino {
+  /** base_fee is the EIP1559 base fee */
+  base_fee?: string;
+}
+export interface QueryBaseFeeResponseAminoMsg {
+  type: "/ethermint.evm.v1.QueryBaseFeeResponse";
+  value: QueryBaseFeeResponseAmino;
+}
+/** QueryBaseFeeResponse returns the EIP1559 base fee. */
+export interface QueryBaseFeeResponseSDKType {
+  base_fee: string;
+}
+function createBaseQueryAccountRequest(): QueryAccountRequest {
+  return {
+    address: ""
+  };
+}
+export const QueryAccountRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryAccountRequest",
+  encode(message: QueryAccountRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryAccountRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryAccountRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryAccountRequest {
+    return {
+      address: isSet(object.address) ? String(object.address) : ""
+    };
+  },
+  toJSON(message: QueryAccountRequest): JsonSafe<QueryAccountRequest> {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryAccountRequest>): QueryAccountRequest {
+    const message = createBaseQueryAccountRequest();
+    message.address = object.address ?? "";
+    return message;
+  },
+  fromAmino(object: QueryAccountRequestAmino): QueryAccountRequest {
+    const message = createBaseQueryAccountRequest();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    }
+    return message;
+  },
+  toAmino(message: QueryAccountRequest): QueryAccountRequestAmino {
+    const obj: any = {};
+    obj.address = message.address === "" ? undefined : message.address;
+    return obj;
+  },
+  fromAminoMsg(object: QueryAccountRequestAminoMsg): QueryAccountRequest {
+    return QueryAccountRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryAccountRequestProtoMsg): QueryAccountRequest {
+    return QueryAccountRequest.decode(message.value);
+  },
+  toProto(message: QueryAccountRequest): Uint8Array {
+    return QueryAccountRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryAccountRequest): QueryAccountRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryAccountRequest",
+      value: QueryAccountRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryAccountResponse(): QueryAccountResponse {
+  return {
+    balance: "",
+    codeHash: "",
+    nonce: BigInt(0)
+  };
+}
+export const QueryAccountResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryAccountResponse",
+  encode(message: QueryAccountResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.balance !== "") {
+      writer.uint32(10).string(message.balance);
+    }
+    if (message.codeHash !== "") {
+      writer.uint32(18).string(message.codeHash);
+    }
+    if (message.nonce !== BigInt(0)) {
+      writer.uint32(24).uint64(message.nonce);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryAccountResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryAccountResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.balance = reader.string();
+          break;
+        case 2:
+          message.codeHash = reader.string();
+          break;
+        case 3:
+          message.nonce = reader.uint64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryAccountResponse {
+    return {
+      balance: isSet(object.balance) ? String(object.balance) : "",
+      codeHash: isSet(object.codeHash) ? String(object.codeHash) : "",
+      nonce: isSet(object.nonce) ? BigInt(object.nonce.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: QueryAccountResponse): JsonSafe<QueryAccountResponse> {
+    const obj: any = {};
+    message.balance !== undefined && (obj.balance = message.balance);
+    message.codeHash !== undefined && (obj.codeHash = message.codeHash);
+    message.nonce !== undefined && (obj.nonce = (message.nonce || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<QueryAccountResponse>): QueryAccountResponse {
+    const message = createBaseQueryAccountResponse();
+    message.balance = object.balance ?? "";
+    message.codeHash = object.codeHash ?? "";
+    message.nonce = object.nonce !== undefined && object.nonce !== null ? BigInt(object.nonce.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: QueryAccountResponseAmino): QueryAccountResponse {
+    const message = createBaseQueryAccountResponse();
+    if (object.balance !== undefined && object.balance !== null) {
+      message.balance = object.balance;
+    }
+    if (object.code_hash !== undefined && object.code_hash !== null) {
+      message.codeHash = object.code_hash;
+    }
+    if (object.nonce !== undefined && object.nonce !== null) {
+      message.nonce = BigInt(object.nonce);
+    }
+    return message;
+  },
+  toAmino(message: QueryAccountResponse): QueryAccountResponseAmino {
+    const obj: any = {};
+    obj.balance = message.balance === "" ? undefined : message.balance;
+    obj.code_hash = message.codeHash === "" ? undefined : message.codeHash;
+    obj.nonce = message.nonce !== BigInt(0) ? message.nonce.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryAccountResponseAminoMsg): QueryAccountResponse {
+    return QueryAccountResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryAccountResponseProtoMsg): QueryAccountResponse {
+    return QueryAccountResponse.decode(message.value);
+  },
+  toProto(message: QueryAccountResponse): Uint8Array {
+    return QueryAccountResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryAccountResponse): QueryAccountResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryAccountResponse",
+      value: QueryAccountResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryCosmosAccountRequest(): QueryCosmosAccountRequest {
+  return {
+    address: ""
+  };
+}
+export const QueryCosmosAccountRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryCosmosAccountRequest",
+  encode(message: QueryCosmosAccountRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryCosmosAccountRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryCosmosAccountRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryCosmosAccountRequest {
+    return {
+      address: isSet(object.address) ? String(object.address) : ""
+    };
+  },
+  toJSON(message: QueryCosmosAccountRequest): JsonSafe<QueryCosmosAccountRequest> {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryCosmosAccountRequest>): QueryCosmosAccountRequest {
+    const message = createBaseQueryCosmosAccountRequest();
+    message.address = object.address ?? "";
+    return message;
+  },
+  fromAmino(object: QueryCosmosAccountRequestAmino): QueryCosmosAccountRequest {
+    const message = createBaseQueryCosmosAccountRequest();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    }
+    return message;
+  },
+  toAmino(message: QueryCosmosAccountRequest): QueryCosmosAccountRequestAmino {
+    const obj: any = {};
+    obj.address = message.address === "" ? undefined : message.address;
+    return obj;
+  },
+  fromAminoMsg(object: QueryCosmosAccountRequestAminoMsg): QueryCosmosAccountRequest {
+    return QueryCosmosAccountRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryCosmosAccountRequestProtoMsg): QueryCosmosAccountRequest {
+    return QueryCosmosAccountRequest.decode(message.value);
+  },
+  toProto(message: QueryCosmosAccountRequest): Uint8Array {
+    return QueryCosmosAccountRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryCosmosAccountRequest): QueryCosmosAccountRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryCosmosAccountRequest",
+      value: QueryCosmosAccountRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryCosmosAccountResponse(): QueryCosmosAccountResponse {
+  return {
+    cosmosAddress: "",
+    sequence: BigInt(0),
+    accountNumber: BigInt(0)
+  };
+}
+export const QueryCosmosAccountResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryCosmosAccountResponse",
+  encode(message: QueryCosmosAccountResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.cosmosAddress !== "") {
+      writer.uint32(10).string(message.cosmosAddress);
+    }
+    if (message.sequence !== BigInt(0)) {
+      writer.uint32(16).uint64(message.sequence);
+    }
+    if (message.accountNumber !== BigInt(0)) {
+      writer.uint32(24).uint64(message.accountNumber);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryCosmosAccountResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryCosmosAccountResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.cosmosAddress = reader.string();
+          break;
+        case 2:
+          message.sequence = reader.uint64();
+          break;
+        case 3:
+          message.accountNumber = reader.uint64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryCosmosAccountResponse {
+    return {
+      cosmosAddress: isSet(object.cosmosAddress) ? String(object.cosmosAddress) : "",
+      sequence: isSet(object.sequence) ? BigInt(object.sequence.toString()) : BigInt(0),
+      accountNumber: isSet(object.accountNumber) ? BigInt(object.accountNumber.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: QueryCosmosAccountResponse): JsonSafe<QueryCosmosAccountResponse> {
+    const obj: any = {};
+    message.cosmosAddress !== undefined && (obj.cosmosAddress = message.cosmosAddress);
+    message.sequence !== undefined && (obj.sequence = (message.sequence || BigInt(0)).toString());
+    message.accountNumber !== undefined && (obj.accountNumber = (message.accountNumber || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<QueryCosmosAccountResponse>): QueryCosmosAccountResponse {
+    const message = createBaseQueryCosmosAccountResponse();
+    message.cosmosAddress = object.cosmosAddress ?? "";
+    message.sequence = object.sequence !== undefined && object.sequence !== null ? BigInt(object.sequence.toString()) : BigInt(0);
+    message.accountNumber = object.accountNumber !== undefined && object.accountNumber !== null ? BigInt(object.accountNumber.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: QueryCosmosAccountResponseAmino): QueryCosmosAccountResponse {
+    const message = createBaseQueryCosmosAccountResponse();
+    if (object.cosmos_address !== undefined && object.cosmos_address !== null) {
+      message.cosmosAddress = object.cosmos_address;
+    }
+    if (object.sequence !== undefined && object.sequence !== null) {
+      message.sequence = BigInt(object.sequence);
+    }
+    if (object.account_number !== undefined && object.account_number !== null) {
+      message.accountNumber = BigInt(object.account_number);
+    }
+    return message;
+  },
+  toAmino(message: QueryCosmosAccountResponse): QueryCosmosAccountResponseAmino {
+    const obj: any = {};
+    obj.cosmos_address = message.cosmosAddress === "" ? undefined : message.cosmosAddress;
+    obj.sequence = message.sequence !== BigInt(0) ? message.sequence.toString() : undefined;
+    obj.account_number = message.accountNumber !== BigInt(0) ? message.accountNumber.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryCosmosAccountResponseAminoMsg): QueryCosmosAccountResponse {
+    return QueryCosmosAccountResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryCosmosAccountResponseProtoMsg): QueryCosmosAccountResponse {
+    return QueryCosmosAccountResponse.decode(message.value);
+  },
+  toProto(message: QueryCosmosAccountResponse): Uint8Array {
+    return QueryCosmosAccountResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryCosmosAccountResponse): QueryCosmosAccountResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryCosmosAccountResponse",
+      value: QueryCosmosAccountResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryValidatorAccountRequest(): QueryValidatorAccountRequest {
+  return {
+    consAddress: ""
+  };
+}
+export const QueryValidatorAccountRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryValidatorAccountRequest",
+  encode(message: QueryValidatorAccountRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.consAddress !== "") {
+      writer.uint32(10).string(message.consAddress);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryValidatorAccountRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryValidatorAccountRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.consAddress = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryValidatorAccountRequest {
+    return {
+      consAddress: isSet(object.consAddress) ? String(object.consAddress) : ""
+    };
+  },
+  toJSON(message: QueryValidatorAccountRequest): JsonSafe<QueryValidatorAccountRequest> {
+    const obj: any = {};
+    message.consAddress !== undefined && (obj.consAddress = message.consAddress);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryValidatorAccountRequest>): QueryValidatorAccountRequest {
+    const message = createBaseQueryValidatorAccountRequest();
+    message.consAddress = object.consAddress ?? "";
+    return message;
+  },
+  fromAmino(object: QueryValidatorAccountRequestAmino): QueryValidatorAccountRequest {
+    const message = createBaseQueryValidatorAccountRequest();
+    if (object.cons_address !== undefined && object.cons_address !== null) {
+      message.consAddress = object.cons_address;
+    }
+    return message;
+  },
+  toAmino(message: QueryValidatorAccountRequest): QueryValidatorAccountRequestAmino {
+    const obj: any = {};
+    obj.cons_address = message.consAddress === "" ? undefined : message.consAddress;
+    return obj;
+  },
+  fromAminoMsg(object: QueryValidatorAccountRequestAminoMsg): QueryValidatorAccountRequest {
+    return QueryValidatorAccountRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryValidatorAccountRequestProtoMsg): QueryValidatorAccountRequest {
+    return QueryValidatorAccountRequest.decode(message.value);
+  },
+  toProto(message: QueryValidatorAccountRequest): Uint8Array {
+    return QueryValidatorAccountRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryValidatorAccountRequest): QueryValidatorAccountRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryValidatorAccountRequest",
+      value: QueryValidatorAccountRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryValidatorAccountResponse(): QueryValidatorAccountResponse {
+  return {
+    accountAddress: "",
+    sequence: BigInt(0),
+    accountNumber: BigInt(0)
+  };
+}
+export const QueryValidatorAccountResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryValidatorAccountResponse",
+  encode(message: QueryValidatorAccountResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.accountAddress !== "") {
+      writer.uint32(10).string(message.accountAddress);
+    }
+    if (message.sequence !== BigInt(0)) {
+      writer.uint32(16).uint64(message.sequence);
+    }
+    if (message.accountNumber !== BigInt(0)) {
+      writer.uint32(24).uint64(message.accountNumber);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryValidatorAccountResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryValidatorAccountResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.accountAddress = reader.string();
+          break;
+        case 2:
+          message.sequence = reader.uint64();
+          break;
+        case 3:
+          message.accountNumber = reader.uint64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryValidatorAccountResponse {
+    return {
+      accountAddress: isSet(object.accountAddress) ? String(object.accountAddress) : "",
+      sequence: isSet(object.sequence) ? BigInt(object.sequence.toString()) : BigInt(0),
+      accountNumber: isSet(object.accountNumber) ? BigInt(object.accountNumber.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: QueryValidatorAccountResponse): JsonSafe<QueryValidatorAccountResponse> {
+    const obj: any = {};
+    message.accountAddress !== undefined && (obj.accountAddress = message.accountAddress);
+    message.sequence !== undefined && (obj.sequence = (message.sequence || BigInt(0)).toString());
+    message.accountNumber !== undefined && (obj.accountNumber = (message.accountNumber || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<QueryValidatorAccountResponse>): QueryValidatorAccountResponse {
+    const message = createBaseQueryValidatorAccountResponse();
+    message.accountAddress = object.accountAddress ?? "";
+    message.sequence = object.sequence !== undefined && object.sequence !== null ? BigInt(object.sequence.toString()) : BigInt(0);
+    message.accountNumber = object.accountNumber !== undefined && object.accountNumber !== null ? BigInt(object.accountNumber.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: QueryValidatorAccountResponseAmino): QueryValidatorAccountResponse {
+    const message = createBaseQueryValidatorAccountResponse();
+    if (object.account_address !== undefined && object.account_address !== null) {
+      message.accountAddress = object.account_address;
+    }
+    if (object.sequence !== undefined && object.sequence !== null) {
+      message.sequence = BigInt(object.sequence);
+    }
+    if (object.account_number !== undefined && object.account_number !== null) {
+      message.accountNumber = BigInt(object.account_number);
+    }
+    return message;
+  },
+  toAmino(message: QueryValidatorAccountResponse): QueryValidatorAccountResponseAmino {
+    const obj: any = {};
+    obj.account_address = message.accountAddress === "" ? undefined : message.accountAddress;
+    obj.sequence = message.sequence !== BigInt(0) ? message.sequence.toString() : undefined;
+    obj.account_number = message.accountNumber !== BigInt(0) ? message.accountNumber.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryValidatorAccountResponseAminoMsg): QueryValidatorAccountResponse {
+    return QueryValidatorAccountResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryValidatorAccountResponseProtoMsg): QueryValidatorAccountResponse {
+    return QueryValidatorAccountResponse.decode(message.value);
+  },
+  toProto(message: QueryValidatorAccountResponse): Uint8Array {
+    return QueryValidatorAccountResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryValidatorAccountResponse): QueryValidatorAccountResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryValidatorAccountResponse",
+      value: QueryValidatorAccountResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryBalanceRequest(): QueryBalanceRequest {
+  return {
+    address: ""
+  };
+}
+export const QueryBalanceRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryBalanceRequest",
+  encode(message: QueryBalanceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryBalanceRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBalanceRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryBalanceRequest {
+    return {
+      address: isSet(object.address) ? String(object.address) : ""
+    };
+  },
+  toJSON(message: QueryBalanceRequest): JsonSafe<QueryBalanceRequest> {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryBalanceRequest>): QueryBalanceRequest {
+    const message = createBaseQueryBalanceRequest();
+    message.address = object.address ?? "";
+    return message;
+  },
+  fromAmino(object: QueryBalanceRequestAmino): QueryBalanceRequest {
+    const message = createBaseQueryBalanceRequest();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    }
+    return message;
+  },
+  toAmino(message: QueryBalanceRequest): QueryBalanceRequestAmino {
+    const obj: any = {};
+    obj.address = message.address === "" ? undefined : message.address;
+    return obj;
+  },
+  fromAminoMsg(object: QueryBalanceRequestAminoMsg): QueryBalanceRequest {
+    return QueryBalanceRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryBalanceRequestProtoMsg): QueryBalanceRequest {
+    return QueryBalanceRequest.decode(message.value);
+  },
+  toProto(message: QueryBalanceRequest): Uint8Array {
+    return QueryBalanceRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryBalanceRequest): QueryBalanceRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryBalanceRequest",
+      value: QueryBalanceRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryBalanceResponse(): QueryBalanceResponse {
+  return {
+    balance: ""
+  };
+}
+export const QueryBalanceResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryBalanceResponse",
+  encode(message: QueryBalanceResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.balance !== "") {
+      writer.uint32(10).string(message.balance);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryBalanceResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBalanceResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.balance = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryBalanceResponse {
+    return {
+      balance: isSet(object.balance) ? String(object.balance) : ""
+    };
+  },
+  toJSON(message: QueryBalanceResponse): JsonSafe<QueryBalanceResponse> {
+    const obj: any = {};
+    message.balance !== undefined && (obj.balance = message.balance);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryBalanceResponse>): QueryBalanceResponse {
+    const message = createBaseQueryBalanceResponse();
+    message.balance = object.balance ?? "";
+    return message;
+  },
+  fromAmino(object: QueryBalanceResponseAmino): QueryBalanceResponse {
+    const message = createBaseQueryBalanceResponse();
+    if (object.balance !== undefined && object.balance !== null) {
+      message.balance = object.balance;
+    }
+    return message;
+  },
+  toAmino(message: QueryBalanceResponse): QueryBalanceResponseAmino {
+    const obj: any = {};
+    obj.balance = message.balance === "" ? undefined : message.balance;
+    return obj;
+  },
+  fromAminoMsg(object: QueryBalanceResponseAminoMsg): QueryBalanceResponse {
+    return QueryBalanceResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryBalanceResponseProtoMsg): QueryBalanceResponse {
+    return QueryBalanceResponse.decode(message.value);
+  },
+  toProto(message: QueryBalanceResponse): Uint8Array {
+    return QueryBalanceResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryBalanceResponse): QueryBalanceResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryBalanceResponse",
+      value: QueryBalanceResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryStorageRequest(): QueryStorageRequest {
+  return {
+    address: "",
+    key: ""
+  };
+}
+export const QueryStorageRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryStorageRequest",
+  encode(message: QueryStorageRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    if (message.key !== "") {
+      writer.uint32(18).string(message.key);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryStorageRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryStorageRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        case 2:
+          message.key = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryStorageRequest {
+    return {
+      address: isSet(object.address) ? String(object.address) : "",
+      key: isSet(object.key) ? String(object.key) : ""
+    };
+  },
+  toJSON(message: QueryStorageRequest): JsonSafe<QueryStorageRequest> {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    message.key !== undefined && (obj.key = message.key);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryStorageRequest>): QueryStorageRequest {
+    const message = createBaseQueryStorageRequest();
+    message.address = object.address ?? "";
+    message.key = object.key ?? "";
+    return message;
+  },
+  fromAmino(object: QueryStorageRequestAmino): QueryStorageRequest {
+    const message = createBaseQueryStorageRequest();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    }
+    if (object.key !== undefined && object.key !== null) {
+      message.key = object.key;
+    }
+    return message;
+  },
+  toAmino(message: QueryStorageRequest): QueryStorageRequestAmino {
+    const obj: any = {};
+    obj.address = message.address === "" ? undefined : message.address;
+    obj.key = message.key === "" ? undefined : message.key;
+    return obj;
+  },
+  fromAminoMsg(object: QueryStorageRequestAminoMsg): QueryStorageRequest {
+    return QueryStorageRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryStorageRequestProtoMsg): QueryStorageRequest {
+    return QueryStorageRequest.decode(message.value);
+  },
+  toProto(message: QueryStorageRequest): Uint8Array {
+    return QueryStorageRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryStorageRequest): QueryStorageRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryStorageRequest",
+      value: QueryStorageRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryStorageResponse(): QueryStorageResponse {
+  return {
+    value: ""
+  };
+}
+export const QueryStorageResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryStorageResponse",
+  encode(message: QueryStorageResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.value !== "") {
+      writer.uint32(10).string(message.value);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryStorageResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryStorageResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.value = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryStorageResponse {
+    return {
+      value: isSet(object.value) ? String(object.value) : ""
+    };
+  },
+  toJSON(message: QueryStorageResponse): JsonSafe<QueryStorageResponse> {
+    const obj: any = {};
+    message.value !== undefined && (obj.value = message.value);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryStorageResponse>): QueryStorageResponse {
+    const message = createBaseQueryStorageResponse();
+    message.value = object.value ?? "";
+    return message;
+  },
+  fromAmino(object: QueryStorageResponseAmino): QueryStorageResponse {
+    const message = createBaseQueryStorageResponse();
+    if (object.value !== undefined && object.value !== null) {
+      message.value = object.value;
+    }
+    return message;
+  },
+  toAmino(message: QueryStorageResponse): QueryStorageResponseAmino {
+    const obj: any = {};
+    obj.value = message.value === "" ? undefined : message.value;
+    return obj;
+  },
+  fromAminoMsg(object: QueryStorageResponseAminoMsg): QueryStorageResponse {
+    return QueryStorageResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryStorageResponseProtoMsg): QueryStorageResponse {
+    return QueryStorageResponse.decode(message.value);
+  },
+  toProto(message: QueryStorageResponse): Uint8Array {
+    return QueryStorageResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryStorageResponse): QueryStorageResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryStorageResponse",
+      value: QueryStorageResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryCodeRequest(): QueryCodeRequest {
+  return {
+    address: ""
+  };
+}
+export const QueryCodeRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryCodeRequest",
+  encode(message: QueryCodeRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryCodeRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryCodeRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.address = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryCodeRequest {
+    return {
+      address: isSet(object.address) ? String(object.address) : ""
+    };
+  },
+  toJSON(message: QueryCodeRequest): JsonSafe<QueryCodeRequest> {
+    const obj: any = {};
+    message.address !== undefined && (obj.address = message.address);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryCodeRequest>): QueryCodeRequest {
+    const message = createBaseQueryCodeRequest();
+    message.address = object.address ?? "";
+    return message;
+  },
+  fromAmino(object: QueryCodeRequestAmino): QueryCodeRequest {
+    const message = createBaseQueryCodeRequest();
+    if (object.address !== undefined && object.address !== null) {
+      message.address = object.address;
+    }
+    return message;
+  },
+  toAmino(message: QueryCodeRequest): QueryCodeRequestAmino {
+    const obj: any = {};
+    obj.address = message.address === "" ? undefined : message.address;
+    return obj;
+  },
+  fromAminoMsg(object: QueryCodeRequestAminoMsg): QueryCodeRequest {
+    return QueryCodeRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryCodeRequestProtoMsg): QueryCodeRequest {
+    return QueryCodeRequest.decode(message.value);
+  },
+  toProto(message: QueryCodeRequest): Uint8Array {
+    return QueryCodeRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryCodeRequest): QueryCodeRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryCodeRequest",
+      value: QueryCodeRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryCodeResponse(): QueryCodeResponse {
+  return {
+    code: new Uint8Array()
+  };
+}
+export const QueryCodeResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryCodeResponse",
+  encode(message: QueryCodeResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.code.length !== 0) {
+      writer.uint32(10).bytes(message.code);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryCodeResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryCodeResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.code = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryCodeResponse {
+    return {
+      code: isSet(object.code) ? bytesFromBase64(object.code) : new Uint8Array()
+    };
+  },
+  toJSON(message: QueryCodeResponse): JsonSafe<QueryCodeResponse> {
+    const obj: any = {};
+    message.code !== undefined && (obj.code = base64FromBytes(message.code !== undefined ? message.code : new Uint8Array()));
+    return obj;
+  },
+  fromPartial(object: Partial<QueryCodeResponse>): QueryCodeResponse {
+    const message = createBaseQueryCodeResponse();
+    message.code = object.code ?? new Uint8Array();
+    return message;
+  },
+  fromAmino(object: QueryCodeResponseAmino): QueryCodeResponse {
+    const message = createBaseQueryCodeResponse();
+    if (object.code !== undefined && object.code !== null) {
+      message.code = bytesFromBase64(object.code);
+    }
+    return message;
+  },
+  toAmino(message: QueryCodeResponse): QueryCodeResponseAmino {
+    const obj: any = {};
+    obj.code = message.code ? base64FromBytes(message.code) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryCodeResponseAminoMsg): QueryCodeResponse {
+    return QueryCodeResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryCodeResponseProtoMsg): QueryCodeResponse {
+    return QueryCodeResponse.decode(message.value);
+  },
+  toProto(message: QueryCodeResponse): Uint8Array {
+    return QueryCodeResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryCodeResponse): QueryCodeResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryCodeResponse",
+      value: QueryCodeResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryTxLogsRequest(): QueryTxLogsRequest {
+  return {
+    hash: "",
+    pagination: undefined
+  };
+}
+export const QueryTxLogsRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryTxLogsRequest",
+  encode(message: QueryTxLogsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.hash !== "") {
+      writer.uint32(10).string(message.hash);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryTxLogsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryTxLogsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.hash = reader.string();
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryTxLogsRequest {
+    return {
+      hash: isSet(object.hash) ? String(object.hash) : "",
+      pagination: isSet(object.pagination) ? PageRequest.fromJSON(object.pagination) : undefined
+    };
+  },
+  toJSON(message: QueryTxLogsRequest): JsonSafe<QueryTxLogsRequest> {
+    const obj: any = {};
+    message.hash !== undefined && (obj.hash = message.hash);
+    message.pagination !== undefined && (obj.pagination = message.pagination ? PageRequest.toJSON(message.pagination) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryTxLogsRequest>): QueryTxLogsRequest {
+    const message = createBaseQueryTxLogsRequest();
+    message.hash = object.hash ?? "";
+    message.pagination = object.pagination !== undefined && object.pagination !== null ? PageRequest.fromPartial(object.pagination) : undefined;
+    return message;
+  },
+  fromAmino(object: QueryTxLogsRequestAmino): QueryTxLogsRequest {
+    const message = createBaseQueryTxLogsRequest();
+    if (object.hash !== undefined && object.hash !== null) {
+      message.hash = object.hash;
+    }
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageRequest.fromAmino(object.pagination);
+    }
+    return message;
+  },
+  toAmino(message: QueryTxLogsRequest): QueryTxLogsRequestAmino {
+    const obj: any = {};
+    obj.hash = message.hash === "" ? undefined : message.hash;
+    obj.pagination = message.pagination ? PageRequest.toAmino(message.pagination) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryTxLogsRequestAminoMsg): QueryTxLogsRequest {
+    return QueryTxLogsRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryTxLogsRequestProtoMsg): QueryTxLogsRequest {
+    return QueryTxLogsRequest.decode(message.value);
+  },
+  toProto(message: QueryTxLogsRequest): Uint8Array {
+    return QueryTxLogsRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryTxLogsRequest): QueryTxLogsRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryTxLogsRequest",
+      value: QueryTxLogsRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryTxLogsResponse(): QueryTxLogsResponse {
+  return {
+    logs: [],
+    pagination: undefined
+  };
+}
+export const QueryTxLogsResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryTxLogsResponse",
+  encode(message: QueryTxLogsResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    for (const v of message.logs) {
+      Log.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryTxLogsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryTxLogsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.logs.push(Log.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryTxLogsResponse {
+    return {
+      logs: Array.isArray(object?.logs) ? object.logs.map((e: any) => Log.fromJSON(e)) : [],
+      pagination: isSet(object.pagination) ? PageResponse.fromJSON(object.pagination) : undefined
+    };
+  },
+  toJSON(message: QueryTxLogsResponse): JsonSafe<QueryTxLogsResponse> {
+    const obj: any = {};
+    if (message.logs) {
+      obj.logs = message.logs.map(e => e ? Log.toJSON(e) : undefined);
+    } else {
+      obj.logs = [];
+    }
+    message.pagination !== undefined && (obj.pagination = message.pagination ? PageResponse.toJSON(message.pagination) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryTxLogsResponse>): QueryTxLogsResponse {
+    const message = createBaseQueryTxLogsResponse();
+    message.logs = object.logs?.map(e => Log.fromPartial(e)) || [];
+    message.pagination = object.pagination !== undefined && object.pagination !== null ? PageResponse.fromPartial(object.pagination) : undefined;
+    return message;
+  },
+  fromAmino(object: QueryTxLogsResponseAmino): QueryTxLogsResponse {
+    const message = createBaseQueryTxLogsResponse();
+    message.logs = object.logs?.map(e => Log.fromAmino(e)) || [];
+    if (object.pagination !== undefined && object.pagination !== null) {
+      message.pagination = PageResponse.fromAmino(object.pagination);
+    }
+    return message;
+  },
+  toAmino(message: QueryTxLogsResponse): QueryTxLogsResponseAmino {
+    const obj: any = {};
+    if (message.logs) {
+      obj.logs = message.logs.map(e => e ? Log.toAmino(e) : undefined);
+    } else {
+      obj.logs = message.logs;
+    }
+    obj.pagination = message.pagination ? PageResponse.toAmino(message.pagination) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryTxLogsResponseAminoMsg): QueryTxLogsResponse {
+    return QueryTxLogsResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryTxLogsResponseProtoMsg): QueryTxLogsResponse {
+    return QueryTxLogsResponse.decode(message.value);
+  },
+  toProto(message: QueryTxLogsResponse): Uint8Array {
+    return QueryTxLogsResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryTxLogsResponse): QueryTxLogsResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryTxLogsResponse",
+      value: QueryTxLogsResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryParamsRequest(): QueryParamsRequest {
+  return {};
+}
+export const QueryParamsRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryParamsRequest",
+  encode(_: QueryParamsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryParamsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryParamsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(_: any): QueryParamsRequest {
+    return {};
+  },
+  toJSON(_: QueryParamsRequest): JsonSafe<QueryParamsRequest> {
+    const obj: any = {};
+    return obj;
+  },
+  fromPartial(_: Partial<QueryParamsRequest>): QueryParamsRequest {
+    const message = createBaseQueryParamsRequest();
+    return message;
+  },
+  fromAmino(_: QueryParamsRequestAmino): QueryParamsRequest {
+    const message = createBaseQueryParamsRequest();
+    return message;
+  },
+  toAmino(_: QueryParamsRequest): QueryParamsRequestAmino {
+    const obj: any = {};
+    return obj;
+  },
+  fromAminoMsg(object: QueryParamsRequestAminoMsg): QueryParamsRequest {
+    return QueryParamsRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryParamsRequestProtoMsg): QueryParamsRequest {
+    return QueryParamsRequest.decode(message.value);
+  },
+  toProto(message: QueryParamsRequest): Uint8Array {
+    return QueryParamsRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryParamsRequest): QueryParamsRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryParamsRequest",
+      value: QueryParamsRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryParamsResponse(): QueryParamsResponse {
+  return {
+    params: Params.fromPartial({})
+  };
+}
+export const QueryParamsResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryParamsResponse",
+  encode(message: QueryParamsResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.params !== undefined) {
+      Params.encode(message.params, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryParamsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryParamsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.params = Params.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryParamsResponse {
+    return {
+      params: isSet(object.params) ? Params.fromJSON(object.params) : undefined
+    };
+  },
+  toJSON(message: QueryParamsResponse): JsonSafe<QueryParamsResponse> {
+    const obj: any = {};
+    message.params !== undefined && (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryParamsResponse>): QueryParamsResponse {
+    const message = createBaseQueryParamsResponse();
+    message.params = object.params !== undefined && object.params !== null ? Params.fromPartial(object.params) : undefined;
+    return message;
+  },
+  fromAmino(object: QueryParamsResponseAmino): QueryParamsResponse {
+    const message = createBaseQueryParamsResponse();
+    if (object.params !== undefined && object.params !== null) {
+      message.params = Params.fromAmino(object.params);
+    }
+    return message;
+  },
+  toAmino(message: QueryParamsResponse): QueryParamsResponseAmino {
+    const obj: any = {};
+    obj.params = message.params ? Params.toAmino(message.params) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryParamsResponseAminoMsg): QueryParamsResponse {
+    return QueryParamsResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryParamsResponseProtoMsg): QueryParamsResponse {
+    return QueryParamsResponse.decode(message.value);
+  },
+  toProto(message: QueryParamsResponse): Uint8Array {
+    return QueryParamsResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryParamsResponse): QueryParamsResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryParamsResponse",
+      value: QueryParamsResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseEthCallRequest(): EthCallRequest {
+  return {
+    args: new Uint8Array(),
+    gasCap: BigInt(0),
+    proposerAddress: new Uint8Array(),
+    chainId: BigInt(0)
+  };
+}
+export const EthCallRequest = {
+  typeUrl: "/ethermint.evm.v1.EthCallRequest",
+  encode(message: EthCallRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.args.length !== 0) {
+      writer.uint32(10).bytes(message.args);
+    }
+    if (message.gasCap !== BigInt(0)) {
+      writer.uint32(16).uint64(message.gasCap);
+    }
+    if (message.proposerAddress.length !== 0) {
+      writer.uint32(26).bytes(message.proposerAddress);
+    }
+    if (message.chainId !== BigInt(0)) {
+      writer.uint32(32).int64(message.chainId);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EthCallRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEthCallRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.args = reader.bytes();
+          break;
+        case 2:
+          message.gasCap = reader.uint64();
+          break;
+        case 3:
+          message.proposerAddress = reader.bytes();
+          break;
+        case 4:
+          message.chainId = reader.int64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EthCallRequest {
+    return {
+      args: isSet(object.args) ? bytesFromBase64(object.args) : new Uint8Array(),
+      gasCap: isSet(object.gasCap) ? BigInt(object.gasCap.toString()) : BigInt(0),
+      proposerAddress: isSet(object.proposerAddress) ? bytesFromBase64(object.proposerAddress) : new Uint8Array(),
+      chainId: isSet(object.chainId) ? BigInt(object.chainId.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: EthCallRequest): JsonSafe<EthCallRequest> {
+    const obj: any = {};
+    message.args !== undefined && (obj.args = base64FromBytes(message.args !== undefined ? message.args : new Uint8Array()));
+    message.gasCap !== undefined && (obj.gasCap = (message.gasCap || BigInt(0)).toString());
+    message.proposerAddress !== undefined && (obj.proposerAddress = base64FromBytes(message.proposerAddress !== undefined ? message.proposerAddress : new Uint8Array()));
+    message.chainId !== undefined && (obj.chainId = (message.chainId || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<EthCallRequest>): EthCallRequest {
+    const message = createBaseEthCallRequest();
+    message.args = object.args ?? new Uint8Array();
+    message.gasCap = object.gasCap !== undefined && object.gasCap !== null ? BigInt(object.gasCap.toString()) : BigInt(0);
+    message.proposerAddress = object.proposerAddress ?? new Uint8Array();
+    message.chainId = object.chainId !== undefined && object.chainId !== null ? BigInt(object.chainId.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: EthCallRequestAmino): EthCallRequest {
+    const message = createBaseEthCallRequest();
+    if (object.args !== undefined && object.args !== null) {
+      message.args = bytesFromBase64(object.args);
+    }
+    if (object.gas_cap !== undefined && object.gas_cap !== null) {
+      message.gasCap = BigInt(object.gas_cap);
+    }
+    if (object.proposer_address !== undefined && object.proposer_address !== null) {
+      message.proposerAddress = bytesFromBase64(object.proposer_address);
+    }
+    if (object.chain_id !== undefined && object.chain_id !== null) {
+      message.chainId = BigInt(object.chain_id);
+    }
+    return message;
+  },
+  toAmino(message: EthCallRequest): EthCallRequestAmino {
+    const obj: any = {};
+    obj.args = message.args ? base64FromBytes(message.args) : undefined;
+    obj.gas_cap = message.gasCap !== BigInt(0) ? message.gasCap.toString() : undefined;
+    obj.proposer_address = message.proposerAddress ? base64FromBytes(message.proposerAddress) : undefined;
+    obj.chain_id = message.chainId !== BigInt(0) ? message.chainId.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: EthCallRequestAminoMsg): EthCallRequest {
+    return EthCallRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: EthCallRequestProtoMsg): EthCallRequest {
+    return EthCallRequest.decode(message.value);
+  },
+  toProto(message: EthCallRequest): Uint8Array {
+    return EthCallRequest.encode(message).finish();
+  },
+  toProtoMsg(message: EthCallRequest): EthCallRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.EthCallRequest",
+      value: EthCallRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseEstimateGasResponse(): EstimateGasResponse {
+  return {
+    gas: BigInt(0)
+  };
+}
+export const EstimateGasResponse = {
+  typeUrl: "/ethermint.evm.v1.EstimateGasResponse",
+  encode(message: EstimateGasResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.gas !== BigInt(0)) {
+      writer.uint32(8).uint64(message.gas);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EstimateGasResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEstimateGasResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.gas = reader.uint64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EstimateGasResponse {
+    return {
+      gas: isSet(object.gas) ? BigInt(object.gas.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: EstimateGasResponse): JsonSafe<EstimateGasResponse> {
+    const obj: any = {};
+    message.gas !== undefined && (obj.gas = (message.gas || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<EstimateGasResponse>): EstimateGasResponse {
+    const message = createBaseEstimateGasResponse();
+    message.gas = object.gas !== undefined && object.gas !== null ? BigInt(object.gas.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: EstimateGasResponseAmino): EstimateGasResponse {
+    const message = createBaseEstimateGasResponse();
+    if (object.gas !== undefined && object.gas !== null) {
+      message.gas = BigInt(object.gas);
+    }
+    return message;
+  },
+  toAmino(message: EstimateGasResponse): EstimateGasResponseAmino {
+    const obj: any = {};
+    obj.gas = message.gas !== BigInt(0) ? message.gas.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: EstimateGasResponseAminoMsg): EstimateGasResponse {
+    return EstimateGasResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: EstimateGasResponseProtoMsg): EstimateGasResponse {
+    return EstimateGasResponse.decode(message.value);
+  },
+  toProto(message: EstimateGasResponse): Uint8Array {
+    return EstimateGasResponse.encode(message).finish();
+  },
+  toProtoMsg(message: EstimateGasResponse): EstimateGasResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.EstimateGasResponse",
+      value: EstimateGasResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryTraceTxRequest(): QueryTraceTxRequest {
+  return {
+    msg: undefined,
+    traceConfig: undefined,
+    predecessors: [],
+    blockNumber: BigInt(0),
+    blockHash: "",
+    blockTime: Timestamp.fromPartial({}),
+    proposerAddress: new Uint8Array(),
+    chainId: BigInt(0),
+    blockMaxGas: BigInt(0)
+  };
+}
+export const QueryTraceTxRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryTraceTxRequest",
+  encode(message: QueryTraceTxRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.msg !== undefined) {
+      MsgEthereumTx.encode(message.msg, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.traceConfig !== undefined) {
+      TraceConfig.encode(message.traceConfig, writer.uint32(26).fork()).ldelim();
+    }
+    for (const v of message.predecessors) {
+      MsgEthereumTx.encode(v!, writer.uint32(34).fork()).ldelim();
+    }
+    if (message.blockNumber !== BigInt(0)) {
+      writer.uint32(40).int64(message.blockNumber);
+    }
+    if (message.blockHash !== "") {
+      writer.uint32(50).string(message.blockHash);
+    }
+    if (message.blockTime !== undefined) {
+      Timestamp.encode(message.blockTime, writer.uint32(58).fork()).ldelim();
+    }
+    if (message.proposerAddress.length !== 0) {
+      writer.uint32(66).bytes(message.proposerAddress);
+    }
+    if (message.chainId !== BigInt(0)) {
+      writer.uint32(72).int64(message.chainId);
+    }
+    if (message.blockMaxGas !== BigInt(0)) {
+      writer.uint32(80).int64(message.blockMaxGas);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryTraceTxRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryTraceTxRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.msg = MsgEthereumTx.decode(reader, reader.uint32());
+          break;
+        case 3:
+          message.traceConfig = TraceConfig.decode(reader, reader.uint32());
+          break;
+        case 4:
+          message.predecessors.push(MsgEthereumTx.decode(reader, reader.uint32()));
+          break;
+        case 5:
+          message.blockNumber = reader.int64();
+          break;
+        case 6:
+          message.blockHash = reader.string();
+          break;
+        case 7:
+          message.blockTime = Timestamp.decode(reader, reader.uint32());
+          break;
+        case 8:
+          message.proposerAddress = reader.bytes();
+          break;
+        case 9:
+          message.chainId = reader.int64();
+          break;
+        case 10:
+          message.blockMaxGas = reader.int64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryTraceTxRequest {
+    return {
+      msg: isSet(object.msg) ? MsgEthereumTx.fromJSON(object.msg) : undefined,
+      traceConfig: isSet(object.traceConfig) ? TraceConfig.fromJSON(object.traceConfig) : undefined,
+      predecessors: Array.isArray(object?.predecessors) ? object.predecessors.map((e: any) => MsgEthereumTx.fromJSON(e)) : [],
+      blockNumber: isSet(object.blockNumber) ? BigInt(object.blockNumber.toString()) : BigInt(0),
+      blockHash: isSet(object.blockHash) ? String(object.blockHash) : "",
+      blockTime: isSet(object.blockTime) ? fromJsonTimestamp(object.blockTime) : undefined,
+      proposerAddress: isSet(object.proposerAddress) ? bytesFromBase64(object.proposerAddress) : new Uint8Array(),
+      chainId: isSet(object.chainId) ? BigInt(object.chainId.toString()) : BigInt(0),
+      blockMaxGas: isSet(object.blockMaxGas) ? BigInt(object.blockMaxGas.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: QueryTraceTxRequest): JsonSafe<QueryTraceTxRequest> {
+    const obj: any = {};
+    message.msg !== undefined && (obj.msg = message.msg ? MsgEthereumTx.toJSON(message.msg) : undefined);
+    message.traceConfig !== undefined && (obj.traceConfig = message.traceConfig ? TraceConfig.toJSON(message.traceConfig) : undefined);
+    if (message.predecessors) {
+      obj.predecessors = message.predecessors.map(e => e ? MsgEthereumTx.toJSON(e) : undefined);
+    } else {
+      obj.predecessors = [];
+    }
+    message.blockNumber !== undefined && (obj.blockNumber = (message.blockNumber || BigInt(0)).toString());
+    message.blockHash !== undefined && (obj.blockHash = message.blockHash);
+    message.blockTime !== undefined && (obj.blockTime = fromTimestamp(message.blockTime).toISOString());
+    message.proposerAddress !== undefined && (obj.proposerAddress = base64FromBytes(message.proposerAddress !== undefined ? message.proposerAddress : new Uint8Array()));
+    message.chainId !== undefined && (obj.chainId = (message.chainId || BigInt(0)).toString());
+    message.blockMaxGas !== undefined && (obj.blockMaxGas = (message.blockMaxGas || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<QueryTraceTxRequest>): QueryTraceTxRequest {
+    const message = createBaseQueryTraceTxRequest();
+    message.msg = object.msg !== undefined && object.msg !== null ? MsgEthereumTx.fromPartial(object.msg) : undefined;
+    message.traceConfig = object.traceConfig !== undefined && object.traceConfig !== null ? TraceConfig.fromPartial(object.traceConfig) : undefined;
+    message.predecessors = object.predecessors?.map(e => MsgEthereumTx.fromPartial(e)) || [];
+    message.blockNumber = object.blockNumber !== undefined && object.blockNumber !== null ? BigInt(object.blockNumber.toString()) : BigInt(0);
+    message.blockHash = object.blockHash ?? "";
+    message.blockTime = object.blockTime !== undefined && object.blockTime !== null ? Timestamp.fromPartial(object.blockTime) : undefined;
+    message.proposerAddress = object.proposerAddress ?? new Uint8Array();
+    message.chainId = object.chainId !== undefined && object.chainId !== null ? BigInt(object.chainId.toString()) : BigInt(0);
+    message.blockMaxGas = object.blockMaxGas !== undefined && object.blockMaxGas !== null ? BigInt(object.blockMaxGas.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: QueryTraceTxRequestAmino): QueryTraceTxRequest {
+    const message = createBaseQueryTraceTxRequest();
+    if (object.msg !== undefined && object.msg !== null) {
+      message.msg = MsgEthereumTx.fromAmino(object.msg);
+    }
+    if (object.trace_config !== undefined && object.trace_config !== null) {
+      message.traceConfig = TraceConfig.fromAmino(object.trace_config);
+    }
+    message.predecessors = object.predecessors?.map(e => MsgEthereumTx.fromAmino(e)) || [];
+    if (object.block_number !== undefined && object.block_number !== null) {
+      message.blockNumber = BigInt(object.block_number);
+    }
+    if (object.block_hash !== undefined && object.block_hash !== null) {
+      message.blockHash = object.block_hash;
+    }
+    if (object.block_time !== undefined && object.block_time !== null) {
+      message.blockTime = Timestamp.fromAmino(object.block_time);
+    }
+    if (object.proposer_address !== undefined && object.proposer_address !== null) {
+      message.proposerAddress = bytesFromBase64(object.proposer_address);
+    }
+    if (object.chain_id !== undefined && object.chain_id !== null) {
+      message.chainId = BigInt(object.chain_id);
+    }
+    if (object.block_max_gas !== undefined && object.block_max_gas !== null) {
+      message.blockMaxGas = BigInt(object.block_max_gas);
+    }
+    return message;
+  },
+  toAmino(message: QueryTraceTxRequest): QueryTraceTxRequestAmino {
+    const obj: any = {};
+    obj.msg = message.msg ? MsgEthereumTx.toAmino(message.msg) : undefined;
+    obj.trace_config = message.traceConfig ? TraceConfig.toAmino(message.traceConfig) : undefined;
+    if (message.predecessors) {
+      obj.predecessors = message.predecessors.map(e => e ? MsgEthereumTx.toAmino(e) : undefined);
+    } else {
+      obj.predecessors = message.predecessors;
+    }
+    obj.block_number = message.blockNumber !== BigInt(0) ? message.blockNumber.toString() : undefined;
+    obj.block_hash = message.blockHash === "" ? undefined : message.blockHash;
+    obj.block_time = message.blockTime ? Timestamp.toAmino(message.blockTime) : undefined;
+    obj.proposer_address = message.proposerAddress ? base64FromBytes(message.proposerAddress) : undefined;
+    obj.chain_id = message.chainId !== BigInt(0) ? message.chainId.toString() : undefined;
+    obj.block_max_gas = message.blockMaxGas !== BigInt(0) ? message.blockMaxGas.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryTraceTxRequestAminoMsg): QueryTraceTxRequest {
+    return QueryTraceTxRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryTraceTxRequestProtoMsg): QueryTraceTxRequest {
+    return QueryTraceTxRequest.decode(message.value);
+  },
+  toProto(message: QueryTraceTxRequest): Uint8Array {
+    return QueryTraceTxRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryTraceTxRequest): QueryTraceTxRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryTraceTxRequest",
+      value: QueryTraceTxRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryTraceTxResponse(): QueryTraceTxResponse {
+  return {
+    data: new Uint8Array()
+  };
+}
+export const QueryTraceTxResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryTraceTxResponse",
+  encode(message: QueryTraceTxResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.data.length !== 0) {
+      writer.uint32(10).bytes(message.data);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryTraceTxResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryTraceTxResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.data = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryTraceTxResponse {
+    return {
+      data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array()
+    };
+  },
+  toJSON(message: QueryTraceTxResponse): JsonSafe<QueryTraceTxResponse> {
+    const obj: any = {};
+    message.data !== undefined && (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+    return obj;
+  },
+  fromPartial(object: Partial<QueryTraceTxResponse>): QueryTraceTxResponse {
+    const message = createBaseQueryTraceTxResponse();
+    message.data = object.data ?? new Uint8Array();
+    return message;
+  },
+  fromAmino(object: QueryTraceTxResponseAmino): QueryTraceTxResponse {
+    const message = createBaseQueryTraceTxResponse();
+    if (object.data !== undefined && object.data !== null) {
+      message.data = bytesFromBase64(object.data);
+    }
+    return message;
+  },
+  toAmino(message: QueryTraceTxResponse): QueryTraceTxResponseAmino {
+    const obj: any = {};
+    obj.data = message.data ? base64FromBytes(message.data) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryTraceTxResponseAminoMsg): QueryTraceTxResponse {
+    return QueryTraceTxResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryTraceTxResponseProtoMsg): QueryTraceTxResponse {
+    return QueryTraceTxResponse.decode(message.value);
+  },
+  toProto(message: QueryTraceTxResponse): Uint8Array {
+    return QueryTraceTxResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryTraceTxResponse): QueryTraceTxResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryTraceTxResponse",
+      value: QueryTraceTxResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryTraceBlockRequest(): QueryTraceBlockRequest {
+  return {
+    txs: [],
+    traceConfig: undefined,
+    blockNumber: BigInt(0),
+    blockHash: "",
+    blockTime: Timestamp.fromPartial({}),
+    proposerAddress: new Uint8Array(),
+    chainId: BigInt(0),
+    blockMaxGas: BigInt(0)
+  };
+}
+export const QueryTraceBlockRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryTraceBlockRequest",
+  encode(message: QueryTraceBlockRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    for (const v of message.txs) {
+      MsgEthereumTx.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.traceConfig !== undefined) {
+      TraceConfig.encode(message.traceConfig, writer.uint32(26).fork()).ldelim();
+    }
+    if (message.blockNumber !== BigInt(0)) {
+      writer.uint32(40).int64(message.blockNumber);
+    }
+    if (message.blockHash !== "") {
+      writer.uint32(50).string(message.blockHash);
+    }
+    if (message.blockTime !== undefined) {
+      Timestamp.encode(message.blockTime, writer.uint32(58).fork()).ldelim();
+    }
+    if (message.proposerAddress.length !== 0) {
+      writer.uint32(66).bytes(message.proposerAddress);
+    }
+    if (message.chainId !== BigInt(0)) {
+      writer.uint32(72).int64(message.chainId);
+    }
+    if (message.blockMaxGas !== BigInt(0)) {
+      writer.uint32(80).int64(message.blockMaxGas);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryTraceBlockRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryTraceBlockRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.txs.push(MsgEthereumTx.decode(reader, reader.uint32()));
+          break;
+        case 3:
+          message.traceConfig = TraceConfig.decode(reader, reader.uint32());
+          break;
+        case 5:
+          message.blockNumber = reader.int64();
+          break;
+        case 6:
+          message.blockHash = reader.string();
+          break;
+        case 7:
+          message.blockTime = Timestamp.decode(reader, reader.uint32());
+          break;
+        case 8:
+          message.proposerAddress = reader.bytes();
+          break;
+        case 9:
+          message.chainId = reader.int64();
+          break;
+        case 10:
+          message.blockMaxGas = reader.int64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryTraceBlockRequest {
+    return {
+      txs: Array.isArray(object?.txs) ? object.txs.map((e: any) => MsgEthereumTx.fromJSON(e)) : [],
+      traceConfig: isSet(object.traceConfig) ? TraceConfig.fromJSON(object.traceConfig) : undefined,
+      blockNumber: isSet(object.blockNumber) ? BigInt(object.blockNumber.toString()) : BigInt(0),
+      blockHash: isSet(object.blockHash) ? String(object.blockHash) : "",
+      blockTime: isSet(object.blockTime) ? fromJsonTimestamp(object.blockTime) : undefined,
+      proposerAddress: isSet(object.proposerAddress) ? bytesFromBase64(object.proposerAddress) : new Uint8Array(),
+      chainId: isSet(object.chainId) ? BigInt(object.chainId.toString()) : BigInt(0),
+      blockMaxGas: isSet(object.blockMaxGas) ? BigInt(object.blockMaxGas.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: QueryTraceBlockRequest): JsonSafe<QueryTraceBlockRequest> {
+    const obj: any = {};
+    if (message.txs) {
+      obj.txs = message.txs.map(e => e ? MsgEthereumTx.toJSON(e) : undefined);
+    } else {
+      obj.txs = [];
+    }
+    message.traceConfig !== undefined && (obj.traceConfig = message.traceConfig ? TraceConfig.toJSON(message.traceConfig) : undefined);
+    message.blockNumber !== undefined && (obj.blockNumber = (message.blockNumber || BigInt(0)).toString());
+    message.blockHash !== undefined && (obj.blockHash = message.blockHash);
+    message.blockTime !== undefined && (obj.blockTime = fromTimestamp(message.blockTime).toISOString());
+    message.proposerAddress !== undefined && (obj.proposerAddress = base64FromBytes(message.proposerAddress !== undefined ? message.proposerAddress : new Uint8Array()));
+    message.chainId !== undefined && (obj.chainId = (message.chainId || BigInt(0)).toString());
+    message.blockMaxGas !== undefined && (obj.blockMaxGas = (message.blockMaxGas || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<QueryTraceBlockRequest>): QueryTraceBlockRequest {
+    const message = createBaseQueryTraceBlockRequest();
+    message.txs = object.txs?.map(e => MsgEthereumTx.fromPartial(e)) || [];
+    message.traceConfig = object.traceConfig !== undefined && object.traceConfig !== null ? TraceConfig.fromPartial(object.traceConfig) : undefined;
+    message.blockNumber = object.blockNumber !== undefined && object.blockNumber !== null ? BigInt(object.blockNumber.toString()) : BigInt(0);
+    message.blockHash = object.blockHash ?? "";
+    message.blockTime = object.blockTime !== undefined && object.blockTime !== null ? Timestamp.fromPartial(object.blockTime) : undefined;
+    message.proposerAddress = object.proposerAddress ?? new Uint8Array();
+    message.chainId = object.chainId !== undefined && object.chainId !== null ? BigInt(object.chainId.toString()) : BigInt(0);
+    message.blockMaxGas = object.blockMaxGas !== undefined && object.blockMaxGas !== null ? BigInt(object.blockMaxGas.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: QueryTraceBlockRequestAmino): QueryTraceBlockRequest {
+    const message = createBaseQueryTraceBlockRequest();
+    message.txs = object.txs?.map(e => MsgEthereumTx.fromAmino(e)) || [];
+    if (object.trace_config !== undefined && object.trace_config !== null) {
+      message.traceConfig = TraceConfig.fromAmino(object.trace_config);
+    }
+    if (object.block_number !== undefined && object.block_number !== null) {
+      message.blockNumber = BigInt(object.block_number);
+    }
+    if (object.block_hash !== undefined && object.block_hash !== null) {
+      message.blockHash = object.block_hash;
+    }
+    if (object.block_time !== undefined && object.block_time !== null) {
+      message.blockTime = Timestamp.fromAmino(object.block_time);
+    }
+    if (object.proposer_address !== undefined && object.proposer_address !== null) {
+      message.proposerAddress = bytesFromBase64(object.proposer_address);
+    }
+    if (object.chain_id !== undefined && object.chain_id !== null) {
+      message.chainId = BigInt(object.chain_id);
+    }
+    if (object.block_max_gas !== undefined && object.block_max_gas !== null) {
+      message.blockMaxGas = BigInt(object.block_max_gas);
+    }
+    return message;
+  },
+  toAmino(message: QueryTraceBlockRequest): QueryTraceBlockRequestAmino {
+    const obj: any = {};
+    if (message.txs) {
+      obj.txs = message.txs.map(e => e ? MsgEthereumTx.toAmino(e) : undefined);
+    } else {
+      obj.txs = message.txs;
+    }
+    obj.trace_config = message.traceConfig ? TraceConfig.toAmino(message.traceConfig) : undefined;
+    obj.block_number = message.blockNumber !== BigInt(0) ? message.blockNumber.toString() : undefined;
+    obj.block_hash = message.blockHash === "" ? undefined : message.blockHash;
+    obj.block_time = message.blockTime ? Timestamp.toAmino(message.blockTime) : undefined;
+    obj.proposer_address = message.proposerAddress ? base64FromBytes(message.proposerAddress) : undefined;
+    obj.chain_id = message.chainId !== BigInt(0) ? message.chainId.toString() : undefined;
+    obj.block_max_gas = message.blockMaxGas !== BigInt(0) ? message.blockMaxGas.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryTraceBlockRequestAminoMsg): QueryTraceBlockRequest {
+    return QueryTraceBlockRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryTraceBlockRequestProtoMsg): QueryTraceBlockRequest {
+    return QueryTraceBlockRequest.decode(message.value);
+  },
+  toProto(message: QueryTraceBlockRequest): Uint8Array {
+    return QueryTraceBlockRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryTraceBlockRequest): QueryTraceBlockRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryTraceBlockRequest",
+      value: QueryTraceBlockRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryTraceBlockResponse(): QueryTraceBlockResponse {
+  return {
+    data: new Uint8Array()
+  };
+}
+export const QueryTraceBlockResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryTraceBlockResponse",
+  encode(message: QueryTraceBlockResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.data.length !== 0) {
+      writer.uint32(10).bytes(message.data);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryTraceBlockResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryTraceBlockResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.data = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryTraceBlockResponse {
+    return {
+      data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array()
+    };
+  },
+  toJSON(message: QueryTraceBlockResponse): JsonSafe<QueryTraceBlockResponse> {
+    const obj: any = {};
+    message.data !== undefined && (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+    return obj;
+  },
+  fromPartial(object: Partial<QueryTraceBlockResponse>): QueryTraceBlockResponse {
+    const message = createBaseQueryTraceBlockResponse();
+    message.data = object.data ?? new Uint8Array();
+    return message;
+  },
+  fromAmino(object: QueryTraceBlockResponseAmino): QueryTraceBlockResponse {
+    const message = createBaseQueryTraceBlockResponse();
+    if (object.data !== undefined && object.data !== null) {
+      message.data = bytesFromBase64(object.data);
+    }
+    return message;
+  },
+  toAmino(message: QueryTraceBlockResponse): QueryTraceBlockResponseAmino {
+    const obj: any = {};
+    obj.data = message.data ? base64FromBytes(message.data) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryTraceBlockResponseAminoMsg): QueryTraceBlockResponse {
+    return QueryTraceBlockResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryTraceBlockResponseProtoMsg): QueryTraceBlockResponse {
+    return QueryTraceBlockResponse.decode(message.value);
+  },
+  toProto(message: QueryTraceBlockResponse): Uint8Array {
+    return QueryTraceBlockResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryTraceBlockResponse): QueryTraceBlockResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryTraceBlockResponse",
+      value: QueryTraceBlockResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryBaseFeeRequest(): QueryBaseFeeRequest {
+  return {};
+}
+export const QueryBaseFeeRequest = {
+  typeUrl: "/ethermint.evm.v1.QueryBaseFeeRequest",
+  encode(_: QueryBaseFeeRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryBaseFeeRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBaseFeeRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(_: any): QueryBaseFeeRequest {
+    return {};
+  },
+  toJSON(_: QueryBaseFeeRequest): JsonSafe<QueryBaseFeeRequest> {
+    const obj: any = {};
+    return obj;
+  },
+  fromPartial(_: Partial<QueryBaseFeeRequest>): QueryBaseFeeRequest {
+    const message = createBaseQueryBaseFeeRequest();
+    return message;
+  },
+  fromAmino(_: QueryBaseFeeRequestAmino): QueryBaseFeeRequest {
+    const message = createBaseQueryBaseFeeRequest();
+    return message;
+  },
+  toAmino(_: QueryBaseFeeRequest): QueryBaseFeeRequestAmino {
+    const obj: any = {};
+    return obj;
+  },
+  fromAminoMsg(object: QueryBaseFeeRequestAminoMsg): QueryBaseFeeRequest {
+    return QueryBaseFeeRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryBaseFeeRequestProtoMsg): QueryBaseFeeRequest {
+    return QueryBaseFeeRequest.decode(message.value);
+  },
+  toProto(message: QueryBaseFeeRequest): Uint8Array {
+    return QueryBaseFeeRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryBaseFeeRequest): QueryBaseFeeRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryBaseFeeRequest",
+      value: QueryBaseFeeRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryBaseFeeResponse(): QueryBaseFeeResponse {
+  return {
+    baseFee: ""
+  };
+}
+export const QueryBaseFeeResponse = {
+  typeUrl: "/ethermint.evm.v1.QueryBaseFeeResponse",
+  encode(message: QueryBaseFeeResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.baseFee !== "") {
+      writer.uint32(10).string(message.baseFee);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryBaseFeeResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBaseFeeResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.baseFee = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryBaseFeeResponse {
+    return {
+      baseFee: isSet(object.baseFee) ? String(object.baseFee) : ""
+    };
+  },
+  toJSON(message: QueryBaseFeeResponse): JsonSafe<QueryBaseFeeResponse> {
+    const obj: any = {};
+    message.baseFee !== undefined && (obj.baseFee = message.baseFee);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryBaseFeeResponse>): QueryBaseFeeResponse {
+    const message = createBaseQueryBaseFeeResponse();
+    message.baseFee = object.baseFee ?? "";
+    return message;
+  },
+  fromAmino(object: QueryBaseFeeResponseAmino): QueryBaseFeeResponse {
+    const message = createBaseQueryBaseFeeResponse();
+    if (object.base_fee !== undefined && object.base_fee !== null) {
+      message.baseFee = object.base_fee;
+    }
+    return message;
+  },
+  toAmino(message: QueryBaseFeeResponse): QueryBaseFeeResponseAmino {
+    const obj: any = {};
+    obj.base_fee = message.baseFee === "" ? undefined : message.baseFee;
+    return obj;
+  },
+  fromAminoMsg(object: QueryBaseFeeResponseAminoMsg): QueryBaseFeeResponse {
+    return QueryBaseFeeResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryBaseFeeResponseProtoMsg): QueryBaseFeeResponse {
+    return QueryBaseFeeResponse.decode(message.value);
+  },
+  toProto(message: QueryBaseFeeResponse): Uint8Array {
+    return QueryBaseFeeResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryBaseFeeResponse): QueryBaseFeeResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.QueryBaseFeeResponse",
+      value: QueryBaseFeeResponse.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/evm/v1/tx.amino.ts
+++ b/wardenjs/src/codegen/ethermint/evm/v1/tx.amino.ts
@@ -1,0 +1,14 @@
+//@ts-nocheck
+import { MsgEthereumTx, MsgUpdateParams } from "./tx.js";
+export const AminoConverter = {
+  "/ethermint.evm.v1.MsgEthereumTx": {
+    aminoType: "/ethermint.evm.v1.MsgEthereumTx",
+    toAmino: MsgEthereumTx.toAmino,
+    fromAmino: MsgEthereumTx.fromAmino
+  },
+  "/ethermint.evm.v1.MsgUpdateParams": {
+    aminoType: "/ethermint.evm.v1.MsgUpdateParams",
+    toAmino: MsgUpdateParams.toAmino,
+    fromAmino: MsgUpdateParams.fromAmino
+  }
+};

--- a/wardenjs/src/codegen/ethermint/evm/v1/tx.registry.ts
+++ b/wardenjs/src/codegen/ethermint/evm/v1/tx.registry.ts
@@ -1,0 +1,81 @@
+//@ts-nocheck
+import { GeneratedType, Registry } from "@cosmjs/proto-signing";
+import { MsgEthereumTx, MsgUpdateParams } from "./tx.js";
+export const registry: ReadonlyArray<[string, GeneratedType]> = [["/ethermint.evm.v1.MsgEthereumTx", MsgEthereumTx], ["/ethermint.evm.v1.MsgUpdateParams", MsgUpdateParams]];
+export const load = (protoRegistry: Registry) => {
+  registry.forEach(([typeUrl, mod]) => {
+    protoRegistry.register(typeUrl, mod);
+  });
+};
+export const MessageComposer = {
+  encoded: {
+    ethereumTx(value: MsgEthereumTx) {
+      return {
+        typeUrl: "/ethermint.evm.v1.MsgEthereumTx",
+        value: MsgEthereumTx.encode(value).finish()
+      };
+    },
+    updateParams(value: MsgUpdateParams) {
+      return {
+        typeUrl: "/ethermint.evm.v1.MsgUpdateParams",
+        value: MsgUpdateParams.encode(value).finish()
+      };
+    }
+  },
+  withTypeUrl: {
+    ethereumTx(value: MsgEthereumTx) {
+      return {
+        typeUrl: "/ethermint.evm.v1.MsgEthereumTx",
+        value
+      };
+    },
+    updateParams(value: MsgUpdateParams) {
+      return {
+        typeUrl: "/ethermint.evm.v1.MsgUpdateParams",
+        value
+      };
+    }
+  },
+  toJSON: {
+    ethereumTx(value: MsgEthereumTx) {
+      return {
+        typeUrl: "/ethermint.evm.v1.MsgEthereumTx",
+        value: MsgEthereumTx.toJSON(value)
+      };
+    },
+    updateParams(value: MsgUpdateParams) {
+      return {
+        typeUrl: "/ethermint.evm.v1.MsgUpdateParams",
+        value: MsgUpdateParams.toJSON(value)
+      };
+    }
+  },
+  fromJSON: {
+    ethereumTx(value: any) {
+      return {
+        typeUrl: "/ethermint.evm.v1.MsgEthereumTx",
+        value: MsgEthereumTx.fromJSON(value)
+      };
+    },
+    updateParams(value: any) {
+      return {
+        typeUrl: "/ethermint.evm.v1.MsgUpdateParams",
+        value: MsgUpdateParams.fromJSON(value)
+      };
+    }
+  },
+  fromPartial: {
+    ethereumTx(value: MsgEthereumTx) {
+      return {
+        typeUrl: "/ethermint.evm.v1.MsgEthereumTx",
+        value: MsgEthereumTx.fromPartial(value)
+      };
+    },
+    updateParams(value: MsgUpdateParams) {
+      return {
+        typeUrl: "/ethermint.evm.v1.MsgUpdateParams",
+        value: MsgUpdateParams.fromPartial(value)
+      };
+    }
+  }
+};

--- a/wardenjs/src/codegen/ethermint/evm/v1/tx.rpc.msg.ts
+++ b/wardenjs/src/codegen/ethermint/evm/v1/tx.rpc.msg.ts
@@ -1,0 +1,32 @@
+//@ts-nocheck
+import { Rpc } from "../../../helpers.js";
+import { BinaryReader } from "../../../binary.js";
+import { MsgEthereumTx, MsgEthereumTxResponse, MsgUpdateParams, MsgUpdateParamsResponse } from "./tx.js";
+/** Msg defines the evm Msg service. */
+export interface Msg {
+  /** EthereumTx defines a method submitting Ethereum transactions. */
+  ethereumTx(request: MsgEthereumTx): Promise<MsgEthereumTxResponse>;
+  /**
+   * UpdateParams defined a governance operation for updating the x/evm module parameters.
+   * The authority is hard-coded to the Cosmos SDK x/gov module account
+   */
+  updateParams(request: MsgUpdateParams): Promise<MsgUpdateParamsResponse>;
+}
+export class MsgClientImpl implements Msg {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.ethereumTx = this.ethereumTx.bind(this);
+    this.updateParams = this.updateParams.bind(this);
+  }
+  ethereumTx(request: MsgEthereumTx): Promise<MsgEthereumTxResponse> {
+    const data = MsgEthereumTx.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Msg", "EthereumTx", data);
+    return promise.then(data => MsgEthereumTxResponse.decode(new BinaryReader(data)));
+  }
+  updateParams(request: MsgUpdateParams): Promise<MsgUpdateParamsResponse> {
+    const data = MsgUpdateParams.encode(request).finish();
+    const promise = this.rpc.request("ethermint.evm.v1.Msg", "UpdateParams", data);
+    return promise.then(data => MsgUpdateParamsResponse.decode(new BinaryReader(data)));
+  }
+}

--- a/wardenjs/src/codegen/ethermint/evm/v1/tx.ts
+++ b/wardenjs/src/codegen/ethermint/evm/v1/tx.ts
@@ -1,0 +1,1503 @@
+//@ts-nocheck
+import { Any, AnyAmino, AnySDKType } from "../../../google/protobuf/any.js";
+import { Params, ParamsAmino, ParamsSDKType, AccessTuple, AccessTupleAmino, AccessTupleSDKType, Log, LogAmino, LogSDKType } from "./evm.js";
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet, bytesFromBase64, base64FromBytes } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** MsgEthereumTx encapsulates an Ethereum transaction as an SDK message. */
+export interface MsgEthereumTx {
+  /** data is inner transaction data of the Ethereum transaction */
+  data?: Any;
+  /** size is the encoded storage size of the transaction (DEPRECATED) */
+  size: number;
+  /** hash of the transaction in hex format */
+  hash: string;
+  /**
+   * from is the ethereum signer address in hex format. This address value is checked
+   * against the address derived from the signature (V, R, S) using the
+   * secp256k1 elliptic curve
+   */
+  from: string;
+}
+export interface MsgEthereumTxProtoMsg {
+  typeUrl: "/ethermint.evm.v1.MsgEthereumTx";
+  value: Uint8Array;
+}
+/** MsgEthereumTx encapsulates an Ethereum transaction as an SDK message. */
+export interface MsgEthereumTxAmino {
+  /** data is inner transaction data of the Ethereum transaction */
+  data?: AnyAmino;
+  /** size is the encoded storage size of the transaction (DEPRECATED) */
+  size: number;
+  /** hash of the transaction in hex format */
+  hash?: string;
+  /**
+   * from is the ethereum signer address in hex format. This address value is checked
+   * against the address derived from the signature (V, R, S) using the
+   * secp256k1 elliptic curve
+   */
+  from?: string;
+}
+export interface MsgEthereumTxAminoMsg {
+  type: "/ethermint.evm.v1.MsgEthereumTx";
+  value: MsgEthereumTxAmino;
+}
+/** MsgEthereumTx encapsulates an Ethereum transaction as an SDK message. */
+export interface MsgEthereumTxSDKType {
+  data?: AnySDKType;
+  size: number;
+  hash: string;
+  from: string;
+}
+/**
+ * LegacyTx is the transaction data of regular Ethereum transactions.
+ * NOTE: All non-protected transactions (i.e non EIP155 signed) will fail if the
+ * AllowUnprotectedTxs parameter is disabled.
+ */
+export interface LegacyTx {
+  $typeUrl?: "/ethermint.evm.v1.LegacyTx";
+  /** nonce corresponds to the account nonce (transaction sequence). */
+  nonce: bigint;
+  /** gas_price defines the value for each gas unit */
+  gasPrice: string;
+  /** gas defines the gas limit defined for the transaction. */
+  gas: bigint;
+  /** to is the hex formatted address of the recipient */
+  to: string;
+  /** value defines the unsigned integer value of the transaction amount. */
+  value: string;
+  /** data is the data payload bytes of the transaction. */
+  data: Uint8Array;
+  /** v defines the signature value */
+  v: Uint8Array;
+  /** r defines the signature value */
+  r: Uint8Array;
+  /** s define the signature value */
+  s: Uint8Array;
+}
+export interface LegacyTxProtoMsg {
+  typeUrl: "/ethermint.evm.v1.LegacyTx";
+  value: Uint8Array;
+}
+/**
+ * LegacyTx is the transaction data of regular Ethereum transactions.
+ * NOTE: All non-protected transactions (i.e non EIP155 signed) will fail if the
+ * AllowUnprotectedTxs parameter is disabled.
+ */
+export interface LegacyTxAmino {
+  /** nonce corresponds to the account nonce (transaction sequence). */
+  nonce?: string;
+  /** gas_price defines the value for each gas unit */
+  gas_price?: string;
+  /** gas defines the gas limit defined for the transaction. */
+  gas?: string;
+  /** to is the hex formatted address of the recipient */
+  to?: string;
+  /** value defines the unsigned integer value of the transaction amount. */
+  value?: string;
+  /** data is the data payload bytes of the transaction. */
+  data?: string;
+  /** v defines the signature value */
+  v?: string;
+  /** r defines the signature value */
+  r?: string;
+  /** s define the signature value */
+  s?: string;
+}
+export interface LegacyTxAminoMsg {
+  type: "/ethermint.evm.v1.LegacyTx";
+  value: LegacyTxAmino;
+}
+/**
+ * LegacyTx is the transaction data of regular Ethereum transactions.
+ * NOTE: All non-protected transactions (i.e non EIP155 signed) will fail if the
+ * AllowUnprotectedTxs parameter is disabled.
+ */
+export interface LegacyTxSDKType {
+  $typeUrl?: "/ethermint.evm.v1.LegacyTx";
+  nonce: bigint;
+  gas_price: string;
+  gas: bigint;
+  to: string;
+  value: string;
+  data: Uint8Array;
+  v: Uint8Array;
+  r: Uint8Array;
+  s: Uint8Array;
+}
+/** AccessListTx is the data of EIP-2930 access list transactions. */
+export interface AccessListTx {
+  $typeUrl?: "/ethermint.evm.v1.AccessListTx";
+  /** chain_id of the destination EVM chain */
+  chainId: string;
+  /** nonce corresponds to the account nonce (transaction sequence). */
+  nonce: bigint;
+  /** gas_price defines the value for each gas unit */
+  gasPrice: string;
+  /** gas defines the gas limit defined for the transaction. */
+  gas: bigint;
+  /** to is the recipient address in hex format */
+  to: string;
+  /** value defines the unsigned integer value of the transaction amount. */
+  value: string;
+  /** data is the data payload bytes of the transaction. */
+  data: Uint8Array;
+  /** accesses is an array of access tuples */
+  accesses: AccessTuple[];
+  /** v defines the signature value */
+  v: Uint8Array;
+  /** r defines the signature value */
+  r: Uint8Array;
+  /** s define the signature value */
+  s: Uint8Array;
+}
+export interface AccessListTxProtoMsg {
+  typeUrl: "/ethermint.evm.v1.AccessListTx";
+  value: Uint8Array;
+}
+/** AccessListTx is the data of EIP-2930 access list transactions. */
+export interface AccessListTxAmino {
+  /** chain_id of the destination EVM chain */
+  chain_id: string;
+  /** nonce corresponds to the account nonce (transaction sequence). */
+  nonce?: string;
+  /** gas_price defines the value for each gas unit */
+  gas_price?: string;
+  /** gas defines the gas limit defined for the transaction. */
+  gas?: string;
+  /** to is the recipient address in hex format */
+  to?: string;
+  /** value defines the unsigned integer value of the transaction amount. */
+  value?: string;
+  /** data is the data payload bytes of the transaction. */
+  data?: string;
+  /** accesses is an array of access tuples */
+  accesses: AccessTupleAmino[];
+  /** v defines the signature value */
+  v?: string;
+  /** r defines the signature value */
+  r?: string;
+  /** s define the signature value */
+  s?: string;
+}
+export interface AccessListTxAminoMsg {
+  type: "/ethermint.evm.v1.AccessListTx";
+  value: AccessListTxAmino;
+}
+/** AccessListTx is the data of EIP-2930 access list transactions. */
+export interface AccessListTxSDKType {
+  $typeUrl?: "/ethermint.evm.v1.AccessListTx";
+  chain_id: string;
+  nonce: bigint;
+  gas_price: string;
+  gas: bigint;
+  to: string;
+  value: string;
+  data: Uint8Array;
+  accesses: AccessTupleSDKType[];
+  v: Uint8Array;
+  r: Uint8Array;
+  s: Uint8Array;
+}
+/** DynamicFeeTx is the data of EIP-1559 dynamic fee transactions. */
+export interface DynamicFeeTx {
+  $typeUrl?: "/ethermint.evm.v1.DynamicFeeTx";
+  /** chain_id of the destination EVM chain */
+  chainId: string;
+  /** nonce corresponds to the account nonce (transaction sequence). */
+  nonce: bigint;
+  /** gas_tip_cap defines the max value for the gas tip */
+  gasTipCap: string;
+  /** gas_fee_cap defines the max value for the gas fee */
+  gasFeeCap: string;
+  /** gas defines the gas limit defined for the transaction. */
+  gas: bigint;
+  /** to is the hex formatted address of the recipient */
+  to: string;
+  /** value defines the transaction amount. */
+  value: string;
+  /** data is the data payload bytes of the transaction. */
+  data: Uint8Array;
+  /** accesses is an array of access tuples */
+  accesses: AccessTuple[];
+  /** v defines the signature value */
+  v: Uint8Array;
+  /** r defines the signature value */
+  r: Uint8Array;
+  /** s define the signature value */
+  s: Uint8Array;
+}
+export interface DynamicFeeTxProtoMsg {
+  typeUrl: "/ethermint.evm.v1.DynamicFeeTx";
+  value: Uint8Array;
+}
+/** DynamicFeeTx is the data of EIP-1559 dynamic fee transactions. */
+export interface DynamicFeeTxAmino {
+  /** chain_id of the destination EVM chain */
+  chain_id: string;
+  /** nonce corresponds to the account nonce (transaction sequence). */
+  nonce?: string;
+  /** gas_tip_cap defines the max value for the gas tip */
+  gas_tip_cap?: string;
+  /** gas_fee_cap defines the max value for the gas fee */
+  gas_fee_cap?: string;
+  /** gas defines the gas limit defined for the transaction. */
+  gas?: string;
+  /** to is the hex formatted address of the recipient */
+  to?: string;
+  /** value defines the transaction amount. */
+  value?: string;
+  /** data is the data payload bytes of the transaction. */
+  data?: string;
+  /** accesses is an array of access tuples */
+  accesses: AccessTupleAmino[];
+  /** v defines the signature value */
+  v?: string;
+  /** r defines the signature value */
+  r?: string;
+  /** s define the signature value */
+  s?: string;
+}
+export interface DynamicFeeTxAminoMsg {
+  type: "/ethermint.evm.v1.DynamicFeeTx";
+  value: DynamicFeeTxAmino;
+}
+/** DynamicFeeTx is the data of EIP-1559 dynamic fee transactions. */
+export interface DynamicFeeTxSDKType {
+  $typeUrl?: "/ethermint.evm.v1.DynamicFeeTx";
+  chain_id: string;
+  nonce: bigint;
+  gas_tip_cap: string;
+  gas_fee_cap: string;
+  gas: bigint;
+  to: string;
+  value: string;
+  data: Uint8Array;
+  accesses: AccessTupleSDKType[];
+  v: Uint8Array;
+  r: Uint8Array;
+  s: Uint8Array;
+}
+/** ExtensionOptionsEthereumTx is an extension option for ethereum transactions */
+export interface ExtensionOptionsEthereumTx {}
+export interface ExtensionOptionsEthereumTxProtoMsg {
+  typeUrl: "/ethermint.evm.v1.ExtensionOptionsEthereumTx";
+  value: Uint8Array;
+}
+/** ExtensionOptionsEthereumTx is an extension option for ethereum transactions */
+export interface ExtensionOptionsEthereumTxAmino {}
+export interface ExtensionOptionsEthereumTxAminoMsg {
+  type: "/ethermint.evm.v1.ExtensionOptionsEthereumTx";
+  value: ExtensionOptionsEthereumTxAmino;
+}
+/** ExtensionOptionsEthereumTx is an extension option for ethereum transactions */
+export interface ExtensionOptionsEthereumTxSDKType {}
+/** MsgEthereumTxResponse defines the Msg/EthereumTx response type. */
+export interface MsgEthereumTxResponse {
+  /**
+   * hash of the ethereum transaction in hex format. This hash differs from the
+   * Tendermint sha256 hash of the transaction bytes. See
+   * https://github.com/tendermint/tendermint/issues/6539 for reference
+   */
+  hash: string;
+  /**
+   * logs contains the transaction hash and the proto-compatible ethereum
+   * logs.
+   */
+  logs: Log[];
+  /**
+   * ret is the returned data from evm function (result or data supplied with revert
+   * opcode)
+   */
+  ret: Uint8Array;
+  /** vm_error is the error returned by vm execution */
+  vmError: string;
+  /** gas_used specifies how much gas was consumed by the transaction */
+  gasUsed: bigint;
+}
+export interface MsgEthereumTxResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.MsgEthereumTxResponse";
+  value: Uint8Array;
+}
+/** MsgEthereumTxResponse defines the Msg/EthereumTx response type. */
+export interface MsgEthereumTxResponseAmino {
+  /**
+   * hash of the ethereum transaction in hex format. This hash differs from the
+   * Tendermint sha256 hash of the transaction bytes. See
+   * https://github.com/tendermint/tendermint/issues/6539 for reference
+   */
+  hash?: string;
+  /**
+   * logs contains the transaction hash and the proto-compatible ethereum
+   * logs.
+   */
+  logs?: LogAmino[];
+  /**
+   * ret is the returned data from evm function (result or data supplied with revert
+   * opcode)
+   */
+  ret?: string;
+  /** vm_error is the error returned by vm execution */
+  vm_error?: string;
+  /** gas_used specifies how much gas was consumed by the transaction */
+  gas_used?: string;
+}
+export interface MsgEthereumTxResponseAminoMsg {
+  type: "/ethermint.evm.v1.MsgEthereumTxResponse";
+  value: MsgEthereumTxResponseAmino;
+}
+/** MsgEthereumTxResponse defines the Msg/EthereumTx response type. */
+export interface MsgEthereumTxResponseSDKType {
+  hash: string;
+  logs: LogSDKType[];
+  ret: Uint8Array;
+  vm_error: string;
+  gas_used: bigint;
+}
+/** MsgUpdateParams defines a Msg for updating the x/evm module parameters. */
+export interface MsgUpdateParams {
+  /** authority is the address of the governance account. */
+  authority: string;
+  /**
+   * params defines the x/evm parameters to update.
+   * NOTE: All parameters must be supplied.
+   */
+  params: Params;
+}
+export interface MsgUpdateParamsProtoMsg {
+  typeUrl: "/ethermint.evm.v1.MsgUpdateParams";
+  value: Uint8Array;
+}
+/** MsgUpdateParams defines a Msg for updating the x/evm module parameters. */
+export interface MsgUpdateParamsAmino {
+  /** authority is the address of the governance account. */
+  authority?: string;
+  /**
+   * params defines the x/evm parameters to update.
+   * NOTE: All parameters must be supplied.
+   */
+  params?: ParamsAmino;
+}
+export interface MsgUpdateParamsAminoMsg {
+  type: "/ethermint.evm.v1.MsgUpdateParams";
+  value: MsgUpdateParamsAmino;
+}
+/** MsgUpdateParams defines a Msg for updating the x/evm module parameters. */
+export interface MsgUpdateParamsSDKType {
+  authority: string;
+  params: ParamsSDKType;
+}
+/**
+ * MsgUpdateParamsResponse defines the response structure for executing a
+ * MsgUpdateParams message.
+ */
+export interface MsgUpdateParamsResponse {}
+export interface MsgUpdateParamsResponseProtoMsg {
+  typeUrl: "/ethermint.evm.v1.MsgUpdateParamsResponse";
+  value: Uint8Array;
+}
+/**
+ * MsgUpdateParamsResponse defines the response structure for executing a
+ * MsgUpdateParams message.
+ */
+export interface MsgUpdateParamsResponseAmino {}
+export interface MsgUpdateParamsResponseAminoMsg {
+  type: "/ethermint.evm.v1.MsgUpdateParamsResponse";
+  value: MsgUpdateParamsResponseAmino;
+}
+/**
+ * MsgUpdateParamsResponse defines the response structure for executing a
+ * MsgUpdateParams message.
+ */
+export interface MsgUpdateParamsResponseSDKType {}
+function createBaseMsgEthereumTx(): MsgEthereumTx {
+  return {
+    data: undefined,
+    size: 0,
+    hash: "",
+    from: ""
+  };
+}
+export const MsgEthereumTx = {
+  typeUrl: "/ethermint.evm.v1.MsgEthereumTx",
+  encode(message: MsgEthereumTx, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.data !== undefined) {
+      Any.encode(message.data, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.size !== 0) {
+      writer.uint32(17).double(message.size);
+    }
+    if (message.hash !== "") {
+      writer.uint32(26).string(message.hash);
+    }
+    if (message.from !== "") {
+      writer.uint32(34).string(message.from);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): MsgEthereumTx {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgEthereumTx();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.data = Any.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.size = reader.double();
+          break;
+        case 3:
+          message.hash = reader.string();
+          break;
+        case 4:
+          message.from = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): MsgEthereumTx {
+    return {
+      data: isSet(object.data) ? Any.fromJSON(object.data) : undefined,
+      size: isSet(object.size) ? Number(object.size) : 0,
+      hash: isSet(object.hash) ? String(object.hash) : "",
+      from: isSet(object.from) ? String(object.from) : ""
+    };
+  },
+  toJSON(message: MsgEthereumTx): JsonSafe<MsgEthereumTx> {
+    const obj: any = {};
+    message.data !== undefined && (obj.data = message.data ? Any.toJSON(message.data) : undefined);
+    message.size !== undefined && (obj.size = message.size);
+    message.hash !== undefined && (obj.hash = message.hash);
+    message.from !== undefined && (obj.from = message.from);
+    return obj;
+  },
+  fromPartial(object: Partial<MsgEthereumTx>): MsgEthereumTx {
+    const message = createBaseMsgEthereumTx();
+    message.data = object.data !== undefined && object.data !== null ? Any.fromPartial(object.data) : undefined;
+    message.size = object.size ?? 0;
+    message.hash = object.hash ?? "";
+    message.from = object.from ?? "";
+    return message;
+  },
+  fromAmino(object: MsgEthereumTxAmino): MsgEthereumTx {
+    const message = createBaseMsgEthereumTx();
+    if (object.data !== undefined && object.data !== null) {
+      message.data = Any.fromAmino(object.data);
+    }
+    if (object.size !== undefined && object.size !== null) {
+      message.size = object.size;
+    }
+    if (object.hash !== undefined && object.hash !== null) {
+      message.hash = object.hash;
+    }
+    if (object.from !== undefined && object.from !== null) {
+      message.from = object.from;
+    }
+    return message;
+  },
+  toAmino(message: MsgEthereumTx): MsgEthereumTxAmino {
+    const obj: any = {};
+    obj.data = message.data ? Any.toAmino(message.data) : undefined;
+    obj.size = message.size ?? 0;
+    obj.hash = message.hash === "" ? undefined : message.hash;
+    obj.from = message.from === "" ? undefined : message.from;
+    return obj;
+  },
+  fromAminoMsg(object: MsgEthereumTxAminoMsg): MsgEthereumTx {
+    return MsgEthereumTx.fromAmino(object.value);
+  },
+  fromProtoMsg(message: MsgEthereumTxProtoMsg): MsgEthereumTx {
+    return MsgEthereumTx.decode(message.value);
+  },
+  toProto(message: MsgEthereumTx): Uint8Array {
+    return MsgEthereumTx.encode(message).finish();
+  },
+  toProtoMsg(message: MsgEthereumTx): MsgEthereumTxProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.MsgEthereumTx",
+      value: MsgEthereumTx.encode(message).finish()
+    };
+  }
+};
+function createBaseLegacyTx(): LegacyTx {
+  return {
+    $typeUrl: "/ethermint.evm.v1.LegacyTx",
+    nonce: BigInt(0),
+    gasPrice: "",
+    gas: BigInt(0),
+    to: "",
+    value: "",
+    data: new Uint8Array(),
+    v: new Uint8Array(),
+    r: new Uint8Array(),
+    s: new Uint8Array()
+  };
+}
+export const LegacyTx = {
+  typeUrl: "/ethermint.evm.v1.LegacyTx",
+  encode(message: LegacyTx, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.nonce !== BigInt(0)) {
+      writer.uint32(8).uint64(message.nonce);
+    }
+    if (message.gasPrice !== "") {
+      writer.uint32(18).string(message.gasPrice);
+    }
+    if (message.gas !== BigInt(0)) {
+      writer.uint32(24).uint64(message.gas);
+    }
+    if (message.to !== "") {
+      writer.uint32(34).string(message.to);
+    }
+    if (message.value !== "") {
+      writer.uint32(42).string(message.value);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(50).bytes(message.data);
+    }
+    if (message.v.length !== 0) {
+      writer.uint32(58).bytes(message.v);
+    }
+    if (message.r.length !== 0) {
+      writer.uint32(66).bytes(message.r);
+    }
+    if (message.s.length !== 0) {
+      writer.uint32(74).bytes(message.s);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): LegacyTx {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLegacyTx();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.nonce = reader.uint64();
+          break;
+        case 2:
+          message.gasPrice = reader.string();
+          break;
+        case 3:
+          message.gas = reader.uint64();
+          break;
+        case 4:
+          message.to = reader.string();
+          break;
+        case 5:
+          message.value = reader.string();
+          break;
+        case 6:
+          message.data = reader.bytes();
+          break;
+        case 7:
+          message.v = reader.bytes();
+          break;
+        case 8:
+          message.r = reader.bytes();
+          break;
+        case 9:
+          message.s = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): LegacyTx {
+    return {
+      nonce: isSet(object.nonce) ? BigInt(object.nonce.toString()) : BigInt(0),
+      gasPrice: isSet(object.gasPrice) ? String(object.gasPrice) : "",
+      gas: isSet(object.gas) ? BigInt(object.gas.toString()) : BigInt(0),
+      to: isSet(object.to) ? String(object.to) : "",
+      value: isSet(object.value) ? String(object.value) : "",
+      data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(),
+      v: isSet(object.v) ? bytesFromBase64(object.v) : new Uint8Array(),
+      r: isSet(object.r) ? bytesFromBase64(object.r) : new Uint8Array(),
+      s: isSet(object.s) ? bytesFromBase64(object.s) : new Uint8Array()
+    };
+  },
+  toJSON(message: LegacyTx): JsonSafe<LegacyTx> {
+    const obj: any = {};
+    message.nonce !== undefined && (obj.nonce = (message.nonce || BigInt(0)).toString());
+    message.gasPrice !== undefined && (obj.gasPrice = message.gasPrice);
+    message.gas !== undefined && (obj.gas = (message.gas || BigInt(0)).toString());
+    message.to !== undefined && (obj.to = message.to);
+    message.value !== undefined && (obj.value = message.value);
+    message.data !== undefined && (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+    message.v !== undefined && (obj.v = base64FromBytes(message.v !== undefined ? message.v : new Uint8Array()));
+    message.r !== undefined && (obj.r = base64FromBytes(message.r !== undefined ? message.r : new Uint8Array()));
+    message.s !== undefined && (obj.s = base64FromBytes(message.s !== undefined ? message.s : new Uint8Array()));
+    return obj;
+  },
+  fromPartial(object: Partial<LegacyTx>): LegacyTx {
+    const message = createBaseLegacyTx();
+    message.nonce = object.nonce !== undefined && object.nonce !== null ? BigInt(object.nonce.toString()) : BigInt(0);
+    message.gasPrice = object.gasPrice ?? "";
+    message.gas = object.gas !== undefined && object.gas !== null ? BigInt(object.gas.toString()) : BigInt(0);
+    message.to = object.to ?? "";
+    message.value = object.value ?? "";
+    message.data = object.data ?? new Uint8Array();
+    message.v = object.v ?? new Uint8Array();
+    message.r = object.r ?? new Uint8Array();
+    message.s = object.s ?? new Uint8Array();
+    return message;
+  },
+  fromAmino(object: LegacyTxAmino): LegacyTx {
+    const message = createBaseLegacyTx();
+    if (object.nonce !== undefined && object.nonce !== null) {
+      message.nonce = BigInt(object.nonce);
+    }
+    if (object.gas_price !== undefined && object.gas_price !== null) {
+      message.gasPrice = object.gas_price;
+    }
+    if (object.gas !== undefined && object.gas !== null) {
+      message.gas = BigInt(object.gas);
+    }
+    if (object.to !== undefined && object.to !== null) {
+      message.to = object.to;
+    }
+    if (object.value !== undefined && object.value !== null) {
+      message.value = object.value;
+    }
+    if (object.data !== undefined && object.data !== null) {
+      message.data = bytesFromBase64(object.data);
+    }
+    if (object.v !== undefined && object.v !== null) {
+      message.v = bytesFromBase64(object.v);
+    }
+    if (object.r !== undefined && object.r !== null) {
+      message.r = bytesFromBase64(object.r);
+    }
+    if (object.s !== undefined && object.s !== null) {
+      message.s = bytesFromBase64(object.s);
+    }
+    return message;
+  },
+  toAmino(message: LegacyTx): LegacyTxAmino {
+    const obj: any = {};
+    obj.nonce = message.nonce !== BigInt(0) ? message.nonce.toString() : undefined;
+    obj.gas_price = message.gasPrice === "" ? undefined : message.gasPrice;
+    obj.gas = message.gas !== BigInt(0) ? message.gas.toString() : undefined;
+    obj.to = message.to === "" ? undefined : message.to;
+    obj.value = message.value === "" ? undefined : message.value;
+    obj.data = message.data ? base64FromBytes(message.data) : undefined;
+    obj.v = message.v ? base64FromBytes(message.v) : undefined;
+    obj.r = message.r ? base64FromBytes(message.r) : undefined;
+    obj.s = message.s ? base64FromBytes(message.s) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: LegacyTxAminoMsg): LegacyTx {
+    return LegacyTx.fromAmino(object.value);
+  },
+  fromProtoMsg(message: LegacyTxProtoMsg): LegacyTx {
+    return LegacyTx.decode(message.value);
+  },
+  toProto(message: LegacyTx): Uint8Array {
+    return LegacyTx.encode(message).finish();
+  },
+  toProtoMsg(message: LegacyTx): LegacyTxProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.LegacyTx",
+      value: LegacyTx.encode(message).finish()
+    };
+  }
+};
+function createBaseAccessListTx(): AccessListTx {
+  return {
+    $typeUrl: "/ethermint.evm.v1.AccessListTx",
+    chainId: "",
+    nonce: BigInt(0),
+    gasPrice: "",
+    gas: BigInt(0),
+    to: "",
+    value: "",
+    data: new Uint8Array(),
+    accesses: [],
+    v: new Uint8Array(),
+    r: new Uint8Array(),
+    s: new Uint8Array()
+  };
+}
+export const AccessListTx = {
+  typeUrl: "/ethermint.evm.v1.AccessListTx",
+  encode(message: AccessListTx, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.chainId !== "") {
+      writer.uint32(10).string(message.chainId);
+    }
+    if (message.nonce !== BigInt(0)) {
+      writer.uint32(16).uint64(message.nonce);
+    }
+    if (message.gasPrice !== "") {
+      writer.uint32(26).string(message.gasPrice);
+    }
+    if (message.gas !== BigInt(0)) {
+      writer.uint32(32).uint64(message.gas);
+    }
+    if (message.to !== "") {
+      writer.uint32(42).string(message.to);
+    }
+    if (message.value !== "") {
+      writer.uint32(50).string(message.value);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(58).bytes(message.data);
+    }
+    for (const v of message.accesses) {
+      AccessTuple.encode(v!, writer.uint32(66).fork()).ldelim();
+    }
+    if (message.v.length !== 0) {
+      writer.uint32(74).bytes(message.v);
+    }
+    if (message.r.length !== 0) {
+      writer.uint32(82).bytes(message.r);
+    }
+    if (message.s.length !== 0) {
+      writer.uint32(90).bytes(message.s);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): AccessListTx {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAccessListTx();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.chainId = reader.string();
+          break;
+        case 2:
+          message.nonce = reader.uint64();
+          break;
+        case 3:
+          message.gasPrice = reader.string();
+          break;
+        case 4:
+          message.gas = reader.uint64();
+          break;
+        case 5:
+          message.to = reader.string();
+          break;
+        case 6:
+          message.value = reader.string();
+          break;
+        case 7:
+          message.data = reader.bytes();
+          break;
+        case 8:
+          message.accesses.push(AccessTuple.decode(reader, reader.uint32()));
+          break;
+        case 9:
+          message.v = reader.bytes();
+          break;
+        case 10:
+          message.r = reader.bytes();
+          break;
+        case 11:
+          message.s = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): AccessListTx {
+    return {
+      chainId: isSet(object.chainId) ? String(object.chainId) : "",
+      nonce: isSet(object.nonce) ? BigInt(object.nonce.toString()) : BigInt(0),
+      gasPrice: isSet(object.gasPrice) ? String(object.gasPrice) : "",
+      gas: isSet(object.gas) ? BigInt(object.gas.toString()) : BigInt(0),
+      to: isSet(object.to) ? String(object.to) : "",
+      value: isSet(object.value) ? String(object.value) : "",
+      data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(),
+      accesses: Array.isArray(object?.accesses) ? object.accesses.map((e: any) => AccessTuple.fromJSON(e)) : [],
+      v: isSet(object.v) ? bytesFromBase64(object.v) : new Uint8Array(),
+      r: isSet(object.r) ? bytesFromBase64(object.r) : new Uint8Array(),
+      s: isSet(object.s) ? bytesFromBase64(object.s) : new Uint8Array()
+    };
+  },
+  toJSON(message: AccessListTx): JsonSafe<AccessListTx> {
+    const obj: any = {};
+    message.chainId !== undefined && (obj.chainId = message.chainId);
+    message.nonce !== undefined && (obj.nonce = (message.nonce || BigInt(0)).toString());
+    message.gasPrice !== undefined && (obj.gasPrice = message.gasPrice);
+    message.gas !== undefined && (obj.gas = (message.gas || BigInt(0)).toString());
+    message.to !== undefined && (obj.to = message.to);
+    message.value !== undefined && (obj.value = message.value);
+    message.data !== undefined && (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+    if (message.accesses) {
+      obj.accesses = message.accesses.map(e => e ? AccessTuple.toJSON(e) : undefined);
+    } else {
+      obj.accesses = [];
+    }
+    message.v !== undefined && (obj.v = base64FromBytes(message.v !== undefined ? message.v : new Uint8Array()));
+    message.r !== undefined && (obj.r = base64FromBytes(message.r !== undefined ? message.r : new Uint8Array()));
+    message.s !== undefined && (obj.s = base64FromBytes(message.s !== undefined ? message.s : new Uint8Array()));
+    return obj;
+  },
+  fromPartial(object: Partial<AccessListTx>): AccessListTx {
+    const message = createBaseAccessListTx();
+    message.chainId = object.chainId ?? "";
+    message.nonce = object.nonce !== undefined && object.nonce !== null ? BigInt(object.nonce.toString()) : BigInt(0);
+    message.gasPrice = object.gasPrice ?? "";
+    message.gas = object.gas !== undefined && object.gas !== null ? BigInt(object.gas.toString()) : BigInt(0);
+    message.to = object.to ?? "";
+    message.value = object.value ?? "";
+    message.data = object.data ?? new Uint8Array();
+    message.accesses = object.accesses?.map(e => AccessTuple.fromPartial(e)) || [];
+    message.v = object.v ?? new Uint8Array();
+    message.r = object.r ?? new Uint8Array();
+    message.s = object.s ?? new Uint8Array();
+    return message;
+  },
+  fromAmino(object: AccessListTxAmino): AccessListTx {
+    const message = createBaseAccessListTx();
+    if (object.chain_id !== undefined && object.chain_id !== null) {
+      message.chainId = object.chain_id;
+    }
+    if (object.nonce !== undefined && object.nonce !== null) {
+      message.nonce = BigInt(object.nonce);
+    }
+    if (object.gas_price !== undefined && object.gas_price !== null) {
+      message.gasPrice = object.gas_price;
+    }
+    if (object.gas !== undefined && object.gas !== null) {
+      message.gas = BigInt(object.gas);
+    }
+    if (object.to !== undefined && object.to !== null) {
+      message.to = object.to;
+    }
+    if (object.value !== undefined && object.value !== null) {
+      message.value = object.value;
+    }
+    if (object.data !== undefined && object.data !== null) {
+      message.data = bytesFromBase64(object.data);
+    }
+    message.accesses = object.accesses?.map(e => AccessTuple.fromAmino(e)) || [];
+    if (object.v !== undefined && object.v !== null) {
+      message.v = bytesFromBase64(object.v);
+    }
+    if (object.r !== undefined && object.r !== null) {
+      message.r = bytesFromBase64(object.r);
+    }
+    if (object.s !== undefined && object.s !== null) {
+      message.s = bytesFromBase64(object.s);
+    }
+    return message;
+  },
+  toAmino(message: AccessListTx): AccessListTxAmino {
+    const obj: any = {};
+    obj.chain_id = message.chainId ?? "";
+    obj.nonce = message.nonce !== BigInt(0) ? message.nonce.toString() : undefined;
+    obj.gas_price = message.gasPrice === "" ? undefined : message.gasPrice;
+    obj.gas = message.gas !== BigInt(0) ? message.gas.toString() : undefined;
+    obj.to = message.to === "" ? undefined : message.to;
+    obj.value = message.value === "" ? undefined : message.value;
+    obj.data = message.data ? base64FromBytes(message.data) : undefined;
+    if (message.accesses) {
+      obj.accesses = message.accesses.map(e => e ? AccessTuple.toAmino(e) : undefined);
+    } else {
+      obj.accesses = message.accesses;
+    }
+    obj.v = message.v ? base64FromBytes(message.v) : undefined;
+    obj.r = message.r ? base64FromBytes(message.r) : undefined;
+    obj.s = message.s ? base64FromBytes(message.s) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: AccessListTxAminoMsg): AccessListTx {
+    return AccessListTx.fromAmino(object.value);
+  },
+  fromProtoMsg(message: AccessListTxProtoMsg): AccessListTx {
+    return AccessListTx.decode(message.value);
+  },
+  toProto(message: AccessListTx): Uint8Array {
+    return AccessListTx.encode(message).finish();
+  },
+  toProtoMsg(message: AccessListTx): AccessListTxProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.AccessListTx",
+      value: AccessListTx.encode(message).finish()
+    };
+  }
+};
+function createBaseDynamicFeeTx(): DynamicFeeTx {
+  return {
+    $typeUrl: "/ethermint.evm.v1.DynamicFeeTx",
+    chainId: "",
+    nonce: BigInt(0),
+    gasTipCap: "",
+    gasFeeCap: "",
+    gas: BigInt(0),
+    to: "",
+    value: "",
+    data: new Uint8Array(),
+    accesses: [],
+    v: new Uint8Array(),
+    r: new Uint8Array(),
+    s: new Uint8Array()
+  };
+}
+export const DynamicFeeTx = {
+  typeUrl: "/ethermint.evm.v1.DynamicFeeTx",
+  encode(message: DynamicFeeTx, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.chainId !== "") {
+      writer.uint32(10).string(message.chainId);
+    }
+    if (message.nonce !== BigInt(0)) {
+      writer.uint32(16).uint64(message.nonce);
+    }
+    if (message.gasTipCap !== "") {
+      writer.uint32(26).string(message.gasTipCap);
+    }
+    if (message.gasFeeCap !== "") {
+      writer.uint32(34).string(message.gasFeeCap);
+    }
+    if (message.gas !== BigInt(0)) {
+      writer.uint32(40).uint64(message.gas);
+    }
+    if (message.to !== "") {
+      writer.uint32(50).string(message.to);
+    }
+    if (message.value !== "") {
+      writer.uint32(58).string(message.value);
+    }
+    if (message.data.length !== 0) {
+      writer.uint32(66).bytes(message.data);
+    }
+    for (const v of message.accesses) {
+      AccessTuple.encode(v!, writer.uint32(74).fork()).ldelim();
+    }
+    if (message.v.length !== 0) {
+      writer.uint32(82).bytes(message.v);
+    }
+    if (message.r.length !== 0) {
+      writer.uint32(90).bytes(message.r);
+    }
+    if (message.s.length !== 0) {
+      writer.uint32(98).bytes(message.s);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): DynamicFeeTx {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDynamicFeeTx();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.chainId = reader.string();
+          break;
+        case 2:
+          message.nonce = reader.uint64();
+          break;
+        case 3:
+          message.gasTipCap = reader.string();
+          break;
+        case 4:
+          message.gasFeeCap = reader.string();
+          break;
+        case 5:
+          message.gas = reader.uint64();
+          break;
+        case 6:
+          message.to = reader.string();
+          break;
+        case 7:
+          message.value = reader.string();
+          break;
+        case 8:
+          message.data = reader.bytes();
+          break;
+        case 9:
+          message.accesses.push(AccessTuple.decode(reader, reader.uint32()));
+          break;
+        case 10:
+          message.v = reader.bytes();
+          break;
+        case 11:
+          message.r = reader.bytes();
+          break;
+        case 12:
+          message.s = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): DynamicFeeTx {
+    return {
+      chainId: isSet(object.chainId) ? String(object.chainId) : "",
+      nonce: isSet(object.nonce) ? BigInt(object.nonce.toString()) : BigInt(0),
+      gasTipCap: isSet(object.gasTipCap) ? String(object.gasTipCap) : "",
+      gasFeeCap: isSet(object.gasFeeCap) ? String(object.gasFeeCap) : "",
+      gas: isSet(object.gas) ? BigInt(object.gas.toString()) : BigInt(0),
+      to: isSet(object.to) ? String(object.to) : "",
+      value: isSet(object.value) ? String(object.value) : "",
+      data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(),
+      accesses: Array.isArray(object?.accesses) ? object.accesses.map((e: any) => AccessTuple.fromJSON(e)) : [],
+      v: isSet(object.v) ? bytesFromBase64(object.v) : new Uint8Array(),
+      r: isSet(object.r) ? bytesFromBase64(object.r) : new Uint8Array(),
+      s: isSet(object.s) ? bytesFromBase64(object.s) : new Uint8Array()
+    };
+  },
+  toJSON(message: DynamicFeeTx): JsonSafe<DynamicFeeTx> {
+    const obj: any = {};
+    message.chainId !== undefined && (obj.chainId = message.chainId);
+    message.nonce !== undefined && (obj.nonce = (message.nonce || BigInt(0)).toString());
+    message.gasTipCap !== undefined && (obj.gasTipCap = message.gasTipCap);
+    message.gasFeeCap !== undefined && (obj.gasFeeCap = message.gasFeeCap);
+    message.gas !== undefined && (obj.gas = (message.gas || BigInt(0)).toString());
+    message.to !== undefined && (obj.to = message.to);
+    message.value !== undefined && (obj.value = message.value);
+    message.data !== undefined && (obj.data = base64FromBytes(message.data !== undefined ? message.data : new Uint8Array()));
+    if (message.accesses) {
+      obj.accesses = message.accesses.map(e => e ? AccessTuple.toJSON(e) : undefined);
+    } else {
+      obj.accesses = [];
+    }
+    message.v !== undefined && (obj.v = base64FromBytes(message.v !== undefined ? message.v : new Uint8Array()));
+    message.r !== undefined && (obj.r = base64FromBytes(message.r !== undefined ? message.r : new Uint8Array()));
+    message.s !== undefined && (obj.s = base64FromBytes(message.s !== undefined ? message.s : new Uint8Array()));
+    return obj;
+  },
+  fromPartial(object: Partial<DynamicFeeTx>): DynamicFeeTx {
+    const message = createBaseDynamicFeeTx();
+    message.chainId = object.chainId ?? "";
+    message.nonce = object.nonce !== undefined && object.nonce !== null ? BigInt(object.nonce.toString()) : BigInt(0);
+    message.gasTipCap = object.gasTipCap ?? "";
+    message.gasFeeCap = object.gasFeeCap ?? "";
+    message.gas = object.gas !== undefined && object.gas !== null ? BigInt(object.gas.toString()) : BigInt(0);
+    message.to = object.to ?? "";
+    message.value = object.value ?? "";
+    message.data = object.data ?? new Uint8Array();
+    message.accesses = object.accesses?.map(e => AccessTuple.fromPartial(e)) || [];
+    message.v = object.v ?? new Uint8Array();
+    message.r = object.r ?? new Uint8Array();
+    message.s = object.s ?? new Uint8Array();
+    return message;
+  },
+  fromAmino(object: DynamicFeeTxAmino): DynamicFeeTx {
+    const message = createBaseDynamicFeeTx();
+    if (object.chain_id !== undefined && object.chain_id !== null) {
+      message.chainId = object.chain_id;
+    }
+    if (object.nonce !== undefined && object.nonce !== null) {
+      message.nonce = BigInt(object.nonce);
+    }
+    if (object.gas_tip_cap !== undefined && object.gas_tip_cap !== null) {
+      message.gasTipCap = object.gas_tip_cap;
+    }
+    if (object.gas_fee_cap !== undefined && object.gas_fee_cap !== null) {
+      message.gasFeeCap = object.gas_fee_cap;
+    }
+    if (object.gas !== undefined && object.gas !== null) {
+      message.gas = BigInt(object.gas);
+    }
+    if (object.to !== undefined && object.to !== null) {
+      message.to = object.to;
+    }
+    if (object.value !== undefined && object.value !== null) {
+      message.value = object.value;
+    }
+    if (object.data !== undefined && object.data !== null) {
+      message.data = bytesFromBase64(object.data);
+    }
+    message.accesses = object.accesses?.map(e => AccessTuple.fromAmino(e)) || [];
+    if (object.v !== undefined && object.v !== null) {
+      message.v = bytesFromBase64(object.v);
+    }
+    if (object.r !== undefined && object.r !== null) {
+      message.r = bytesFromBase64(object.r);
+    }
+    if (object.s !== undefined && object.s !== null) {
+      message.s = bytesFromBase64(object.s);
+    }
+    return message;
+  },
+  toAmino(message: DynamicFeeTx): DynamicFeeTxAmino {
+    const obj: any = {};
+    obj.chain_id = message.chainId ?? "";
+    obj.nonce = message.nonce !== BigInt(0) ? message.nonce.toString() : undefined;
+    obj.gas_tip_cap = message.gasTipCap === "" ? undefined : message.gasTipCap;
+    obj.gas_fee_cap = message.gasFeeCap === "" ? undefined : message.gasFeeCap;
+    obj.gas = message.gas !== BigInt(0) ? message.gas.toString() : undefined;
+    obj.to = message.to === "" ? undefined : message.to;
+    obj.value = message.value === "" ? undefined : message.value;
+    obj.data = message.data ? base64FromBytes(message.data) : undefined;
+    if (message.accesses) {
+      obj.accesses = message.accesses.map(e => e ? AccessTuple.toAmino(e) : undefined);
+    } else {
+      obj.accesses = message.accesses;
+    }
+    obj.v = message.v ? base64FromBytes(message.v) : undefined;
+    obj.r = message.r ? base64FromBytes(message.r) : undefined;
+    obj.s = message.s ? base64FromBytes(message.s) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: DynamicFeeTxAminoMsg): DynamicFeeTx {
+    return DynamicFeeTx.fromAmino(object.value);
+  },
+  fromProtoMsg(message: DynamicFeeTxProtoMsg): DynamicFeeTx {
+    return DynamicFeeTx.decode(message.value);
+  },
+  toProto(message: DynamicFeeTx): Uint8Array {
+    return DynamicFeeTx.encode(message).finish();
+  },
+  toProtoMsg(message: DynamicFeeTx): DynamicFeeTxProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.DynamicFeeTx",
+      value: DynamicFeeTx.encode(message).finish()
+    };
+  }
+};
+function createBaseExtensionOptionsEthereumTx(): ExtensionOptionsEthereumTx {
+  return {};
+}
+export const ExtensionOptionsEthereumTx = {
+  typeUrl: "/ethermint.evm.v1.ExtensionOptionsEthereumTx",
+  encode(_: ExtensionOptionsEthereumTx, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): ExtensionOptionsEthereumTx {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseExtensionOptionsEthereumTx();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(_: any): ExtensionOptionsEthereumTx {
+    return {};
+  },
+  toJSON(_: ExtensionOptionsEthereumTx): JsonSafe<ExtensionOptionsEthereumTx> {
+    const obj: any = {};
+    return obj;
+  },
+  fromPartial(_: Partial<ExtensionOptionsEthereumTx>): ExtensionOptionsEthereumTx {
+    const message = createBaseExtensionOptionsEthereumTx();
+    return message;
+  },
+  fromAmino(_: ExtensionOptionsEthereumTxAmino): ExtensionOptionsEthereumTx {
+    const message = createBaseExtensionOptionsEthereumTx();
+    return message;
+  },
+  toAmino(_: ExtensionOptionsEthereumTx): ExtensionOptionsEthereumTxAmino {
+    const obj: any = {};
+    return obj;
+  },
+  fromAminoMsg(object: ExtensionOptionsEthereumTxAminoMsg): ExtensionOptionsEthereumTx {
+    return ExtensionOptionsEthereumTx.fromAmino(object.value);
+  },
+  fromProtoMsg(message: ExtensionOptionsEthereumTxProtoMsg): ExtensionOptionsEthereumTx {
+    return ExtensionOptionsEthereumTx.decode(message.value);
+  },
+  toProto(message: ExtensionOptionsEthereumTx): Uint8Array {
+    return ExtensionOptionsEthereumTx.encode(message).finish();
+  },
+  toProtoMsg(message: ExtensionOptionsEthereumTx): ExtensionOptionsEthereumTxProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.ExtensionOptionsEthereumTx",
+      value: ExtensionOptionsEthereumTx.encode(message).finish()
+    };
+  }
+};
+function createBaseMsgEthereumTxResponse(): MsgEthereumTxResponse {
+  return {
+    hash: "",
+    logs: [],
+    ret: new Uint8Array(),
+    vmError: "",
+    gasUsed: BigInt(0)
+  };
+}
+export const MsgEthereumTxResponse = {
+  typeUrl: "/ethermint.evm.v1.MsgEthereumTxResponse",
+  encode(message: MsgEthereumTxResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.hash !== "") {
+      writer.uint32(10).string(message.hash);
+    }
+    for (const v of message.logs) {
+      Log.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.ret.length !== 0) {
+      writer.uint32(26).bytes(message.ret);
+    }
+    if (message.vmError !== "") {
+      writer.uint32(34).string(message.vmError);
+    }
+    if (message.gasUsed !== BigInt(0)) {
+      writer.uint32(40).uint64(message.gasUsed);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): MsgEthereumTxResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgEthereumTxResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.hash = reader.string();
+          break;
+        case 2:
+          message.logs.push(Log.decode(reader, reader.uint32()));
+          break;
+        case 3:
+          message.ret = reader.bytes();
+          break;
+        case 4:
+          message.vmError = reader.string();
+          break;
+        case 5:
+          message.gasUsed = reader.uint64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): MsgEthereumTxResponse {
+    return {
+      hash: isSet(object.hash) ? String(object.hash) : "",
+      logs: Array.isArray(object?.logs) ? object.logs.map((e: any) => Log.fromJSON(e)) : [],
+      ret: isSet(object.ret) ? bytesFromBase64(object.ret) : new Uint8Array(),
+      vmError: isSet(object.vmError) ? String(object.vmError) : "",
+      gasUsed: isSet(object.gasUsed) ? BigInt(object.gasUsed.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: MsgEthereumTxResponse): JsonSafe<MsgEthereumTxResponse> {
+    const obj: any = {};
+    message.hash !== undefined && (obj.hash = message.hash);
+    if (message.logs) {
+      obj.logs = message.logs.map(e => e ? Log.toJSON(e) : undefined);
+    } else {
+      obj.logs = [];
+    }
+    message.ret !== undefined && (obj.ret = base64FromBytes(message.ret !== undefined ? message.ret : new Uint8Array()));
+    message.vmError !== undefined && (obj.vmError = message.vmError);
+    message.gasUsed !== undefined && (obj.gasUsed = (message.gasUsed || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<MsgEthereumTxResponse>): MsgEthereumTxResponse {
+    const message = createBaseMsgEthereumTxResponse();
+    message.hash = object.hash ?? "";
+    message.logs = object.logs?.map(e => Log.fromPartial(e)) || [];
+    message.ret = object.ret ?? new Uint8Array();
+    message.vmError = object.vmError ?? "";
+    message.gasUsed = object.gasUsed !== undefined && object.gasUsed !== null ? BigInt(object.gasUsed.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: MsgEthereumTxResponseAmino): MsgEthereumTxResponse {
+    const message = createBaseMsgEthereumTxResponse();
+    if (object.hash !== undefined && object.hash !== null) {
+      message.hash = object.hash;
+    }
+    message.logs = object.logs?.map(e => Log.fromAmino(e)) || [];
+    if (object.ret !== undefined && object.ret !== null) {
+      message.ret = bytesFromBase64(object.ret);
+    }
+    if (object.vm_error !== undefined && object.vm_error !== null) {
+      message.vmError = object.vm_error;
+    }
+    if (object.gas_used !== undefined && object.gas_used !== null) {
+      message.gasUsed = BigInt(object.gas_used);
+    }
+    return message;
+  },
+  toAmino(message: MsgEthereumTxResponse): MsgEthereumTxResponseAmino {
+    const obj: any = {};
+    obj.hash = message.hash === "" ? undefined : message.hash;
+    if (message.logs) {
+      obj.logs = message.logs.map(e => e ? Log.toAmino(e) : undefined);
+    } else {
+      obj.logs = message.logs;
+    }
+    obj.ret = message.ret ? base64FromBytes(message.ret) : undefined;
+    obj.vm_error = message.vmError === "" ? undefined : message.vmError;
+    obj.gas_used = message.gasUsed !== BigInt(0) ? message.gasUsed.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: MsgEthereumTxResponseAminoMsg): MsgEthereumTxResponse {
+    return MsgEthereumTxResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: MsgEthereumTxResponseProtoMsg): MsgEthereumTxResponse {
+    return MsgEthereumTxResponse.decode(message.value);
+  },
+  toProto(message: MsgEthereumTxResponse): Uint8Array {
+    return MsgEthereumTxResponse.encode(message).finish();
+  },
+  toProtoMsg(message: MsgEthereumTxResponse): MsgEthereumTxResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.MsgEthereumTxResponse",
+      value: MsgEthereumTxResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseMsgUpdateParams(): MsgUpdateParams {
+  return {
+    authority: "",
+    params: Params.fromPartial({})
+  };
+}
+export const MsgUpdateParams = {
+  typeUrl: "/ethermint.evm.v1.MsgUpdateParams",
+  encode(message: MsgUpdateParams, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.authority !== "") {
+      writer.uint32(10).string(message.authority);
+    }
+    if (message.params !== undefined) {
+      Params.encode(message.params, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): MsgUpdateParams {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgUpdateParams();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.authority = reader.string();
+          break;
+        case 2:
+          message.params = Params.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): MsgUpdateParams {
+    return {
+      authority: isSet(object.authority) ? String(object.authority) : "",
+      params: isSet(object.params) ? Params.fromJSON(object.params) : undefined
+    };
+  },
+  toJSON(message: MsgUpdateParams): JsonSafe<MsgUpdateParams> {
+    const obj: any = {};
+    message.authority !== undefined && (obj.authority = message.authority);
+    message.params !== undefined && (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<MsgUpdateParams>): MsgUpdateParams {
+    const message = createBaseMsgUpdateParams();
+    message.authority = object.authority ?? "";
+    message.params = object.params !== undefined && object.params !== null ? Params.fromPartial(object.params) : undefined;
+    return message;
+  },
+  fromAmino(object: MsgUpdateParamsAmino): MsgUpdateParams {
+    const message = createBaseMsgUpdateParams();
+    if (object.authority !== undefined && object.authority !== null) {
+      message.authority = object.authority;
+    }
+    if (object.params !== undefined && object.params !== null) {
+      message.params = Params.fromAmino(object.params);
+    }
+    return message;
+  },
+  toAmino(message: MsgUpdateParams): MsgUpdateParamsAmino {
+    const obj: any = {};
+    obj.authority = message.authority === "" ? undefined : message.authority;
+    obj.params = message.params ? Params.toAmino(message.params) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: MsgUpdateParamsAminoMsg): MsgUpdateParams {
+    return MsgUpdateParams.fromAmino(object.value);
+  },
+  fromProtoMsg(message: MsgUpdateParamsProtoMsg): MsgUpdateParams {
+    return MsgUpdateParams.decode(message.value);
+  },
+  toProto(message: MsgUpdateParams): Uint8Array {
+    return MsgUpdateParams.encode(message).finish();
+  },
+  toProtoMsg(message: MsgUpdateParams): MsgUpdateParamsProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.MsgUpdateParams",
+      value: MsgUpdateParams.encode(message).finish()
+    };
+  }
+};
+function createBaseMsgUpdateParamsResponse(): MsgUpdateParamsResponse {
+  return {};
+}
+export const MsgUpdateParamsResponse = {
+  typeUrl: "/ethermint.evm.v1.MsgUpdateParamsResponse",
+  encode(_: MsgUpdateParamsResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): MsgUpdateParamsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgUpdateParamsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(_: any): MsgUpdateParamsResponse {
+    return {};
+  },
+  toJSON(_: MsgUpdateParamsResponse): JsonSafe<MsgUpdateParamsResponse> {
+    const obj: any = {};
+    return obj;
+  },
+  fromPartial(_: Partial<MsgUpdateParamsResponse>): MsgUpdateParamsResponse {
+    const message = createBaseMsgUpdateParamsResponse();
+    return message;
+  },
+  fromAmino(_: MsgUpdateParamsResponseAmino): MsgUpdateParamsResponse {
+    const message = createBaseMsgUpdateParamsResponse();
+    return message;
+  },
+  toAmino(_: MsgUpdateParamsResponse): MsgUpdateParamsResponseAmino {
+    const obj: any = {};
+    return obj;
+  },
+  fromAminoMsg(object: MsgUpdateParamsResponseAminoMsg): MsgUpdateParamsResponse {
+    return MsgUpdateParamsResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: MsgUpdateParamsResponseProtoMsg): MsgUpdateParamsResponse {
+    return MsgUpdateParamsResponse.decode(message.value);
+  },
+  toProto(message: MsgUpdateParamsResponse): Uint8Array {
+    return MsgUpdateParamsResponse.encode(message).finish();
+  },
+  toProtoMsg(message: MsgUpdateParamsResponse): MsgUpdateParamsResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.evm.v1.MsgUpdateParamsResponse",
+      value: MsgUpdateParamsResponse.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/feemarket/v1/events.ts
+++ b/wardenjs/src/codegen/ethermint/feemarket/v1/events.ts
@@ -1,0 +1,213 @@
+//@ts-nocheck
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** EventFeeMarket is the event type for the fee market module */
+export interface EventFeeMarket {
+  /** base_fee for EIP-1559 blocks */
+  baseFee: string;
+}
+export interface EventFeeMarketProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.EventFeeMarket";
+  value: Uint8Array;
+}
+/** EventFeeMarket is the event type for the fee market module */
+export interface EventFeeMarketAmino {
+  /** base_fee for EIP-1559 blocks */
+  base_fee?: string;
+}
+export interface EventFeeMarketAminoMsg {
+  type: "/ethermint.feemarket.v1.EventFeeMarket";
+  value: EventFeeMarketAmino;
+}
+/** EventFeeMarket is the event type for the fee market module */
+export interface EventFeeMarketSDKType {
+  base_fee: string;
+}
+/** EventBlockGas defines an Ethereum block gas event */
+export interface EventBlockGas {
+  /** height of the block */
+  height: string;
+  /** amount of gas wanted by the block */
+  amount: string;
+}
+export interface EventBlockGasProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.EventBlockGas";
+  value: Uint8Array;
+}
+/** EventBlockGas defines an Ethereum block gas event */
+export interface EventBlockGasAmino {
+  /** height of the block */
+  height?: string;
+  /** amount of gas wanted by the block */
+  amount?: string;
+}
+export interface EventBlockGasAminoMsg {
+  type: "/ethermint.feemarket.v1.EventBlockGas";
+  value: EventBlockGasAmino;
+}
+/** EventBlockGas defines an Ethereum block gas event */
+export interface EventBlockGasSDKType {
+  height: string;
+  amount: string;
+}
+function createBaseEventFeeMarket(): EventFeeMarket {
+  return {
+    baseFee: ""
+  };
+}
+export const EventFeeMarket = {
+  typeUrl: "/ethermint.feemarket.v1.EventFeeMarket",
+  encode(message: EventFeeMarket, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.baseFee !== "") {
+      writer.uint32(10).string(message.baseFee);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EventFeeMarket {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventFeeMarket();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.baseFee = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EventFeeMarket {
+    return {
+      baseFee: isSet(object.baseFee) ? String(object.baseFee) : ""
+    };
+  },
+  toJSON(message: EventFeeMarket): JsonSafe<EventFeeMarket> {
+    const obj: any = {};
+    message.baseFee !== undefined && (obj.baseFee = message.baseFee);
+    return obj;
+  },
+  fromPartial(object: Partial<EventFeeMarket>): EventFeeMarket {
+    const message = createBaseEventFeeMarket();
+    message.baseFee = object.baseFee ?? "";
+    return message;
+  },
+  fromAmino(object: EventFeeMarketAmino): EventFeeMarket {
+    const message = createBaseEventFeeMarket();
+    if (object.base_fee !== undefined && object.base_fee !== null) {
+      message.baseFee = object.base_fee;
+    }
+    return message;
+  },
+  toAmino(message: EventFeeMarket): EventFeeMarketAmino {
+    const obj: any = {};
+    obj.base_fee = message.baseFee === "" ? undefined : message.baseFee;
+    return obj;
+  },
+  fromAminoMsg(object: EventFeeMarketAminoMsg): EventFeeMarket {
+    return EventFeeMarket.fromAmino(object.value);
+  },
+  fromProtoMsg(message: EventFeeMarketProtoMsg): EventFeeMarket {
+    return EventFeeMarket.decode(message.value);
+  },
+  toProto(message: EventFeeMarket): Uint8Array {
+    return EventFeeMarket.encode(message).finish();
+  },
+  toProtoMsg(message: EventFeeMarket): EventFeeMarketProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.EventFeeMarket",
+      value: EventFeeMarket.encode(message).finish()
+    };
+  }
+};
+function createBaseEventBlockGas(): EventBlockGas {
+  return {
+    height: "",
+    amount: ""
+  };
+}
+export const EventBlockGas = {
+  typeUrl: "/ethermint.feemarket.v1.EventBlockGas",
+  encode(message: EventBlockGas, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.height !== "") {
+      writer.uint32(10).string(message.height);
+    }
+    if (message.amount !== "") {
+      writer.uint32(18).string(message.amount);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): EventBlockGas {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventBlockGas();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.height = reader.string();
+          break;
+        case 2:
+          message.amount = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): EventBlockGas {
+    return {
+      height: isSet(object.height) ? String(object.height) : "",
+      amount: isSet(object.amount) ? String(object.amount) : ""
+    };
+  },
+  toJSON(message: EventBlockGas): JsonSafe<EventBlockGas> {
+    const obj: any = {};
+    message.height !== undefined && (obj.height = message.height);
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+  fromPartial(object: Partial<EventBlockGas>): EventBlockGas {
+    const message = createBaseEventBlockGas();
+    message.height = object.height ?? "";
+    message.amount = object.amount ?? "";
+    return message;
+  },
+  fromAmino(object: EventBlockGasAmino): EventBlockGas {
+    const message = createBaseEventBlockGas();
+    if (object.height !== undefined && object.height !== null) {
+      message.height = object.height;
+    }
+    if (object.amount !== undefined && object.amount !== null) {
+      message.amount = object.amount;
+    }
+    return message;
+  },
+  toAmino(message: EventBlockGas): EventBlockGasAmino {
+    const obj: any = {};
+    obj.height = message.height === "" ? undefined : message.height;
+    obj.amount = message.amount === "" ? undefined : message.amount;
+    return obj;
+  },
+  fromAminoMsg(object: EventBlockGasAminoMsg): EventBlockGas {
+    return EventBlockGas.fromAmino(object.value);
+  },
+  fromProtoMsg(message: EventBlockGasProtoMsg): EventBlockGas {
+    return EventBlockGas.decode(message.value);
+  },
+  toProto(message: EventBlockGas): Uint8Array {
+    return EventBlockGas.encode(message).finish();
+  },
+  toProtoMsg(message: EventBlockGas): EventBlockGasProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.EventBlockGas",
+      value: EventBlockGas.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/feemarket/v1/feemarket.ts
+++ b/wardenjs/src/codegen/ethermint/feemarket/v1/feemarket.ts
@@ -1,0 +1,232 @@
+//@ts-nocheck
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { Decimal } from "@cosmjs/math";
+import { isSet } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** Params defines the EVM module parameters */
+export interface Params {
+  /** no_base_fee forces the EIP-1559 base fee to 0 (needed for 0 price calls) */
+  noBaseFee: boolean;
+  /**
+   * base_fee_change_denominator bounds the amount the base fee can change
+   * between blocks.
+   */
+  baseFeeChangeDenominator: number;
+  /**
+   * elasticity_multiplier bounds the maximum gas limit an EIP-1559 block may
+   * have.
+   */
+  elasticityMultiplier: number;
+  /** enable_height defines at which block height the base fee calculation is enabled. */
+  enableHeight: bigint;
+  /** base_fee for EIP-1559 blocks. */
+  baseFee: string;
+  /** min_gas_price defines the minimum gas price value for cosmos and eth transactions */
+  minGasPrice: string;
+  /**
+   * min_gas_multiplier bounds the minimum gas used to be charged
+   * to senders based on gas limit
+   */
+  minGasMultiplier: string;
+}
+export interface ParamsProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.Params";
+  value: Uint8Array;
+}
+/** Params defines the EVM module parameters */
+export interface ParamsAmino {
+  /** no_base_fee forces the EIP-1559 base fee to 0 (needed for 0 price calls) */
+  no_base_fee?: boolean;
+  /**
+   * base_fee_change_denominator bounds the amount the base fee can change
+   * between blocks.
+   */
+  base_fee_change_denominator?: number;
+  /**
+   * elasticity_multiplier bounds the maximum gas limit an EIP-1559 block may
+   * have.
+   */
+  elasticity_multiplier?: number;
+  /** enable_height defines at which block height the base fee calculation is enabled. */
+  enable_height?: string;
+  /** base_fee for EIP-1559 blocks. */
+  base_fee?: string;
+  /** min_gas_price defines the minimum gas price value for cosmos and eth transactions */
+  min_gas_price?: string;
+  /**
+   * min_gas_multiplier bounds the minimum gas used to be charged
+   * to senders based on gas limit
+   */
+  min_gas_multiplier?: string;
+}
+export interface ParamsAminoMsg {
+  type: "/ethermint.feemarket.v1.Params";
+  value: ParamsAmino;
+}
+/** Params defines the EVM module parameters */
+export interface ParamsSDKType {
+  no_base_fee: boolean;
+  base_fee_change_denominator: number;
+  elasticity_multiplier: number;
+  enable_height: bigint;
+  base_fee: string;
+  min_gas_price: string;
+  min_gas_multiplier: string;
+}
+function createBaseParams(): Params {
+  return {
+    noBaseFee: false,
+    baseFeeChangeDenominator: 0,
+    elasticityMultiplier: 0,
+    enableHeight: BigInt(0),
+    baseFee: "",
+    minGasPrice: "",
+    minGasMultiplier: ""
+  };
+}
+export const Params = {
+  typeUrl: "/ethermint.feemarket.v1.Params",
+  encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.noBaseFee === true) {
+      writer.uint32(8).bool(message.noBaseFee);
+    }
+    if (message.baseFeeChangeDenominator !== 0) {
+      writer.uint32(16).uint32(message.baseFeeChangeDenominator);
+    }
+    if (message.elasticityMultiplier !== 0) {
+      writer.uint32(24).uint32(message.elasticityMultiplier);
+    }
+    if (message.enableHeight !== BigInt(0)) {
+      writer.uint32(40).int64(message.enableHeight);
+    }
+    if (message.baseFee !== "") {
+      writer.uint32(50).string(message.baseFee);
+    }
+    if (message.minGasPrice !== "") {
+      writer.uint32(58).string(Decimal.fromUserInput(message.minGasPrice, 18).atomics);
+    }
+    if (message.minGasMultiplier !== "") {
+      writer.uint32(66).string(Decimal.fromUserInput(message.minGasMultiplier, 18).atomics);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): Params {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseParams();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.noBaseFee = reader.bool();
+          break;
+        case 2:
+          message.baseFeeChangeDenominator = reader.uint32();
+          break;
+        case 3:
+          message.elasticityMultiplier = reader.uint32();
+          break;
+        case 5:
+          message.enableHeight = reader.int64();
+          break;
+        case 6:
+          message.baseFee = reader.string();
+          break;
+        case 7:
+          message.minGasPrice = Decimal.fromAtomics(reader.string(), 18).toString();
+          break;
+        case 8:
+          message.minGasMultiplier = Decimal.fromAtomics(reader.string(), 18).toString();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): Params {
+    return {
+      noBaseFee: isSet(object.noBaseFee) ? Boolean(object.noBaseFee) : false,
+      baseFeeChangeDenominator: isSet(object.baseFeeChangeDenominator) ? Number(object.baseFeeChangeDenominator) : 0,
+      elasticityMultiplier: isSet(object.elasticityMultiplier) ? Number(object.elasticityMultiplier) : 0,
+      enableHeight: isSet(object.enableHeight) ? BigInt(object.enableHeight.toString()) : BigInt(0),
+      baseFee: isSet(object.baseFee) ? String(object.baseFee) : "",
+      minGasPrice: isSet(object.minGasPrice) ? String(object.minGasPrice) : "",
+      minGasMultiplier: isSet(object.minGasMultiplier) ? String(object.minGasMultiplier) : ""
+    };
+  },
+  toJSON(message: Params): JsonSafe<Params> {
+    const obj: any = {};
+    message.noBaseFee !== undefined && (obj.noBaseFee = message.noBaseFee);
+    message.baseFeeChangeDenominator !== undefined && (obj.baseFeeChangeDenominator = Math.round(message.baseFeeChangeDenominator));
+    message.elasticityMultiplier !== undefined && (obj.elasticityMultiplier = Math.round(message.elasticityMultiplier));
+    message.enableHeight !== undefined && (obj.enableHeight = (message.enableHeight || BigInt(0)).toString());
+    message.baseFee !== undefined && (obj.baseFee = message.baseFee);
+    message.minGasPrice !== undefined && (obj.minGasPrice = message.minGasPrice);
+    message.minGasMultiplier !== undefined && (obj.minGasMultiplier = message.minGasMultiplier);
+    return obj;
+  },
+  fromPartial(object: Partial<Params>): Params {
+    const message = createBaseParams();
+    message.noBaseFee = object.noBaseFee ?? false;
+    message.baseFeeChangeDenominator = object.baseFeeChangeDenominator ?? 0;
+    message.elasticityMultiplier = object.elasticityMultiplier ?? 0;
+    message.enableHeight = object.enableHeight !== undefined && object.enableHeight !== null ? BigInt(object.enableHeight.toString()) : BigInt(0);
+    message.baseFee = object.baseFee ?? "";
+    message.minGasPrice = object.minGasPrice ?? "";
+    message.minGasMultiplier = object.minGasMultiplier ?? "";
+    return message;
+  },
+  fromAmino(object: ParamsAmino): Params {
+    const message = createBaseParams();
+    if (object.no_base_fee !== undefined && object.no_base_fee !== null) {
+      message.noBaseFee = object.no_base_fee;
+    }
+    if (object.base_fee_change_denominator !== undefined && object.base_fee_change_denominator !== null) {
+      message.baseFeeChangeDenominator = object.base_fee_change_denominator;
+    }
+    if (object.elasticity_multiplier !== undefined && object.elasticity_multiplier !== null) {
+      message.elasticityMultiplier = object.elasticity_multiplier;
+    }
+    if (object.enable_height !== undefined && object.enable_height !== null) {
+      message.enableHeight = BigInt(object.enable_height);
+    }
+    if (object.base_fee !== undefined && object.base_fee !== null) {
+      message.baseFee = object.base_fee;
+    }
+    if (object.min_gas_price !== undefined && object.min_gas_price !== null) {
+      message.minGasPrice = object.min_gas_price;
+    }
+    if (object.min_gas_multiplier !== undefined && object.min_gas_multiplier !== null) {
+      message.minGasMultiplier = object.min_gas_multiplier;
+    }
+    return message;
+  },
+  toAmino(message: Params): ParamsAmino {
+    const obj: any = {};
+    obj.no_base_fee = message.noBaseFee === false ? undefined : message.noBaseFee;
+    obj.base_fee_change_denominator = message.baseFeeChangeDenominator === 0 ? undefined : message.baseFeeChangeDenominator;
+    obj.elasticity_multiplier = message.elasticityMultiplier === 0 ? undefined : message.elasticityMultiplier;
+    obj.enable_height = message.enableHeight !== BigInt(0) ? message.enableHeight.toString() : undefined;
+    obj.base_fee = message.baseFee === "" ? undefined : message.baseFee;
+    obj.min_gas_price = message.minGasPrice === "" ? undefined : message.minGasPrice;
+    obj.min_gas_multiplier = message.minGasMultiplier === "" ? undefined : message.minGasMultiplier;
+    return obj;
+  },
+  fromAminoMsg(object: ParamsAminoMsg): Params {
+    return Params.fromAmino(object.value);
+  },
+  fromProtoMsg(message: ParamsProtoMsg): Params {
+    return Params.decode(message.value);
+  },
+  toProto(message: Params): Uint8Array {
+    return Params.encode(message).finish();
+  },
+  toProtoMsg(message: Params): ParamsProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.Params",
+      value: Params.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/feemarket/v1/genesis.ts
+++ b/wardenjs/src/codegen/ethermint/feemarket/v1/genesis.ts
@@ -1,0 +1,125 @@
+//@ts-nocheck
+import { Params, ParamsAmino, ParamsSDKType } from "./feemarket.js";
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** GenesisState defines the feemarket module's genesis state. */
+export interface GenesisState {
+  /** params defines all the parameters of the feemarket module. */
+  params: Params;
+  /**
+   * block_gas is the amount of gas wanted on the last block before the upgrade.
+   * Zero by default.
+   */
+  blockGas: bigint;
+}
+export interface GenesisStateProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.GenesisState";
+  value: Uint8Array;
+}
+/** GenesisState defines the feemarket module's genesis state. */
+export interface GenesisStateAmino {
+  /** params defines all the parameters of the feemarket module. */
+  params?: ParamsAmino;
+  /**
+   * block_gas is the amount of gas wanted on the last block before the upgrade.
+   * Zero by default.
+   */
+  block_gas?: string;
+}
+export interface GenesisStateAminoMsg {
+  type: "/ethermint.feemarket.v1.GenesisState";
+  value: GenesisStateAmino;
+}
+/** GenesisState defines the feemarket module's genesis state. */
+export interface GenesisStateSDKType {
+  params: ParamsSDKType;
+  block_gas: bigint;
+}
+function createBaseGenesisState(): GenesisState {
+  return {
+    params: Params.fromPartial({}),
+    blockGas: BigInt(0)
+  };
+}
+export const GenesisState = {
+  typeUrl: "/ethermint.feemarket.v1.GenesisState",
+  encode(message: GenesisState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.params !== undefined) {
+      Params.encode(message.params, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.blockGas !== BigInt(0)) {
+      writer.uint32(24).uint64(message.blockGas);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): GenesisState {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGenesisState();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.params = Params.decode(reader, reader.uint32());
+          break;
+        case 3:
+          message.blockGas = reader.uint64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): GenesisState {
+    return {
+      params: isSet(object.params) ? Params.fromJSON(object.params) : undefined,
+      blockGas: isSet(object.blockGas) ? BigInt(object.blockGas.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: GenesisState): JsonSafe<GenesisState> {
+    const obj: any = {};
+    message.params !== undefined && (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    message.blockGas !== undefined && (obj.blockGas = (message.blockGas || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<GenesisState>): GenesisState {
+    const message = createBaseGenesisState();
+    message.params = object.params !== undefined && object.params !== null ? Params.fromPartial(object.params) : undefined;
+    message.blockGas = object.blockGas !== undefined && object.blockGas !== null ? BigInt(object.blockGas.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: GenesisStateAmino): GenesisState {
+    const message = createBaseGenesisState();
+    if (object.params !== undefined && object.params !== null) {
+      message.params = Params.fromAmino(object.params);
+    }
+    if (object.block_gas !== undefined && object.block_gas !== null) {
+      message.blockGas = BigInt(object.block_gas);
+    }
+    return message;
+  },
+  toAmino(message: GenesisState): GenesisStateAmino {
+    const obj: any = {};
+    obj.params = message.params ? Params.toAmino(message.params) : undefined;
+    obj.block_gas = message.blockGas !== BigInt(0) ? message.blockGas.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: GenesisStateAminoMsg): GenesisState {
+    return GenesisState.fromAmino(object.value);
+  },
+  fromProtoMsg(message: GenesisStateProtoMsg): GenesisState {
+    return GenesisState.decode(message.value);
+  },
+  toProto(message: GenesisState): Uint8Array {
+    return GenesisState.encode(message).finish();
+  },
+  toProtoMsg(message: GenesisState): GenesisStateProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.GenesisState",
+      value: GenesisState.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/feemarket/v1/query.lcd.ts
+++ b/wardenjs/src/codegen/ethermint/feemarket/v1/query.lcd.ts
@@ -1,0 +1,31 @@
+//@ts-nocheck
+import { LCDClient } from "@cosmology/lcd";
+import { QueryParamsRequest, QueryParamsResponseSDKType, QueryBaseFeeRequest, QueryBaseFeeResponseSDKType, QueryBlockGasRequest, QueryBlockGasResponseSDKType } from "./query.js";
+export class LCDQueryClient {
+  req: LCDClient;
+  constructor({
+    requestClient
+  }: {
+    requestClient: LCDClient;
+  }) {
+    this.req = requestClient;
+    this.params = this.params.bind(this);
+    this.baseFee = this.baseFee.bind(this);
+    this.blockGas = this.blockGas.bind(this);
+  }
+  /* Params queries the parameters of x/feemarket module. */
+  async params(_params: QueryParamsRequest = {}): Promise<QueryParamsResponseSDKType> {
+    const endpoint = `evmos/feemarket/v1/params`;
+    return await this.req.get<QueryParamsResponseSDKType>(endpoint);
+  }
+  /* BaseFee queries the base fee of the parent block of the current block. */
+  async baseFee(_params: QueryBaseFeeRequest = {}): Promise<QueryBaseFeeResponseSDKType> {
+    const endpoint = `evmos/feemarket/v1/base_fee`;
+    return await this.req.get<QueryBaseFeeResponseSDKType>(endpoint);
+  }
+  /* BlockGas queries the gas used at a given block height */
+  async blockGas(_params: QueryBlockGasRequest = {}): Promise<QueryBlockGasResponseSDKType> {
+    const endpoint = `evmos/feemarket/v1/block_gas`;
+    return await this.req.get<QueryBlockGasResponseSDKType>(endpoint);
+  }
+}

--- a/wardenjs/src/codegen/ethermint/feemarket/v1/query.rpc.Query.ts
+++ b/wardenjs/src/codegen/ethermint/feemarket/v1/query.rpc.Query.ts
@@ -1,0 +1,109 @@
+//@ts-nocheck
+import { Rpc } from "../../../helpers.js";
+import { BinaryReader } from "../../../binary.js";
+import { QueryClient, createProtobufRpcClient, ProtobufRpcClient } from "@cosmjs/stargate";
+import { ReactQueryParams } from "../../../react-query.js";
+import { useQuery } from "@tanstack/react-query";
+import { QueryParamsRequest, QueryParamsResponse, QueryBaseFeeRequest, QueryBaseFeeResponse, QueryBlockGasRequest, QueryBlockGasResponse } from "./query.js";
+/** Query defines the gRPC querier service. */
+export interface Query {
+  /** Params queries the parameters of x/feemarket module. */
+  params(request?: QueryParamsRequest): Promise<QueryParamsResponse>;
+  /** BaseFee queries the base fee of the parent block of the current block. */
+  baseFee(request?: QueryBaseFeeRequest): Promise<QueryBaseFeeResponse>;
+  /** BlockGas queries the gas used at a given block height */
+  blockGas(request?: QueryBlockGasRequest): Promise<QueryBlockGasResponse>;
+}
+export class QueryClientImpl implements Query {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.params = this.params.bind(this);
+    this.baseFee = this.baseFee.bind(this);
+    this.blockGas = this.blockGas.bind(this);
+  }
+  params(request: QueryParamsRequest = {}): Promise<QueryParamsResponse> {
+    const data = QueryParamsRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.feemarket.v1.Query", "Params", data);
+    return promise.then(data => QueryParamsResponse.decode(new BinaryReader(data)));
+  }
+  baseFee(request: QueryBaseFeeRequest = {}): Promise<QueryBaseFeeResponse> {
+    const data = QueryBaseFeeRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.feemarket.v1.Query", "BaseFee", data);
+    return promise.then(data => QueryBaseFeeResponse.decode(new BinaryReader(data)));
+  }
+  blockGas(request: QueryBlockGasRequest = {}): Promise<QueryBlockGasResponse> {
+    const data = QueryBlockGasRequest.encode(request).finish();
+    const promise = this.rpc.request("ethermint.feemarket.v1.Query", "BlockGas", data);
+    return promise.then(data => QueryBlockGasResponse.decode(new BinaryReader(data)));
+  }
+}
+export const createRpcQueryExtension = (base: QueryClient) => {
+  const rpc = createProtobufRpcClient(base);
+  const queryService = new QueryClientImpl(rpc);
+  return {
+    params(request?: QueryParamsRequest): Promise<QueryParamsResponse> {
+      return queryService.params(request);
+    },
+    baseFee(request?: QueryBaseFeeRequest): Promise<QueryBaseFeeResponse> {
+      return queryService.baseFee(request);
+    },
+    blockGas(request?: QueryBlockGasRequest): Promise<QueryBlockGasResponse> {
+      return queryService.blockGas(request);
+    }
+  };
+};
+export interface UseParamsQuery<TData> extends ReactQueryParams<QueryParamsResponse, TData> {
+  request?: QueryParamsRequest;
+}
+export interface UseBaseFeeQuery<TData> extends ReactQueryParams<QueryBaseFeeResponse, TData> {
+  request?: QueryBaseFeeRequest;
+}
+export interface UseBlockGasQuery<TData> extends ReactQueryParams<QueryBlockGasResponse, TData> {
+  request?: QueryBlockGasRequest;
+}
+const _queryClients: WeakMap<ProtobufRpcClient, QueryClientImpl> = new WeakMap();
+const getQueryService = (rpc: ProtobufRpcClient | undefined): QueryClientImpl | undefined => {
+  if (!rpc) return;
+  if (_queryClients.has(rpc)) {
+    return _queryClients.get(rpc);
+  }
+  const queryService = new QueryClientImpl(rpc);
+  _queryClients.set(rpc, queryService);
+  return queryService;
+};
+export const createRpcQueryHooks = (rpc: ProtobufRpcClient | undefined) => {
+  const queryService = getQueryService(rpc);
+  const useParams = <TData = QueryParamsResponse,>({
+    request,
+    options
+  }: UseParamsQuery<TData>) => {
+    return useQuery<QueryParamsResponse, Error, TData>(["paramsQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.params(request);
+    }, options);
+  };
+  const useBaseFee = <TData = QueryBaseFeeResponse,>({
+    request,
+    options
+  }: UseBaseFeeQuery<TData>) => {
+    return useQuery<QueryBaseFeeResponse, Error, TData>(["baseFeeQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.baseFee(request);
+    }, options);
+  };
+  const useBlockGas = <TData = QueryBlockGasResponse,>({
+    request,
+    options
+  }: UseBlockGasQuery<TData>) => {
+    return useQuery<QueryBlockGasResponse, Error, TData>(["blockGasQuery", request], () => {
+      if (!queryService) throw new Error("Query Service not initialized");
+      return queryService.blockGas(request);
+    }, options);
+  };
+  return {
+    /** Params queries the parameters of x/feemarket module. */useParams,
+    /** BaseFee queries the base fee of the parent block of the current block. */useBaseFee,
+    /** BlockGas queries the gas used at a given block height */useBlockGas
+  };
+};

--- a/wardenjs/src/codegen/ethermint/feemarket/v1/query.ts
+++ b/wardenjs/src/codegen/ethermint/feemarket/v1/query.ts
@@ -1,0 +1,521 @@
+//@ts-nocheck
+import { Params, ParamsAmino, ParamsSDKType } from "./feemarket.js";
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { JsonSafe } from "../../../json-safe.js";
+import { isSet } from "../../../helpers.js";
+/** QueryParamsRequest defines the request type for querying x/evm parameters. */
+export interface QueryParamsRequest {}
+export interface QueryParamsRequestProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.QueryParamsRequest";
+  value: Uint8Array;
+}
+/** QueryParamsRequest defines the request type for querying x/evm parameters. */
+export interface QueryParamsRequestAmino {}
+export interface QueryParamsRequestAminoMsg {
+  type: "/ethermint.feemarket.v1.QueryParamsRequest";
+  value: QueryParamsRequestAmino;
+}
+/** QueryParamsRequest defines the request type for querying x/evm parameters. */
+export interface QueryParamsRequestSDKType {}
+/** QueryParamsResponse defines the response type for querying x/evm parameters. */
+export interface QueryParamsResponse {
+  /** params define the evm module parameters. */
+  params: Params;
+}
+export interface QueryParamsResponseProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.QueryParamsResponse";
+  value: Uint8Array;
+}
+/** QueryParamsResponse defines the response type for querying x/evm parameters. */
+export interface QueryParamsResponseAmino {
+  /** params define the evm module parameters. */
+  params?: ParamsAmino;
+}
+export interface QueryParamsResponseAminoMsg {
+  type: "/ethermint.feemarket.v1.QueryParamsResponse";
+  value: QueryParamsResponseAmino;
+}
+/** QueryParamsResponse defines the response type for querying x/evm parameters. */
+export interface QueryParamsResponseSDKType {
+  params: ParamsSDKType;
+}
+/**
+ * QueryBaseFeeRequest defines the request type for querying the EIP1559 base
+ * fee.
+ */
+export interface QueryBaseFeeRequest {}
+export interface QueryBaseFeeRequestProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.QueryBaseFeeRequest";
+  value: Uint8Array;
+}
+/**
+ * QueryBaseFeeRequest defines the request type for querying the EIP1559 base
+ * fee.
+ */
+export interface QueryBaseFeeRequestAmino {}
+export interface QueryBaseFeeRequestAminoMsg {
+  type: "/ethermint.feemarket.v1.QueryBaseFeeRequest";
+  value: QueryBaseFeeRequestAmino;
+}
+/**
+ * QueryBaseFeeRequest defines the request type for querying the EIP1559 base
+ * fee.
+ */
+export interface QueryBaseFeeRequestSDKType {}
+/** QueryBaseFeeResponse returns the EIP1559 base fee. */
+export interface QueryBaseFeeResponse {
+  /** base_fee is the EIP1559 base fee */
+  baseFee: string;
+}
+export interface QueryBaseFeeResponseProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.QueryBaseFeeResponse";
+  value: Uint8Array;
+}
+/** QueryBaseFeeResponse returns the EIP1559 base fee. */
+export interface QueryBaseFeeResponseAmino {
+  /** base_fee is the EIP1559 base fee */
+  base_fee?: string;
+}
+export interface QueryBaseFeeResponseAminoMsg {
+  type: "/ethermint.feemarket.v1.QueryBaseFeeResponse";
+  value: QueryBaseFeeResponseAmino;
+}
+/** QueryBaseFeeResponse returns the EIP1559 base fee. */
+export interface QueryBaseFeeResponseSDKType {
+  base_fee: string;
+}
+/**
+ * QueryBlockGasRequest defines the request type for querying the EIP1559 base
+ * fee.
+ */
+export interface QueryBlockGasRequest {}
+export interface QueryBlockGasRequestProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.QueryBlockGasRequest";
+  value: Uint8Array;
+}
+/**
+ * QueryBlockGasRequest defines the request type for querying the EIP1559 base
+ * fee.
+ */
+export interface QueryBlockGasRequestAmino {}
+export interface QueryBlockGasRequestAminoMsg {
+  type: "/ethermint.feemarket.v1.QueryBlockGasRequest";
+  value: QueryBlockGasRequestAmino;
+}
+/**
+ * QueryBlockGasRequest defines the request type for querying the EIP1559 base
+ * fee.
+ */
+export interface QueryBlockGasRequestSDKType {}
+/** QueryBlockGasResponse returns block gas used for a given height. */
+export interface QueryBlockGasResponse {
+  /** gas is the returned block gas */
+  gas: bigint;
+}
+export interface QueryBlockGasResponseProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.QueryBlockGasResponse";
+  value: Uint8Array;
+}
+/** QueryBlockGasResponse returns block gas used for a given height. */
+export interface QueryBlockGasResponseAmino {
+  /** gas is the returned block gas */
+  gas?: string;
+}
+export interface QueryBlockGasResponseAminoMsg {
+  type: "/ethermint.feemarket.v1.QueryBlockGasResponse";
+  value: QueryBlockGasResponseAmino;
+}
+/** QueryBlockGasResponse returns block gas used for a given height. */
+export interface QueryBlockGasResponseSDKType {
+  gas: bigint;
+}
+function createBaseQueryParamsRequest(): QueryParamsRequest {
+  return {};
+}
+export const QueryParamsRequest = {
+  typeUrl: "/ethermint.feemarket.v1.QueryParamsRequest",
+  encode(_: QueryParamsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryParamsRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryParamsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(_: any): QueryParamsRequest {
+    return {};
+  },
+  toJSON(_: QueryParamsRequest): JsonSafe<QueryParamsRequest> {
+    const obj: any = {};
+    return obj;
+  },
+  fromPartial(_: Partial<QueryParamsRequest>): QueryParamsRequest {
+    const message = createBaseQueryParamsRequest();
+    return message;
+  },
+  fromAmino(_: QueryParamsRequestAmino): QueryParamsRequest {
+    const message = createBaseQueryParamsRequest();
+    return message;
+  },
+  toAmino(_: QueryParamsRequest): QueryParamsRequestAmino {
+    const obj: any = {};
+    return obj;
+  },
+  fromAminoMsg(object: QueryParamsRequestAminoMsg): QueryParamsRequest {
+    return QueryParamsRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryParamsRequestProtoMsg): QueryParamsRequest {
+    return QueryParamsRequest.decode(message.value);
+  },
+  toProto(message: QueryParamsRequest): Uint8Array {
+    return QueryParamsRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryParamsRequest): QueryParamsRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.QueryParamsRequest",
+      value: QueryParamsRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryParamsResponse(): QueryParamsResponse {
+  return {
+    params: Params.fromPartial({})
+  };
+}
+export const QueryParamsResponse = {
+  typeUrl: "/ethermint.feemarket.v1.QueryParamsResponse",
+  encode(message: QueryParamsResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.params !== undefined) {
+      Params.encode(message.params, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryParamsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryParamsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.params = Params.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryParamsResponse {
+    return {
+      params: isSet(object.params) ? Params.fromJSON(object.params) : undefined
+    };
+  },
+  toJSON(message: QueryParamsResponse): JsonSafe<QueryParamsResponse> {
+    const obj: any = {};
+    message.params !== undefined && (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryParamsResponse>): QueryParamsResponse {
+    const message = createBaseQueryParamsResponse();
+    message.params = object.params !== undefined && object.params !== null ? Params.fromPartial(object.params) : undefined;
+    return message;
+  },
+  fromAmino(object: QueryParamsResponseAmino): QueryParamsResponse {
+    const message = createBaseQueryParamsResponse();
+    if (object.params !== undefined && object.params !== null) {
+      message.params = Params.fromAmino(object.params);
+    }
+    return message;
+  },
+  toAmino(message: QueryParamsResponse): QueryParamsResponseAmino {
+    const obj: any = {};
+    obj.params = message.params ? Params.toAmino(message.params) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryParamsResponseAminoMsg): QueryParamsResponse {
+    return QueryParamsResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryParamsResponseProtoMsg): QueryParamsResponse {
+    return QueryParamsResponse.decode(message.value);
+  },
+  toProto(message: QueryParamsResponse): Uint8Array {
+    return QueryParamsResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryParamsResponse): QueryParamsResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.QueryParamsResponse",
+      value: QueryParamsResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryBaseFeeRequest(): QueryBaseFeeRequest {
+  return {};
+}
+export const QueryBaseFeeRequest = {
+  typeUrl: "/ethermint.feemarket.v1.QueryBaseFeeRequest",
+  encode(_: QueryBaseFeeRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryBaseFeeRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBaseFeeRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(_: any): QueryBaseFeeRequest {
+    return {};
+  },
+  toJSON(_: QueryBaseFeeRequest): JsonSafe<QueryBaseFeeRequest> {
+    const obj: any = {};
+    return obj;
+  },
+  fromPartial(_: Partial<QueryBaseFeeRequest>): QueryBaseFeeRequest {
+    const message = createBaseQueryBaseFeeRequest();
+    return message;
+  },
+  fromAmino(_: QueryBaseFeeRequestAmino): QueryBaseFeeRequest {
+    const message = createBaseQueryBaseFeeRequest();
+    return message;
+  },
+  toAmino(_: QueryBaseFeeRequest): QueryBaseFeeRequestAmino {
+    const obj: any = {};
+    return obj;
+  },
+  fromAminoMsg(object: QueryBaseFeeRequestAminoMsg): QueryBaseFeeRequest {
+    return QueryBaseFeeRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryBaseFeeRequestProtoMsg): QueryBaseFeeRequest {
+    return QueryBaseFeeRequest.decode(message.value);
+  },
+  toProto(message: QueryBaseFeeRequest): Uint8Array {
+    return QueryBaseFeeRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryBaseFeeRequest): QueryBaseFeeRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.QueryBaseFeeRequest",
+      value: QueryBaseFeeRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryBaseFeeResponse(): QueryBaseFeeResponse {
+  return {
+    baseFee: ""
+  };
+}
+export const QueryBaseFeeResponse = {
+  typeUrl: "/ethermint.feemarket.v1.QueryBaseFeeResponse",
+  encode(message: QueryBaseFeeResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.baseFee !== "") {
+      writer.uint32(10).string(message.baseFee);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryBaseFeeResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBaseFeeResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.baseFee = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryBaseFeeResponse {
+    return {
+      baseFee: isSet(object.baseFee) ? String(object.baseFee) : ""
+    };
+  },
+  toJSON(message: QueryBaseFeeResponse): JsonSafe<QueryBaseFeeResponse> {
+    const obj: any = {};
+    message.baseFee !== undefined && (obj.baseFee = message.baseFee);
+    return obj;
+  },
+  fromPartial(object: Partial<QueryBaseFeeResponse>): QueryBaseFeeResponse {
+    const message = createBaseQueryBaseFeeResponse();
+    message.baseFee = object.baseFee ?? "";
+    return message;
+  },
+  fromAmino(object: QueryBaseFeeResponseAmino): QueryBaseFeeResponse {
+    const message = createBaseQueryBaseFeeResponse();
+    if (object.base_fee !== undefined && object.base_fee !== null) {
+      message.baseFee = object.base_fee;
+    }
+    return message;
+  },
+  toAmino(message: QueryBaseFeeResponse): QueryBaseFeeResponseAmino {
+    const obj: any = {};
+    obj.base_fee = message.baseFee === "" ? undefined : message.baseFee;
+    return obj;
+  },
+  fromAminoMsg(object: QueryBaseFeeResponseAminoMsg): QueryBaseFeeResponse {
+    return QueryBaseFeeResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryBaseFeeResponseProtoMsg): QueryBaseFeeResponse {
+    return QueryBaseFeeResponse.decode(message.value);
+  },
+  toProto(message: QueryBaseFeeResponse): Uint8Array {
+    return QueryBaseFeeResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryBaseFeeResponse): QueryBaseFeeResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.QueryBaseFeeResponse",
+      value: QueryBaseFeeResponse.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryBlockGasRequest(): QueryBlockGasRequest {
+  return {};
+}
+export const QueryBlockGasRequest = {
+  typeUrl: "/ethermint.feemarket.v1.QueryBlockGasRequest",
+  encode(_: QueryBlockGasRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryBlockGasRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBlockGasRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(_: any): QueryBlockGasRequest {
+    return {};
+  },
+  toJSON(_: QueryBlockGasRequest): JsonSafe<QueryBlockGasRequest> {
+    const obj: any = {};
+    return obj;
+  },
+  fromPartial(_: Partial<QueryBlockGasRequest>): QueryBlockGasRequest {
+    const message = createBaseQueryBlockGasRequest();
+    return message;
+  },
+  fromAmino(_: QueryBlockGasRequestAmino): QueryBlockGasRequest {
+    const message = createBaseQueryBlockGasRequest();
+    return message;
+  },
+  toAmino(_: QueryBlockGasRequest): QueryBlockGasRequestAmino {
+    const obj: any = {};
+    return obj;
+  },
+  fromAminoMsg(object: QueryBlockGasRequestAminoMsg): QueryBlockGasRequest {
+    return QueryBlockGasRequest.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryBlockGasRequestProtoMsg): QueryBlockGasRequest {
+    return QueryBlockGasRequest.decode(message.value);
+  },
+  toProto(message: QueryBlockGasRequest): Uint8Array {
+    return QueryBlockGasRequest.encode(message).finish();
+  },
+  toProtoMsg(message: QueryBlockGasRequest): QueryBlockGasRequestProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.QueryBlockGasRequest",
+      value: QueryBlockGasRequest.encode(message).finish()
+    };
+  }
+};
+function createBaseQueryBlockGasResponse(): QueryBlockGasResponse {
+  return {
+    gas: BigInt(0)
+  };
+}
+export const QueryBlockGasResponse = {
+  typeUrl: "/ethermint.feemarket.v1.QueryBlockGasResponse",
+  encode(message: QueryBlockGasResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.gas !== BigInt(0)) {
+      writer.uint32(8).int64(message.gas);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): QueryBlockGasResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBlockGasResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.gas = reader.int64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): QueryBlockGasResponse {
+    return {
+      gas: isSet(object.gas) ? BigInt(object.gas.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: QueryBlockGasResponse): JsonSafe<QueryBlockGasResponse> {
+    const obj: any = {};
+    message.gas !== undefined && (obj.gas = (message.gas || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<QueryBlockGasResponse>): QueryBlockGasResponse {
+    const message = createBaseQueryBlockGasResponse();
+    message.gas = object.gas !== undefined && object.gas !== null ? BigInt(object.gas.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: QueryBlockGasResponseAmino): QueryBlockGasResponse {
+    const message = createBaseQueryBlockGasResponse();
+    if (object.gas !== undefined && object.gas !== null) {
+      message.gas = BigInt(object.gas);
+    }
+    return message;
+  },
+  toAmino(message: QueryBlockGasResponse): QueryBlockGasResponseAmino {
+    const obj: any = {};
+    obj.gas = message.gas !== BigInt(0) ? message.gas.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: QueryBlockGasResponseAminoMsg): QueryBlockGasResponse {
+    return QueryBlockGasResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: QueryBlockGasResponseProtoMsg): QueryBlockGasResponse {
+    return QueryBlockGasResponse.decode(message.value);
+  },
+  toProto(message: QueryBlockGasResponse): Uint8Array {
+    return QueryBlockGasResponse.encode(message).finish();
+  },
+  toProtoMsg(message: QueryBlockGasResponse): QueryBlockGasResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.QueryBlockGasResponse",
+      value: QueryBlockGasResponse.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/feemarket/v1/tx.amino.ts
+++ b/wardenjs/src/codegen/ethermint/feemarket/v1/tx.amino.ts
@@ -1,0 +1,9 @@
+//@ts-nocheck
+import { MsgUpdateParams } from "./tx.js";
+export const AminoConverter = {
+  "/ethermint.feemarket.v1.MsgUpdateParams": {
+    aminoType: "/ethermint.feemarket.v1.MsgUpdateParams",
+    toAmino: MsgUpdateParams.toAmino,
+    fromAmino: MsgUpdateParams.fromAmino
+  }
+};

--- a/wardenjs/src/codegen/ethermint/feemarket/v1/tx.registry.ts
+++ b/wardenjs/src/codegen/ethermint/feemarket/v1/tx.registry.ts
@@ -1,0 +1,51 @@
+//@ts-nocheck
+import { GeneratedType, Registry } from "@cosmjs/proto-signing";
+import { MsgUpdateParams } from "./tx.js";
+export const registry: ReadonlyArray<[string, GeneratedType]> = [["/ethermint.feemarket.v1.MsgUpdateParams", MsgUpdateParams]];
+export const load = (protoRegistry: Registry) => {
+  registry.forEach(([typeUrl, mod]) => {
+    protoRegistry.register(typeUrl, mod);
+  });
+};
+export const MessageComposer = {
+  encoded: {
+    updateParams(value: MsgUpdateParams) {
+      return {
+        typeUrl: "/ethermint.feemarket.v1.MsgUpdateParams",
+        value: MsgUpdateParams.encode(value).finish()
+      };
+    }
+  },
+  withTypeUrl: {
+    updateParams(value: MsgUpdateParams) {
+      return {
+        typeUrl: "/ethermint.feemarket.v1.MsgUpdateParams",
+        value
+      };
+    }
+  },
+  toJSON: {
+    updateParams(value: MsgUpdateParams) {
+      return {
+        typeUrl: "/ethermint.feemarket.v1.MsgUpdateParams",
+        value: MsgUpdateParams.toJSON(value)
+      };
+    }
+  },
+  fromJSON: {
+    updateParams(value: any) {
+      return {
+        typeUrl: "/ethermint.feemarket.v1.MsgUpdateParams",
+        value: MsgUpdateParams.fromJSON(value)
+      };
+    }
+  },
+  fromPartial: {
+    updateParams(value: MsgUpdateParams) {
+      return {
+        typeUrl: "/ethermint.feemarket.v1.MsgUpdateParams",
+        value: MsgUpdateParams.fromPartial(value)
+      };
+    }
+  }
+};

--- a/wardenjs/src/codegen/ethermint/feemarket/v1/tx.rpc.msg.ts
+++ b/wardenjs/src/codegen/ethermint/feemarket/v1/tx.rpc.msg.ts
@@ -1,0 +1,24 @@
+//@ts-nocheck
+import { Rpc } from "../../../helpers.js";
+import { BinaryReader } from "../../../binary.js";
+import { MsgUpdateParams, MsgUpdateParamsResponse } from "./tx.js";
+/** Msg defines the erc20 Msg service. */
+export interface Msg {
+  /**
+   * UpdateParams defined a governance operation for updating the x/feemarket module parameters.
+   * The authority is hard-coded to the Cosmos SDK x/gov module account
+   */
+  updateParams(request: MsgUpdateParams): Promise<MsgUpdateParamsResponse>;
+}
+export class MsgClientImpl implements Msg {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.updateParams = this.updateParams.bind(this);
+  }
+  updateParams(request: MsgUpdateParams): Promise<MsgUpdateParamsResponse> {
+    const data = MsgUpdateParams.encode(request).finish();
+    const promise = this.rpc.request("ethermint.feemarket.v1.Msg", "UpdateParams", data);
+    return promise.then(data => MsgUpdateParamsResponse.decode(new BinaryReader(data)));
+  }
+}

--- a/wardenjs/src/codegen/ethermint/feemarket/v1/tx.ts
+++ b/wardenjs/src/codegen/ethermint/feemarket/v1/tx.ts
@@ -1,0 +1,205 @@
+//@ts-nocheck
+import { Params, ParamsAmino, ParamsSDKType } from "./feemarket.js";
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** MsgUpdateParams defines a Msg for updating the x/feemarket module parameters. */
+export interface MsgUpdateParams {
+  /** authority is the address of the governance account. */
+  authority: string;
+  /**
+   * params defines the x/feemarket parameters to update.
+   * NOTE: All parameters must be supplied.
+   */
+  params: Params;
+}
+export interface MsgUpdateParamsProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.MsgUpdateParams";
+  value: Uint8Array;
+}
+/** MsgUpdateParams defines a Msg for updating the x/feemarket module parameters. */
+export interface MsgUpdateParamsAmino {
+  /** authority is the address of the governance account. */
+  authority?: string;
+  /**
+   * params defines the x/feemarket parameters to update.
+   * NOTE: All parameters must be supplied.
+   */
+  params?: ParamsAmino;
+}
+export interface MsgUpdateParamsAminoMsg {
+  type: "/ethermint.feemarket.v1.MsgUpdateParams";
+  value: MsgUpdateParamsAmino;
+}
+/** MsgUpdateParams defines a Msg for updating the x/feemarket module parameters. */
+export interface MsgUpdateParamsSDKType {
+  authority: string;
+  params: ParamsSDKType;
+}
+/**
+ * MsgUpdateParamsResponse defines the response structure for executing a
+ * MsgUpdateParams message.
+ */
+export interface MsgUpdateParamsResponse {}
+export interface MsgUpdateParamsResponseProtoMsg {
+  typeUrl: "/ethermint.feemarket.v1.MsgUpdateParamsResponse";
+  value: Uint8Array;
+}
+/**
+ * MsgUpdateParamsResponse defines the response structure for executing a
+ * MsgUpdateParams message.
+ */
+export interface MsgUpdateParamsResponseAmino {}
+export interface MsgUpdateParamsResponseAminoMsg {
+  type: "/ethermint.feemarket.v1.MsgUpdateParamsResponse";
+  value: MsgUpdateParamsResponseAmino;
+}
+/**
+ * MsgUpdateParamsResponse defines the response structure for executing a
+ * MsgUpdateParams message.
+ */
+export interface MsgUpdateParamsResponseSDKType {}
+function createBaseMsgUpdateParams(): MsgUpdateParams {
+  return {
+    authority: "",
+    params: Params.fromPartial({})
+  };
+}
+export const MsgUpdateParams = {
+  typeUrl: "/ethermint.feemarket.v1.MsgUpdateParams",
+  encode(message: MsgUpdateParams, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.authority !== "") {
+      writer.uint32(10).string(message.authority);
+    }
+    if (message.params !== undefined) {
+      Params.encode(message.params, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): MsgUpdateParams {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgUpdateParams();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.authority = reader.string();
+          break;
+        case 2:
+          message.params = Params.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): MsgUpdateParams {
+    return {
+      authority: isSet(object.authority) ? String(object.authority) : "",
+      params: isSet(object.params) ? Params.fromJSON(object.params) : undefined
+    };
+  },
+  toJSON(message: MsgUpdateParams): JsonSafe<MsgUpdateParams> {
+    const obj: any = {};
+    message.authority !== undefined && (obj.authority = message.authority);
+    message.params !== undefined && (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+  fromPartial(object: Partial<MsgUpdateParams>): MsgUpdateParams {
+    const message = createBaseMsgUpdateParams();
+    message.authority = object.authority ?? "";
+    message.params = object.params !== undefined && object.params !== null ? Params.fromPartial(object.params) : undefined;
+    return message;
+  },
+  fromAmino(object: MsgUpdateParamsAmino): MsgUpdateParams {
+    const message = createBaseMsgUpdateParams();
+    if (object.authority !== undefined && object.authority !== null) {
+      message.authority = object.authority;
+    }
+    if (object.params !== undefined && object.params !== null) {
+      message.params = Params.fromAmino(object.params);
+    }
+    return message;
+  },
+  toAmino(message: MsgUpdateParams): MsgUpdateParamsAmino {
+    const obj: any = {};
+    obj.authority = message.authority === "" ? undefined : message.authority;
+    obj.params = message.params ? Params.toAmino(message.params) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: MsgUpdateParamsAminoMsg): MsgUpdateParams {
+    return MsgUpdateParams.fromAmino(object.value);
+  },
+  fromProtoMsg(message: MsgUpdateParamsProtoMsg): MsgUpdateParams {
+    return MsgUpdateParams.decode(message.value);
+  },
+  toProto(message: MsgUpdateParams): Uint8Array {
+    return MsgUpdateParams.encode(message).finish();
+  },
+  toProtoMsg(message: MsgUpdateParams): MsgUpdateParamsProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.MsgUpdateParams",
+      value: MsgUpdateParams.encode(message).finish()
+    };
+  }
+};
+function createBaseMsgUpdateParamsResponse(): MsgUpdateParamsResponse {
+  return {};
+}
+export const MsgUpdateParamsResponse = {
+  typeUrl: "/ethermint.feemarket.v1.MsgUpdateParamsResponse",
+  encode(_: MsgUpdateParamsResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): MsgUpdateParamsResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgUpdateParamsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(_: any): MsgUpdateParamsResponse {
+    return {};
+  },
+  toJSON(_: MsgUpdateParamsResponse): JsonSafe<MsgUpdateParamsResponse> {
+    const obj: any = {};
+    return obj;
+  },
+  fromPartial(_: Partial<MsgUpdateParamsResponse>): MsgUpdateParamsResponse {
+    const message = createBaseMsgUpdateParamsResponse();
+    return message;
+  },
+  fromAmino(_: MsgUpdateParamsResponseAmino): MsgUpdateParamsResponse {
+    const message = createBaseMsgUpdateParamsResponse();
+    return message;
+  },
+  toAmino(_: MsgUpdateParamsResponse): MsgUpdateParamsResponseAmino {
+    const obj: any = {};
+    return obj;
+  },
+  fromAminoMsg(object: MsgUpdateParamsResponseAminoMsg): MsgUpdateParamsResponse {
+    return MsgUpdateParamsResponse.fromAmino(object.value);
+  },
+  fromProtoMsg(message: MsgUpdateParamsResponseProtoMsg): MsgUpdateParamsResponse {
+    return MsgUpdateParamsResponse.decode(message.value);
+  },
+  toProto(message: MsgUpdateParamsResponse): Uint8Array {
+    return MsgUpdateParamsResponse.encode(message).finish();
+  },
+  toProtoMsg(message: MsgUpdateParamsResponse): MsgUpdateParamsResponseProtoMsg {
+    return {
+      typeUrl: "/ethermint.feemarket.v1.MsgUpdateParamsResponse",
+      value: MsgUpdateParamsResponse.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/lcd.ts
+++ b/wardenjs/src/codegen/ethermint/lcd.ts
@@ -1,0 +1,97 @@
+//@ts-nocheck
+import { LCDClient } from "@cosmology/lcd";
+export const createLCDClient = async ({
+  restEndpoint
+}: {
+  restEndpoint: string;
+}) => {
+  const requestClient = new LCDClient({
+    restEndpoint
+  });
+  return {
+    cosmos: {
+      auth: {
+        v1beta1: new (await import("../cosmos/auth/v1beta1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      authz: {
+        v1beta1: new (await import("../cosmos/authz/v1beta1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      bank: {
+        v1beta1: new (await import("../cosmos/bank/v1beta1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      base: {
+        tendermint: {
+          v1beta1: new (await import("../cosmos/base/tendermint/v1beta1/query.lcd.js")).LCDQueryClient({
+            requestClient
+          })
+        }
+      },
+      distribution: {
+        v1beta1: new (await import("../cosmos/distribution/v1beta1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      feegrant: {
+        v1beta1: new (await import("../cosmos/feegrant/v1beta1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      gov: {
+        v1: new (await import("../cosmos/gov/v1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        }),
+        v1beta1: new (await import("../cosmos/gov/v1beta1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      group: {
+        v1: new (await import("../cosmos/group/v1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      mint: {
+        v1beta1: new (await import("../cosmos/mint/v1beta1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      params: {
+        v1beta1: new (await import("../cosmos/params/v1beta1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      staking: {
+        v1beta1: new (await import("../cosmos/staking/v1beta1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      tx: {
+        v1beta1: new (await import("../cosmos/tx/v1beta1/service.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      upgrade: {
+        v1beta1: new (await import("../cosmos/upgrade/v1beta1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      }
+    },
+    ethermint: {
+      evm: {
+        v1: new (await import("./evm/v1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      },
+      feemarket: {
+        v1: new (await import("./feemarket/v1/query.lcd.js")).LCDQueryClient({
+          requestClient
+        })
+      }
+    }
+  };
+};

--- a/wardenjs/src/codegen/ethermint/rpc.query.ts
+++ b/wardenjs/src/codegen/ethermint/rpc.query.ts
@@ -1,0 +1,65 @@
+//@ts-nocheck
+import { Tendermint34Client, HttpEndpoint } from "@cosmjs/tendermint-rpc";
+import { QueryClient } from "@cosmjs/stargate";
+export const createRPCQueryClient = async ({
+  rpcEndpoint
+}: {
+  rpcEndpoint: string | HttpEndpoint;
+}) => {
+  const tmClient = await Tendermint34Client.connect(rpcEndpoint);
+  const client = new QueryClient(tmClient);
+  return {
+    cosmos: {
+      auth: {
+        v1beta1: (await import("../cosmos/auth/v1beta1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      authz: {
+        v1beta1: (await import("../cosmos/authz/v1beta1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      bank: {
+        v1beta1: (await import("../cosmos/bank/v1beta1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      base: {
+        tendermint: {
+          v1beta1: (await import("../cosmos/base/tendermint/v1beta1/query.rpc.Service.js")).createRpcQueryExtension(client)
+        }
+      },
+      distribution: {
+        v1beta1: (await import("../cosmos/distribution/v1beta1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      feegrant: {
+        v1beta1: (await import("../cosmos/feegrant/v1beta1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      gov: {
+        v1: (await import("../cosmos/gov/v1/query.rpc.Query.js")).createRpcQueryExtension(client),
+        v1beta1: (await import("../cosmos/gov/v1beta1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      group: {
+        v1: (await import("../cosmos/group/v1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      mint: {
+        v1beta1: (await import("../cosmos/mint/v1beta1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      params: {
+        v1beta1: (await import("../cosmos/params/v1beta1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      staking: {
+        v1beta1: (await import("../cosmos/staking/v1beta1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      tx: {
+        v1beta1: (await import("../cosmos/tx/v1beta1/service.rpc.Service.js")).createRpcQueryExtension(client)
+      },
+      upgrade: {
+        v1beta1: (await import("../cosmos/upgrade/v1beta1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      }
+    },
+    ethermint: {
+      evm: {
+        v1: (await import("./evm/v1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      },
+      feemarket: {
+        v1: (await import("./feemarket/v1/query.rpc.Query.js")).createRpcQueryExtension(client)
+      }
+    }
+  };
+};

--- a/wardenjs/src/codegen/ethermint/rpc.tx.ts
+++ b/wardenjs/src/codegen/ethermint/rpc.tx.ts
@@ -1,0 +1,46 @@
+//@ts-nocheck
+import { Rpc } from "../helpers.js";
+export const createRPCMsgClient = async ({
+  rpc
+}: {
+  rpc: Rpc;
+}) => ({
+  cosmos: {
+    authz: {
+      v1beta1: new (await import("../cosmos/authz/v1beta1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    },
+    bank: {
+      v1beta1: new (await import("../cosmos/bank/v1beta1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    },
+    distribution: {
+      v1beta1: new (await import("../cosmos/distribution/v1beta1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    },
+    feegrant: {
+      v1beta1: new (await import("../cosmos/feegrant/v1beta1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    },
+    gov: {
+      v1: new (await import("../cosmos/gov/v1/tx.rpc.msg.js")).MsgClientImpl(rpc),
+      v1beta1: new (await import("../cosmos/gov/v1beta1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    },
+    group: {
+      v1: new (await import("../cosmos/group/v1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    },
+    staking: {
+      v1beta1: new (await import("../cosmos/staking/v1beta1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    },
+    upgrade: {
+      v1beta1: new (await import("../cosmos/upgrade/v1beta1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    },
+    vesting: {
+      v1beta1: new (await import("../cosmos/vesting/v1beta1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    }
+  },
+  ethermint: {
+    evm: {
+      v1: new (await import("./evm/v1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    },
+    feemarket: {
+      v1: new (await import("./feemarket/v1/tx.rpc.msg.js")).MsgClientImpl(rpc)
+    }
+  }
+});

--- a/wardenjs/src/codegen/ethermint/types/v1/dynamic_fee.ts
+++ b/wardenjs/src/codegen/ethermint/types/v1/dynamic_fee.ts
@@ -1,0 +1,99 @@
+//@ts-nocheck
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** ExtensionOptionDynamicFeeTx is an extension option that specifies the maxPrioPrice for cosmos tx */
+export interface ExtensionOptionDynamicFeeTx {
+  /** max_priority_price is the same as `max_priority_fee_per_gas` in eip-1559 spec */
+  maxPriorityPrice: string;
+}
+export interface ExtensionOptionDynamicFeeTxProtoMsg {
+  typeUrl: "/ethermint.types.v1.ExtensionOptionDynamicFeeTx";
+  value: Uint8Array;
+}
+/** ExtensionOptionDynamicFeeTx is an extension option that specifies the maxPrioPrice for cosmos tx */
+export interface ExtensionOptionDynamicFeeTxAmino {
+  /** max_priority_price is the same as `max_priority_fee_per_gas` in eip-1559 spec */
+  max_priority_price?: string;
+}
+export interface ExtensionOptionDynamicFeeTxAminoMsg {
+  type: "/ethermint.types.v1.ExtensionOptionDynamicFeeTx";
+  value: ExtensionOptionDynamicFeeTxAmino;
+}
+/** ExtensionOptionDynamicFeeTx is an extension option that specifies the maxPrioPrice for cosmos tx */
+export interface ExtensionOptionDynamicFeeTxSDKType {
+  max_priority_price: string;
+}
+function createBaseExtensionOptionDynamicFeeTx(): ExtensionOptionDynamicFeeTx {
+  return {
+    maxPriorityPrice: ""
+  };
+}
+export const ExtensionOptionDynamicFeeTx = {
+  typeUrl: "/ethermint.types.v1.ExtensionOptionDynamicFeeTx",
+  encode(message: ExtensionOptionDynamicFeeTx, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.maxPriorityPrice !== "") {
+      writer.uint32(10).string(message.maxPriorityPrice);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): ExtensionOptionDynamicFeeTx {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseExtensionOptionDynamicFeeTx();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.maxPriorityPrice = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): ExtensionOptionDynamicFeeTx {
+    return {
+      maxPriorityPrice: isSet(object.maxPriorityPrice) ? String(object.maxPriorityPrice) : ""
+    };
+  },
+  toJSON(message: ExtensionOptionDynamicFeeTx): JsonSafe<ExtensionOptionDynamicFeeTx> {
+    const obj: any = {};
+    message.maxPriorityPrice !== undefined && (obj.maxPriorityPrice = message.maxPriorityPrice);
+    return obj;
+  },
+  fromPartial(object: Partial<ExtensionOptionDynamicFeeTx>): ExtensionOptionDynamicFeeTx {
+    const message = createBaseExtensionOptionDynamicFeeTx();
+    message.maxPriorityPrice = object.maxPriorityPrice ?? "";
+    return message;
+  },
+  fromAmino(object: ExtensionOptionDynamicFeeTxAmino): ExtensionOptionDynamicFeeTx {
+    const message = createBaseExtensionOptionDynamicFeeTx();
+    if (object.max_priority_price !== undefined && object.max_priority_price !== null) {
+      message.maxPriorityPrice = object.max_priority_price;
+    }
+    return message;
+  },
+  toAmino(message: ExtensionOptionDynamicFeeTx): ExtensionOptionDynamicFeeTxAmino {
+    const obj: any = {};
+    obj.max_priority_price = message.maxPriorityPrice === "" ? undefined : message.maxPriorityPrice;
+    return obj;
+  },
+  fromAminoMsg(object: ExtensionOptionDynamicFeeTxAminoMsg): ExtensionOptionDynamicFeeTx {
+    return ExtensionOptionDynamicFeeTx.fromAmino(object.value);
+  },
+  fromProtoMsg(message: ExtensionOptionDynamicFeeTxProtoMsg): ExtensionOptionDynamicFeeTx {
+    return ExtensionOptionDynamicFeeTx.decode(message.value);
+  },
+  toProto(message: ExtensionOptionDynamicFeeTx): Uint8Array {
+    return ExtensionOptionDynamicFeeTx.encode(message).finish();
+  },
+  toProtoMsg(message: ExtensionOptionDynamicFeeTx): ExtensionOptionDynamicFeeTxProtoMsg {
+    return {
+      typeUrl: "/ethermint.types.v1.ExtensionOptionDynamicFeeTx",
+      value: ExtensionOptionDynamicFeeTx.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/types/v1/indexer.ts
+++ b/wardenjs/src/codegen/ethermint/types/v1/indexer.ts
@@ -1,0 +1,231 @@
+//@ts-nocheck
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/** TxResult is the value stored in eth tx indexer */
+export interface TxResult {
+  /** height of the blockchain */
+  height: bigint;
+  /** tx_index of the cosmos transaction */
+  txIndex: number;
+  /** msg_index in a batch transaction */
+  msgIndex: number;
+  /**
+   * eth_tx_index is the index in the list of valid eth tx in the block,
+   * aka. the transaction list returned by eth_getBlock api.
+   */
+  ethTxIndex: number;
+  /** failed is true if the eth transaction did not go succeed */
+  failed: boolean;
+  /**
+   * gas_used by the transaction. If it exceeds the block gas limit,
+   * it's set to gas limit, which is what's actually deducted by ante handler.
+   */
+  gasUsed: bigint;
+  /**
+   * cumulative_gas_used specifies the cumulated amount of gas used for all
+   * processed messages within the current batch transaction.
+   */
+  cumulativeGasUsed: bigint;
+}
+export interface TxResultProtoMsg {
+  typeUrl: "/ethermint.types.v1.TxResult";
+  value: Uint8Array;
+}
+/** TxResult is the value stored in eth tx indexer */
+export interface TxResultAmino {
+  /** height of the blockchain */
+  height?: string;
+  /** tx_index of the cosmos transaction */
+  tx_index?: number;
+  /** msg_index in a batch transaction */
+  msg_index?: number;
+  /**
+   * eth_tx_index is the index in the list of valid eth tx in the block,
+   * aka. the transaction list returned by eth_getBlock api.
+   */
+  eth_tx_index?: number;
+  /** failed is true if the eth transaction did not go succeed */
+  failed?: boolean;
+  /**
+   * gas_used by the transaction. If it exceeds the block gas limit,
+   * it's set to gas limit, which is what's actually deducted by ante handler.
+   */
+  gas_used?: string;
+  /**
+   * cumulative_gas_used specifies the cumulated amount of gas used for all
+   * processed messages within the current batch transaction.
+   */
+  cumulative_gas_used?: string;
+}
+export interface TxResultAminoMsg {
+  type: "/ethermint.types.v1.TxResult";
+  value: TxResultAmino;
+}
+/** TxResult is the value stored in eth tx indexer */
+export interface TxResultSDKType {
+  height: bigint;
+  tx_index: number;
+  msg_index: number;
+  eth_tx_index: number;
+  failed: boolean;
+  gas_used: bigint;
+  cumulative_gas_used: bigint;
+}
+function createBaseTxResult(): TxResult {
+  return {
+    height: BigInt(0),
+    txIndex: 0,
+    msgIndex: 0,
+    ethTxIndex: 0,
+    failed: false,
+    gasUsed: BigInt(0),
+    cumulativeGasUsed: BigInt(0)
+  };
+}
+export const TxResult = {
+  typeUrl: "/ethermint.types.v1.TxResult",
+  encode(message: TxResult, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.height !== BigInt(0)) {
+      writer.uint32(8).int64(message.height);
+    }
+    if (message.txIndex !== 0) {
+      writer.uint32(16).uint32(message.txIndex);
+    }
+    if (message.msgIndex !== 0) {
+      writer.uint32(24).uint32(message.msgIndex);
+    }
+    if (message.ethTxIndex !== 0) {
+      writer.uint32(32).int32(message.ethTxIndex);
+    }
+    if (message.failed === true) {
+      writer.uint32(40).bool(message.failed);
+    }
+    if (message.gasUsed !== BigInt(0)) {
+      writer.uint32(48).uint64(message.gasUsed);
+    }
+    if (message.cumulativeGasUsed !== BigInt(0)) {
+      writer.uint32(56).uint64(message.cumulativeGasUsed);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): TxResult {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseTxResult();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.height = reader.int64();
+          break;
+        case 2:
+          message.txIndex = reader.uint32();
+          break;
+        case 3:
+          message.msgIndex = reader.uint32();
+          break;
+        case 4:
+          message.ethTxIndex = reader.int32();
+          break;
+        case 5:
+          message.failed = reader.bool();
+          break;
+        case 6:
+          message.gasUsed = reader.uint64();
+          break;
+        case 7:
+          message.cumulativeGasUsed = reader.uint64();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): TxResult {
+    return {
+      height: isSet(object.height) ? BigInt(object.height.toString()) : BigInt(0),
+      txIndex: isSet(object.txIndex) ? Number(object.txIndex) : 0,
+      msgIndex: isSet(object.msgIndex) ? Number(object.msgIndex) : 0,
+      ethTxIndex: isSet(object.ethTxIndex) ? Number(object.ethTxIndex) : 0,
+      failed: isSet(object.failed) ? Boolean(object.failed) : false,
+      gasUsed: isSet(object.gasUsed) ? BigInt(object.gasUsed.toString()) : BigInt(0),
+      cumulativeGasUsed: isSet(object.cumulativeGasUsed) ? BigInt(object.cumulativeGasUsed.toString()) : BigInt(0)
+    };
+  },
+  toJSON(message: TxResult): JsonSafe<TxResult> {
+    const obj: any = {};
+    message.height !== undefined && (obj.height = (message.height || BigInt(0)).toString());
+    message.txIndex !== undefined && (obj.txIndex = Math.round(message.txIndex));
+    message.msgIndex !== undefined && (obj.msgIndex = Math.round(message.msgIndex));
+    message.ethTxIndex !== undefined && (obj.ethTxIndex = Math.round(message.ethTxIndex));
+    message.failed !== undefined && (obj.failed = message.failed);
+    message.gasUsed !== undefined && (obj.gasUsed = (message.gasUsed || BigInt(0)).toString());
+    message.cumulativeGasUsed !== undefined && (obj.cumulativeGasUsed = (message.cumulativeGasUsed || BigInt(0)).toString());
+    return obj;
+  },
+  fromPartial(object: Partial<TxResult>): TxResult {
+    const message = createBaseTxResult();
+    message.height = object.height !== undefined && object.height !== null ? BigInt(object.height.toString()) : BigInt(0);
+    message.txIndex = object.txIndex ?? 0;
+    message.msgIndex = object.msgIndex ?? 0;
+    message.ethTxIndex = object.ethTxIndex ?? 0;
+    message.failed = object.failed ?? false;
+    message.gasUsed = object.gasUsed !== undefined && object.gasUsed !== null ? BigInt(object.gasUsed.toString()) : BigInt(0);
+    message.cumulativeGasUsed = object.cumulativeGasUsed !== undefined && object.cumulativeGasUsed !== null ? BigInt(object.cumulativeGasUsed.toString()) : BigInt(0);
+    return message;
+  },
+  fromAmino(object: TxResultAmino): TxResult {
+    const message = createBaseTxResult();
+    if (object.height !== undefined && object.height !== null) {
+      message.height = BigInt(object.height);
+    }
+    if (object.tx_index !== undefined && object.tx_index !== null) {
+      message.txIndex = object.tx_index;
+    }
+    if (object.msg_index !== undefined && object.msg_index !== null) {
+      message.msgIndex = object.msg_index;
+    }
+    if (object.eth_tx_index !== undefined && object.eth_tx_index !== null) {
+      message.ethTxIndex = object.eth_tx_index;
+    }
+    if (object.failed !== undefined && object.failed !== null) {
+      message.failed = object.failed;
+    }
+    if (object.gas_used !== undefined && object.gas_used !== null) {
+      message.gasUsed = BigInt(object.gas_used);
+    }
+    if (object.cumulative_gas_used !== undefined && object.cumulative_gas_used !== null) {
+      message.cumulativeGasUsed = BigInt(object.cumulative_gas_used);
+    }
+    return message;
+  },
+  toAmino(message: TxResult): TxResultAmino {
+    const obj: any = {};
+    obj.height = message.height !== BigInt(0) ? message.height.toString() : undefined;
+    obj.tx_index = message.txIndex === 0 ? undefined : message.txIndex;
+    obj.msg_index = message.msgIndex === 0 ? undefined : message.msgIndex;
+    obj.eth_tx_index = message.ethTxIndex === 0 ? undefined : message.ethTxIndex;
+    obj.failed = message.failed === false ? undefined : message.failed;
+    obj.gas_used = message.gasUsed !== BigInt(0) ? message.gasUsed.toString() : undefined;
+    obj.cumulative_gas_used = message.cumulativeGasUsed !== BigInt(0) ? message.cumulativeGasUsed.toString() : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: TxResultAminoMsg): TxResult {
+    return TxResult.fromAmino(object.value);
+  },
+  fromProtoMsg(message: TxResultProtoMsg): TxResult {
+    return TxResult.decode(message.value);
+  },
+  toProto(message: TxResult): Uint8Array {
+    return TxResult.encode(message).finish();
+  },
+  toProtoMsg(message: TxResult): TxResultProtoMsg {
+    return {
+      typeUrl: "/ethermint.types.v1.TxResult",
+      value: TxResult.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/ethermint/types/v1/web3.ts
+++ b/wardenjs/src/codegen/ethermint/types/v1/web3.ts
@@ -1,0 +1,164 @@
+//@ts-nocheck
+import { BinaryReader, BinaryWriter } from "../../../binary.js";
+import { isSet, bytesFromBase64, base64FromBytes } from "../../../helpers.js";
+import { JsonSafe } from "../../../json-safe.js";
+/**
+ * ExtensionOptionsWeb3Tx is an extension option that specifies the typed chain id,
+ * the fee payer as well as its signature data.
+ */
+export interface ExtensionOptionsWeb3Tx {
+  /**
+   * typed_data_chain_id is used only in EIP712 Domain and should match
+   * Ethereum network ID in a Web3 provider (e.g. Metamask).
+   */
+  typedDataChainId: bigint;
+  /**
+   * fee_payer is an account address for the fee payer. It will be validated
+   * during EIP712 signature checking.
+   */
+  feePayer: string;
+  /**
+   * fee_payer_sig is a signature data from the fee paying account,
+   * allows to perform fee delegation when using EIP712 Domain.
+   */
+  feePayerSig: Uint8Array;
+}
+export interface ExtensionOptionsWeb3TxProtoMsg {
+  typeUrl: "/ethermint.types.v1.ExtensionOptionsWeb3Tx";
+  value: Uint8Array;
+}
+/**
+ * ExtensionOptionsWeb3Tx is an extension option that specifies the typed chain id,
+ * the fee payer as well as its signature data.
+ */
+export interface ExtensionOptionsWeb3TxAmino {
+  /**
+   * typed_data_chain_id is used only in EIP712 Domain and should match
+   * Ethereum network ID in a Web3 provider (e.g. Metamask).
+   */
+  typed_data_chain_id?: string;
+  /**
+   * fee_payer is an account address for the fee payer. It will be validated
+   * during EIP712 signature checking.
+   */
+  fee_payer?: string;
+  /**
+   * fee_payer_sig is a signature data from the fee paying account,
+   * allows to perform fee delegation when using EIP712 Domain.
+   */
+  fee_payer_sig?: string;
+}
+export interface ExtensionOptionsWeb3TxAminoMsg {
+  type: "/ethermint.types.v1.ExtensionOptionsWeb3Tx";
+  value: ExtensionOptionsWeb3TxAmino;
+}
+/**
+ * ExtensionOptionsWeb3Tx is an extension option that specifies the typed chain id,
+ * the fee payer as well as its signature data.
+ */
+export interface ExtensionOptionsWeb3TxSDKType {
+  typed_data_chain_id: bigint;
+  fee_payer: string;
+  fee_payer_sig: Uint8Array;
+}
+function createBaseExtensionOptionsWeb3Tx(): ExtensionOptionsWeb3Tx {
+  return {
+    typedDataChainId: BigInt(0),
+    feePayer: "",
+    feePayerSig: new Uint8Array()
+  };
+}
+export const ExtensionOptionsWeb3Tx = {
+  typeUrl: "/ethermint.types.v1.ExtensionOptionsWeb3Tx",
+  encode(message: ExtensionOptionsWeb3Tx, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
+    if (message.typedDataChainId !== BigInt(0)) {
+      writer.uint32(8).uint64(message.typedDataChainId);
+    }
+    if (message.feePayer !== "") {
+      writer.uint32(18).string(message.feePayer);
+    }
+    if (message.feePayerSig.length !== 0) {
+      writer.uint32(26).bytes(message.feePayerSig);
+    }
+    return writer;
+  },
+  decode(input: BinaryReader | Uint8Array, length?: number): ExtensionOptionsWeb3Tx {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseExtensionOptionsWeb3Tx();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.typedDataChainId = reader.uint64();
+          break;
+        case 2:
+          message.feePayer = reader.string();
+          break;
+        case 3:
+          message.feePayerSig = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+  fromJSON(object: any): ExtensionOptionsWeb3Tx {
+    return {
+      typedDataChainId: isSet(object.typedDataChainId) ? BigInt(object.typedDataChainId.toString()) : BigInt(0),
+      feePayer: isSet(object.feePayer) ? String(object.feePayer) : "",
+      feePayerSig: isSet(object.feePayerSig) ? bytesFromBase64(object.feePayerSig) : new Uint8Array()
+    };
+  },
+  toJSON(message: ExtensionOptionsWeb3Tx): JsonSafe<ExtensionOptionsWeb3Tx> {
+    const obj: any = {};
+    message.typedDataChainId !== undefined && (obj.typedDataChainId = (message.typedDataChainId || BigInt(0)).toString());
+    message.feePayer !== undefined && (obj.feePayer = message.feePayer);
+    message.feePayerSig !== undefined && (obj.feePayerSig = base64FromBytes(message.feePayerSig !== undefined ? message.feePayerSig : new Uint8Array()));
+    return obj;
+  },
+  fromPartial(object: Partial<ExtensionOptionsWeb3Tx>): ExtensionOptionsWeb3Tx {
+    const message = createBaseExtensionOptionsWeb3Tx();
+    message.typedDataChainId = object.typedDataChainId !== undefined && object.typedDataChainId !== null ? BigInt(object.typedDataChainId.toString()) : BigInt(0);
+    message.feePayer = object.feePayer ?? "";
+    message.feePayerSig = object.feePayerSig ?? new Uint8Array();
+    return message;
+  },
+  fromAmino(object: ExtensionOptionsWeb3TxAmino): ExtensionOptionsWeb3Tx {
+    const message = createBaseExtensionOptionsWeb3Tx();
+    if (object.typed_data_chain_id !== undefined && object.typed_data_chain_id !== null) {
+      message.typedDataChainId = BigInt(object.typed_data_chain_id);
+    }
+    if (object.fee_payer !== undefined && object.fee_payer !== null) {
+      message.feePayer = object.fee_payer;
+    }
+    if (object.fee_payer_sig !== undefined && object.fee_payer_sig !== null) {
+      message.feePayerSig = bytesFromBase64(object.fee_payer_sig);
+    }
+    return message;
+  },
+  toAmino(message: ExtensionOptionsWeb3Tx): ExtensionOptionsWeb3TxAmino {
+    const obj: any = {};
+    obj.typed_data_chain_id = message.typedDataChainId !== BigInt(0) ? message.typedDataChainId.toString() : undefined;
+    obj.fee_payer = message.feePayer === "" ? undefined : message.feePayer;
+    obj.fee_payer_sig = message.feePayerSig ? base64FromBytes(message.feePayerSig) : undefined;
+    return obj;
+  },
+  fromAminoMsg(object: ExtensionOptionsWeb3TxAminoMsg): ExtensionOptionsWeb3Tx {
+    return ExtensionOptionsWeb3Tx.fromAmino(object.value);
+  },
+  fromProtoMsg(message: ExtensionOptionsWeb3TxProtoMsg): ExtensionOptionsWeb3Tx {
+    return ExtensionOptionsWeb3Tx.decode(message.value);
+  },
+  toProto(message: ExtensionOptionsWeb3Tx): Uint8Array {
+    return ExtensionOptionsWeb3Tx.encode(message).finish();
+  },
+  toProtoMsg(message: ExtensionOptionsWeb3Tx): ExtensionOptionsWeb3TxProtoMsg {
+    return {
+      typeUrl: "/ethermint.types.v1.ExtensionOptionsWeb3Tx",
+      value: ExtensionOptionsWeb3Tx.encode(message).finish()
+    };
+  }
+};

--- a/wardenjs/src/codegen/gogoproto/bundle.ts
+++ b/wardenjs/src/codegen/gogoproto/bundle.ts
@@ -1,5 +1,5 @@
 //@ts-nocheck
-import * as _66 from "./gogo.js";
+import * as _80 from "./gogo.js";
 export const gogoproto = {
-  ..._66
+  ..._80
 };

--- a/wardenjs/src/codegen/google/bundle.ts
+++ b/wardenjs/src/codegen/google/bundle.ts
@@ -1,15 +1,15 @@
 //@ts-nocheck
-import * as _67 from "./protobuf/any.js";
-import * as _68 from "./protobuf/descriptor.js";
-import * as _69 from "./protobuf/duration.js";
-import * as _70 from "./protobuf/empty.js";
-import * as _71 from "./protobuf/timestamp.js";
+import * as _81 from "./protobuf/any.js";
+import * as _82 from "./protobuf/descriptor.js";
+import * as _83 from "./protobuf/duration.js";
+import * as _84 from "./protobuf/empty.js";
+import * as _85 from "./protobuf/timestamp.js";
 export namespace google {
   export const protobuf = {
-    ..._67,
-    ..._68,
-    ..._69,
-    ..._70,
-    ..._71
+    ..._81,
+    ..._82,
+    ..._83,
+    ..._84,
+    ..._85
   };
 }

--- a/wardenjs/src/codegen/hooks.ts
+++ b/wardenjs/src/codegen/hooks.ts
@@ -14,6 +14,8 @@ import * as _CosmosParamsV1beta1Queryrpc from "./cosmos/params/v1beta1/query.rpc
 import * as _CosmosStakingV1beta1Queryrpc from "./cosmos/staking/v1beta1/query.rpc.Query.js";
 import * as _CosmosTxV1beta1Servicerpc from "./cosmos/tx/v1beta1/service.rpc.Service.js";
 import * as _CosmosUpgradeV1beta1Queryrpc from "./cosmos/upgrade/v1beta1/query.rpc.Query.js";
+import * as _EthermintEvmV1Queryrpc from "./ethermint/evm/v1/query.rpc.Query.js";
+import * as _EthermintFeemarketV1Queryrpc from "./ethermint/feemarket/v1/query.rpc.Query.js";
 import * as _SlinkyMarketmapV1Queryrpc from "./slinky/marketmap/v1/query.rpc.Query.js";
 import * as _SlinkyOracleV1Queryrpc from "./slinky/oracle/v1/query.rpc.Query.js";
 import * as _WardenActV1beta1Queryrpc from "./warden/act/v1beta1/query.rpc.Query.js";
@@ -67,6 +69,14 @@ export const createRpcQueryHooks = ({
       },
       upgrade: {
         v1beta1: _CosmosUpgradeV1beta1Queryrpc.createRpcQueryHooks(rpc)
+      }
+    },
+    ethermint: {
+      evm: {
+        v1: _EthermintEvmV1Queryrpc.createRpcQueryHooks(rpc)
+      },
+      feemarket: {
+        v1: _EthermintFeemarketV1Queryrpc.createRpcQueryHooks(rpc)
       }
     },
     slinky: {

--- a/wardenjs/src/codegen/index.ts
+++ b/wardenjs/src/codegen/index.ts
@@ -9,6 +9,8 @@ export * from "./amino/bundle.js";
 export * from "./cosmos_proto/bundle.js";
 export * from "./cosmos/bundle.js";
 export * from "./cosmos/client.js";
+export * from "./ethermint/bundle.js";
+export * from "./ethermint/client.js";
 export * from "./gogoproto/bundle.js";
 export * from "./google/bundle.js";
 export * from "./slinky/bundle.js";

--- a/wardenjs/src/codegen/shield/bundle.ts
+++ b/wardenjs/src/codegen/shield/bundle.ts
@@ -1,11 +1,11 @@
 //@ts-nocheck
-import * as _94 from "./ast/ast.js";
-import * as _95 from "./token/token.js";
+import * as _108 from "./ast/ast.js";
+import * as _109 from "./token/token.js";
 export namespace shield {
   export const ast = {
-    ..._94
+    ..._108
   };
   export const token = {
-    ..._95
+    ..._109
   };
 }

--- a/wardenjs/src/codegen/slinky/bundle.ts
+++ b/wardenjs/src/codegen/slinky/bundle.ts
@@ -1,73 +1,73 @@
 //@ts-nocheck
-import * as _72 from "./marketmap/module/v1/module.js";
-import * as _73 from "./marketmap/v1/genesis.js";
-import * as _74 from "./marketmap/v1/market.js";
-import * as _75 from "./marketmap/v1/params.js";
-import * as _76 from "./marketmap/v1/query.js";
-import * as _77 from "./marketmap/v1/tx.js";
-import * as _78 from "./oracle/module/v1/module.js";
-import * as _79 from "./oracle/v1/genesis.js";
-import * as _80 from "./oracle/v1/query.js";
-import * as _81 from "./oracle/v1/tx.js";
-import * as _82 from "./types/v1/currency_pair.js";
-import * as _176 from "./marketmap/v1/tx.amino.js";
-import * as _177 from "./oracle/v1/tx.amino.js";
-import * as _178 from "./marketmap/v1/tx.registry.js";
-import * as _179 from "./oracle/v1/tx.registry.js";
-import * as _180 from "./marketmap/v1/query.lcd.js";
-import * as _181 from "./oracle/v1/query.lcd.js";
-import * as _182 from "./marketmap/v1/query.rpc.Query.js";
-import * as _183 from "./oracle/v1/query.rpc.Query.js";
-import * as _184 from "./marketmap/v1/tx.rpc.msg.js";
-import * as _185 from "./oracle/v1/tx.rpc.msg.js";
-import * as _204 from "./lcd.js";
-import * as _205 from "./rpc.query.js";
-import * as _206 from "./rpc.tx.js";
+import * as _86 from "./marketmap/module/v1/module.js";
+import * as _87 from "./marketmap/v1/genesis.js";
+import * as _88 from "./marketmap/v1/market.js";
+import * as _89 from "./marketmap/v1/params.js";
+import * as _90 from "./marketmap/v1/query.js";
+import * as _91 from "./marketmap/v1/tx.js";
+import * as _92 from "./oracle/module/v1/module.js";
+import * as _93 from "./oracle/v1/genesis.js";
+import * as _94 from "./oracle/v1/query.js";
+import * as _95 from "./oracle/v1/tx.js";
+import * as _96 from "./types/v1/currency_pair.js";
+import * as _200 from "./marketmap/v1/tx.amino.js";
+import * as _201 from "./oracle/v1/tx.amino.js";
+import * as _202 from "./marketmap/v1/tx.registry.js";
+import * as _203 from "./oracle/v1/tx.registry.js";
+import * as _204 from "./marketmap/v1/query.lcd.js";
+import * as _205 from "./oracle/v1/query.lcd.js";
+import * as _206 from "./marketmap/v1/query.rpc.Query.js";
+import * as _207 from "./oracle/v1/query.rpc.Query.js";
+import * as _208 from "./marketmap/v1/tx.rpc.msg.js";
+import * as _209 from "./oracle/v1/tx.rpc.msg.js";
+import * as _231 from "./lcd.js";
+import * as _232 from "./rpc.query.js";
+import * as _233 from "./rpc.tx.js";
 export namespace slinky {
   export namespace marketmap {
     export namespace module {
       export const v1 = {
-        ..._72
+        ..._86
       };
     }
     export const v1 = {
-      ..._73,
-      ..._74,
-      ..._75,
-      ..._76,
-      ..._77,
-      ..._176,
-      ..._178,
-      ..._180,
-      ..._182,
-      ..._184
+      ..._87,
+      ..._88,
+      ..._89,
+      ..._90,
+      ..._91,
+      ..._200,
+      ..._202,
+      ..._204,
+      ..._206,
+      ..._208
     };
   }
   export namespace oracle {
     export namespace module {
       export const v1 = {
-        ..._78
+        ..._92
       };
     }
     export const v1 = {
-      ..._79,
-      ..._80,
-      ..._81,
-      ..._177,
-      ..._179,
-      ..._181,
-      ..._183,
-      ..._185
+      ..._93,
+      ..._94,
+      ..._95,
+      ..._201,
+      ..._203,
+      ..._205,
+      ..._207,
+      ..._209
     };
   }
   export namespace types {
     export const v1 = {
-      ..._82
+      ..._96
     };
   }
   export const ClientFactory = {
-    ..._204,
-    ..._205,
-    ..._206
+    ..._231,
+    ..._232,
+    ..._233
   };
 }

--- a/wardenjs/src/codegen/tendermint/bundle.ts
+++ b/wardenjs/src/codegen/tendermint/bundle.ts
@@ -1,39 +1,39 @@
 //@ts-nocheck
-import * as _83 from "./abci/types.js";
-import * as _84 from "./crypto/keys.js";
-import * as _85 from "./crypto/proof.js";
-import * as _86 from "./libs/bits/types.js";
-import * as _87 from "./p2p/types.js";
-import * as _88 from "./types/block.js";
-import * as _89 from "./types/evidence.js";
-import * as _90 from "./types/params.js";
-import * as _91 from "./types/types.js";
-import * as _92 from "./types/validator.js";
-import * as _93 from "./version/types.js";
+import * as _97 from "./abci/types.js";
+import * as _98 from "./crypto/keys.js";
+import * as _99 from "./crypto/proof.js";
+import * as _100 from "./libs/bits/types.js";
+import * as _101 from "./p2p/types.js";
+import * as _102 from "./types/block.js";
+import * as _103 from "./types/evidence.js";
+import * as _104 from "./types/params.js";
+import * as _105 from "./types/types.js";
+import * as _106 from "./types/validator.js";
+import * as _107 from "./version/types.js";
 export namespace tendermint {
   export const abci = {
-    ..._83
+    ..._97
   };
   export const crypto = {
-    ..._84,
-    ..._85
+    ..._98,
+    ..._99
   };
   export namespace libs {
     export const bits = {
-      ..._86
+      ..._100
     };
   }
   export const p2p = {
-    ..._87
+    ..._101
   };
   export const types = {
-    ..._88,
-    ..._89,
-    ..._90,
-    ..._91,
-    ..._92
+    ..._102,
+    ..._103,
+    ..._104,
+    ..._105,
+    ..._106
   };
   export const version = {
-    ..._93
+    ..._107
   };
 }

--- a/wardenjs/src/codegen/warden/bundle.ts
+++ b/wardenjs/src/codegen/warden/bundle.ts
@@ -1,82 +1,50 @@
 //@ts-nocheck
-import * as _96 from "./act/module/module.js";
-import * as _97 from "./act/v1beta1/action.js";
-import * as _98 from "./act/v1beta1/events.js";
-import * as _99 from "./act/v1beta1/genesis.js";
-import * as _100 from "./act/v1beta1/params.js";
-import * as _101 from "./act/v1beta1/query.js";
-import * as _102 from "./act/v1beta1/rule.js";
-import * as _103 from "./act/v1beta1/tx.js";
-import * as _104 from "./gmp/genesis.js";
-import * as _105 from "./gmp/gmp.js";
-import * as _106 from "./gmp/query.js";
-import * as _107 from "./gmp/tx.js";
-import * as _108 from "./warden/module/module.js";
-import * as _109 from "./warden/v1beta3/events.js";
-import * as _110 from "./warden/v1beta3/genesis.js";
-import * as _111 from "./warden/v1beta3/key.js";
-import * as _112 from "./warden/v1beta3/keychain.js";
-import * as _113 from "./warden/v1beta3/params.js";
-import * as _114 from "./warden/v1beta3/query.js";
-import * as _115 from "./warden/v1beta3/signature.js";
-import * as _116 from "./warden/v1beta3/space.js";
-import * as _117 from "./warden/v1beta3/tx.js";
-import * as _186 from "./act/v1beta1/tx.amino.js";
-import * as _187 from "./gmp/tx.amino.js";
-import * as _188 from "./warden/v1beta3/tx.amino.js";
-import * as _189 from "./act/v1beta1/tx.registry.js";
-import * as _190 from "./gmp/tx.registry.js";
-import * as _191 from "./warden/v1beta3/tx.registry.js";
-import * as _192 from "./act/v1beta1/query.lcd.js";
-import * as _193 from "./gmp/query.lcd.js";
-import * as _194 from "./warden/v1beta3/query.lcd.js";
-import * as _195 from "./act/v1beta1/query.rpc.Query.js";
-import * as _196 from "./gmp/query.rpc.Query.js";
-import * as _197 from "./warden/v1beta3/query.rpc.Query.js";
-import * as _198 from "./act/v1beta1/tx.rpc.msg.js";
-import * as _199 from "./gmp/tx.rpc.msg.js";
-import * as _200 from "./warden/v1beta3/tx.rpc.msg.js";
-import * as _207 from "./lcd.js";
-import * as _208 from "./rpc.query.js";
-import * as _209 from "./rpc.tx.js";
+import * as _110 from "./act/module/module.js";
+import * as _111 from "./act/v1beta1/action.js";
+import * as _112 from "./act/v1beta1/events.js";
+import * as _113 from "./act/v1beta1/genesis.js";
+import * as _114 from "./act/v1beta1/params.js";
+import * as _115 from "./act/v1beta1/query.js";
+import * as _116 from "./act/v1beta1/rule.js";
+import * as _117 from "./act/v1beta1/tx.js";
+import * as _118 from "./gmp/genesis.js";
+import * as _119 from "./gmp/gmp.js";
+import * as _120 from "./gmp/query.js";
+import * as _121 from "./gmp/tx.js";
+import * as _122 from "./warden/module/module.js";
+import * as _123 from "./warden/v1beta3/events.js";
+import * as _124 from "./warden/v1beta3/genesis.js";
+import * as _125 from "./warden/v1beta3/key.js";
+import * as _126 from "./warden/v1beta3/keychain.js";
+import * as _127 from "./warden/v1beta3/params.js";
+import * as _128 from "./warden/v1beta3/query.js";
+import * as _129 from "./warden/v1beta3/signature.js";
+import * as _130 from "./warden/v1beta3/space.js";
+import * as _131 from "./warden/v1beta3/tx.js";
+import * as _210 from "./act/v1beta1/tx.amino.js";
+import * as _211 from "./gmp/tx.amino.js";
+import * as _212 from "./warden/v1beta3/tx.amino.js";
+import * as _213 from "./act/v1beta1/tx.registry.js";
+import * as _214 from "./gmp/tx.registry.js";
+import * as _215 from "./warden/v1beta3/tx.registry.js";
+import * as _216 from "./act/v1beta1/query.lcd.js";
+import * as _217 from "./gmp/query.lcd.js";
+import * as _218 from "./warden/v1beta3/query.lcd.js";
+import * as _219 from "./act/v1beta1/query.rpc.Query.js";
+import * as _220 from "./gmp/query.rpc.Query.js";
+import * as _221 from "./warden/v1beta3/query.rpc.Query.js";
+import * as _222 from "./act/v1beta1/tx.rpc.msg.js";
+import * as _223 from "./gmp/tx.rpc.msg.js";
+import * as _224 from "./warden/v1beta3/tx.rpc.msg.js";
+import * as _234 from "./lcd.js";
+import * as _235 from "./rpc.query.js";
+import * as _236 from "./rpc.tx.js";
 export namespace warden {
   export namespace act {
     export const module = {
-      ..._96
+      ..._110
     };
     export const v1beta1 = {
-      ..._97,
-      ..._98,
-      ..._99,
-      ..._100,
-      ..._101,
-      ..._102,
-      ..._103,
-      ..._186,
-      ..._189,
-      ..._192,
-      ..._195,
-      ..._198
-    };
-  }
-  export const gmp = {
-    ..._104,
-    ..._105,
-    ..._106,
-    ..._107,
-    ..._187,
-    ..._190,
-    ..._193,
-    ..._196,
-    ..._199
-  };
-  export namespace warden {
-    export const module = {
-      ..._108
-    };
-    export const v1beta3 = {
-      ..._109,
-      ..._110,
       ..._111,
       ..._112,
       ..._113,
@@ -84,16 +52,48 @@ export namespace warden {
       ..._115,
       ..._116,
       ..._117,
-      ..._188,
-      ..._191,
-      ..._194,
-      ..._197,
-      ..._200
+      ..._210,
+      ..._213,
+      ..._216,
+      ..._219,
+      ..._222
+    };
+  }
+  export const gmp = {
+    ..._118,
+    ..._119,
+    ..._120,
+    ..._121,
+    ..._211,
+    ..._214,
+    ..._217,
+    ..._220,
+    ..._223
+  };
+  export namespace warden {
+    export const module = {
+      ..._122
+    };
+    export const v1beta3 = {
+      ..._123,
+      ..._124,
+      ..._125,
+      ..._126,
+      ..._127,
+      ..._128,
+      ..._129,
+      ..._130,
+      ..._131,
+      ..._212,
+      ..._215,
+      ..._218,
+      ..._221,
+      ..._224
     };
   }
   export const ClientFactory = {
-    ..._207,
-    ..._208,
-    ..._209
+    ..._234,
+    ..._235,
+    ..._236
   };
 }

--- a/wardenjs/src/codegen/warden/warden/v1beta3/space.ts
+++ b/wardenjs/src/codegen/warden/warden/v1beta3/space.ts
@@ -36,6 +36,8 @@ export interface Space {
    * owner approves it.
    */
   signRuleId: bigint;
+  /** Version of the space. Every time the Space is updated, this number gets increasead by one. */
+  nonce: bigint;
 }
 export interface SpaceProtoMsg {
   typeUrl: "/warden.warden.v1beta3.Space";
@@ -75,6 +77,8 @@ export interface SpaceAmino {
    * owner approves it.
    */
   sign_rule_id?: string;
+  /** Version of the space. Every time the Space is updated, this number gets increasead by one. */
+  nonce?: string;
 }
 export interface SpaceAminoMsg {
   type: "/warden.warden.v1beta3.Space";
@@ -87,6 +91,7 @@ export interface SpaceSDKType {
   owners: string[];
   admin_rule_id: bigint;
   sign_rule_id: bigint;
+  nonce: bigint;
 }
 function createBaseSpace(): Space {
   return {
@@ -94,7 +99,8 @@ function createBaseSpace(): Space {
     creator: "",
     owners: [],
     adminRuleId: BigInt(0),
-    signRuleId: BigInt(0)
+    signRuleId: BigInt(0),
+    nonce: BigInt(0)
   };
 }
 export const Space = {
@@ -114,6 +120,9 @@ export const Space = {
     }
     if (message.signRuleId !== BigInt(0)) {
       writer.uint32(48).uint64(message.signRuleId);
+    }
+    if (message.nonce !== BigInt(0)) {
+      writer.uint32(56).uint64(message.nonce);
     }
     return writer;
   },
@@ -139,6 +148,9 @@ export const Space = {
         case 6:
           message.signRuleId = reader.uint64();
           break;
+        case 7:
+          message.nonce = reader.uint64();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -152,7 +164,8 @@ export const Space = {
       creator: isSet(object.creator) ? String(object.creator) : "",
       owners: Array.isArray(object?.owners) ? object.owners.map((e: any) => String(e)) : [],
       adminRuleId: isSet(object.adminRuleId) ? BigInt(object.adminRuleId.toString()) : BigInt(0),
-      signRuleId: isSet(object.signRuleId) ? BigInt(object.signRuleId.toString()) : BigInt(0)
+      signRuleId: isSet(object.signRuleId) ? BigInt(object.signRuleId.toString()) : BigInt(0),
+      nonce: isSet(object.nonce) ? BigInt(object.nonce.toString()) : BigInt(0)
     };
   },
   toJSON(message: Space): JsonSafe<Space> {
@@ -166,6 +179,7 @@ export const Space = {
     }
     message.adminRuleId !== undefined && (obj.adminRuleId = (message.adminRuleId || BigInt(0)).toString());
     message.signRuleId !== undefined && (obj.signRuleId = (message.signRuleId || BigInt(0)).toString());
+    message.nonce !== undefined && (obj.nonce = (message.nonce || BigInt(0)).toString());
     return obj;
   },
   fromPartial(object: Partial<Space>): Space {
@@ -175,6 +189,7 @@ export const Space = {
     message.owners = object.owners?.map(e => e) || [];
     message.adminRuleId = object.adminRuleId !== undefined && object.adminRuleId !== null ? BigInt(object.adminRuleId.toString()) : BigInt(0);
     message.signRuleId = object.signRuleId !== undefined && object.signRuleId !== null ? BigInt(object.signRuleId.toString()) : BigInt(0);
+    message.nonce = object.nonce !== undefined && object.nonce !== null ? BigInt(object.nonce.toString()) : BigInt(0);
     return message;
   },
   fromAmino(object: SpaceAmino): Space {
@@ -192,6 +207,9 @@ export const Space = {
     if (object.sign_rule_id !== undefined && object.sign_rule_id !== null) {
       message.signRuleId = BigInt(object.sign_rule_id);
     }
+    if (object.nonce !== undefined && object.nonce !== null) {
+      message.nonce = BigInt(object.nonce);
+    }
     return message;
   },
   toAmino(message: Space): SpaceAmino {
@@ -205,6 +223,7 @@ export const Space = {
     }
     obj.admin_rule_id = message.adminRuleId !== BigInt(0) ? message.adminRuleId.toString() : undefined;
     obj.sign_rule_id = message.signRuleId !== BigInt(0) ? message.signRuleId.toString() : undefined;
+    obj.nonce = message.nonce !== BigInt(0) ? message.nonce.toString() : undefined;
     return obj;
   },
   fromAminoMsg(object: SpaceAminoMsg): Space {

--- a/wardenjs/src/codegen/warden/warden/v1beta3/tx.ts
+++ b/wardenjs/src/codegen/warden/warden/v1beta3/tx.ts
@@ -112,6 +112,7 @@ export interface MsgAddSpaceOwner {
   authority: string;
   spaceId: bigint;
   newOwner: string;
+  nonce: bigint;
 }
 export interface MsgAddSpaceOwnerProtoMsg {
   typeUrl: "/warden.warden.v1beta3.MsgAddSpaceOwner";
@@ -121,6 +122,7 @@ export interface MsgAddSpaceOwnerAmino {
   authority?: string;
   space_id?: string;
   new_owner?: string;
+  nonce?: string;
 }
 export interface MsgAddSpaceOwnerAminoMsg {
   type: "/warden.warden.v1beta3.MsgAddSpaceOwner";
@@ -130,6 +132,7 @@ export interface MsgAddSpaceOwnerSDKType {
   authority: string;
   space_id: bigint;
   new_owner: string;
+  nonce: bigint;
 }
 export interface MsgAddSpaceOwnerResponse {}
 export interface MsgAddSpaceOwnerResponseProtoMsg {
@@ -146,6 +149,7 @@ export interface MsgRemoveSpaceOwner {
   authority: string;
   spaceId: bigint;
   owner: string;
+  nonce: bigint;
 }
 export interface MsgRemoveSpaceOwnerProtoMsg {
   typeUrl: "/warden.warden.v1beta3.MsgRemoveSpaceOwner";
@@ -155,6 +159,7 @@ export interface MsgRemoveSpaceOwnerAmino {
   authority?: string;
   space_id?: string;
   owner?: string;
+  nonce?: string;
 }
 export interface MsgRemoveSpaceOwnerAminoMsg {
   type: "/warden.warden.v1beta3.MsgRemoveSpaceOwner";
@@ -164,6 +169,7 @@ export interface MsgRemoveSpaceOwnerSDKType {
   authority: string;
   space_id: bigint;
   owner: string;
+  nonce: bigint;
 }
 export interface MsgRemoveSpaceOwnerResponse {}
 export interface MsgRemoveSpaceOwnerResponseProtoMsg {
@@ -264,6 +270,7 @@ export interface MsgUpdateSpace {
   spaceId: bigint;
   adminRuleId: bigint;
   signRuleId: bigint;
+  nonce: bigint;
 }
 export interface MsgUpdateSpaceProtoMsg {
   typeUrl: "/warden.warden.v1beta3.MsgUpdateSpace";
@@ -274,6 +281,7 @@ export interface MsgUpdateSpaceAmino {
   space_id?: string;
   admin_rule_id?: string;
   sign_rule_id?: string;
+  nonce?: string;
 }
 export interface MsgUpdateSpaceAminoMsg {
   type: "/warden.warden.v1beta3.MsgUpdateSpace";
@@ -284,6 +292,7 @@ export interface MsgUpdateSpaceSDKType {
   space_id: bigint;
   admin_rule_id: bigint;
   sign_rule_id: bigint;
+  nonce: bigint;
 }
 export interface MsgUpdateSpaceResponse {}
 export interface MsgUpdateSpaceResponseProtoMsg {
@@ -417,6 +426,7 @@ export interface MsgNewKeyRequest {
   keyType: KeyType;
   ruleId: bigint;
   maxKeychainFees: Coin[];
+  nonce: bigint;
 }
 export interface MsgNewKeyRequestProtoMsg {
   typeUrl: "/warden.warden.v1beta3.MsgNewKeyRequest";
@@ -429,6 +439,7 @@ export interface MsgNewKeyRequestAmino {
   key_type?: KeyType;
   rule_id?: string;
   max_keychain_fees: CoinAmino[];
+  nonce?: string;
 }
 export interface MsgNewKeyRequestAminoMsg {
   type: "/warden.warden.v1beta3.MsgNewKeyRequest";
@@ -441,6 +452,7 @@ export interface MsgNewKeyRequestSDKType {
   key_type: KeyType;
   rule_id: bigint;
   max_keychain_fees: CoinSDKType[];
+  nonce: bigint;
 }
 export interface MsgNewKeyRequestResponse {
   id: bigint;
@@ -557,6 +569,7 @@ export interface MsgNewSignRequest {
   analyzers: string[];
   encryptionKey: Uint8Array;
   maxKeychainFees: Coin[];
+  nonce: bigint;
 }
 export interface MsgNewSignRequestProtoMsg {
   typeUrl: "/warden.warden.v1beta3.MsgNewSignRequest";
@@ -569,6 +582,7 @@ export interface MsgNewSignRequestAmino {
   analyzers?: string[];
   encryption_key?: string;
   max_keychain_fees: CoinAmino[];
+  nonce?: string;
 }
 export interface MsgNewSignRequestAminoMsg {
   type: "/warden.warden.v1beta3.MsgNewSignRequest";
@@ -581,6 +595,7 @@ export interface MsgNewSignRequestSDKType {
   analyzers: string[];
   encryption_key: Uint8Array;
   max_keychain_fees: CoinSDKType[];
+  nonce: bigint;
 }
 export interface MsgNewSignRequestResponse {
   id: bigint;
@@ -1004,7 +1019,8 @@ function createBaseMsgAddSpaceOwner(): MsgAddSpaceOwner {
   return {
     authority: "",
     spaceId: BigInt(0),
-    newOwner: ""
+    newOwner: "",
+    nonce: BigInt(0)
   };
 }
 export const MsgAddSpaceOwner = {
@@ -1018,6 +1034,9 @@ export const MsgAddSpaceOwner = {
     }
     if (message.newOwner !== "") {
       writer.uint32(26).string(message.newOwner);
+    }
+    if (message.nonce !== BigInt(0)) {
+      writer.uint32(32).uint64(message.nonce);
     }
     return writer;
   },
@@ -1037,6 +1056,9 @@ export const MsgAddSpaceOwner = {
         case 3:
           message.newOwner = reader.string();
           break;
+        case 4:
+          message.nonce = reader.uint64();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -1048,7 +1070,8 @@ export const MsgAddSpaceOwner = {
     return {
       authority: isSet(object.authority) ? String(object.authority) : "",
       spaceId: isSet(object.spaceId) ? BigInt(object.spaceId.toString()) : BigInt(0),
-      newOwner: isSet(object.newOwner) ? String(object.newOwner) : ""
+      newOwner: isSet(object.newOwner) ? String(object.newOwner) : "",
+      nonce: isSet(object.nonce) ? BigInt(object.nonce.toString()) : BigInt(0)
     };
   },
   toJSON(message: MsgAddSpaceOwner): JsonSafe<MsgAddSpaceOwner> {
@@ -1056,6 +1079,7 @@ export const MsgAddSpaceOwner = {
     message.authority !== undefined && (obj.authority = message.authority);
     message.spaceId !== undefined && (obj.spaceId = (message.spaceId || BigInt(0)).toString());
     message.newOwner !== undefined && (obj.newOwner = message.newOwner);
+    message.nonce !== undefined && (obj.nonce = (message.nonce || BigInt(0)).toString());
     return obj;
   },
   fromPartial(object: Partial<MsgAddSpaceOwner>): MsgAddSpaceOwner {
@@ -1063,6 +1087,7 @@ export const MsgAddSpaceOwner = {
     message.authority = object.authority ?? "";
     message.spaceId = object.spaceId !== undefined && object.spaceId !== null ? BigInt(object.spaceId.toString()) : BigInt(0);
     message.newOwner = object.newOwner ?? "";
+    message.nonce = object.nonce !== undefined && object.nonce !== null ? BigInt(object.nonce.toString()) : BigInt(0);
     return message;
   },
   fromAmino(object: MsgAddSpaceOwnerAmino): MsgAddSpaceOwner {
@@ -1076,6 +1101,9 @@ export const MsgAddSpaceOwner = {
     if (object.new_owner !== undefined && object.new_owner !== null) {
       message.newOwner = object.new_owner;
     }
+    if (object.nonce !== undefined && object.nonce !== null) {
+      message.nonce = BigInt(object.nonce);
+    }
     return message;
   },
   toAmino(message: MsgAddSpaceOwner): MsgAddSpaceOwnerAmino {
@@ -1083,6 +1111,7 @@ export const MsgAddSpaceOwner = {
     obj.authority = message.authority === "" ? undefined : message.authority;
     obj.space_id = message.spaceId !== BigInt(0) ? message.spaceId.toString() : undefined;
     obj.new_owner = message.newOwner === "" ? undefined : message.newOwner;
+    obj.nonce = message.nonce !== BigInt(0) ? message.nonce.toString() : undefined;
     return obj;
   },
   fromAminoMsg(object: MsgAddSpaceOwnerAminoMsg): MsgAddSpaceOwner {
@@ -1162,7 +1191,8 @@ function createBaseMsgRemoveSpaceOwner(): MsgRemoveSpaceOwner {
   return {
     authority: "",
     spaceId: BigInt(0),
-    owner: ""
+    owner: "",
+    nonce: BigInt(0)
   };
 }
 export const MsgRemoveSpaceOwner = {
@@ -1176,6 +1206,9 @@ export const MsgRemoveSpaceOwner = {
     }
     if (message.owner !== "") {
       writer.uint32(26).string(message.owner);
+    }
+    if (message.nonce !== BigInt(0)) {
+      writer.uint32(32).uint64(message.nonce);
     }
     return writer;
   },
@@ -1195,6 +1228,9 @@ export const MsgRemoveSpaceOwner = {
         case 3:
           message.owner = reader.string();
           break;
+        case 4:
+          message.nonce = reader.uint64();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -1206,7 +1242,8 @@ export const MsgRemoveSpaceOwner = {
     return {
       authority: isSet(object.authority) ? String(object.authority) : "",
       spaceId: isSet(object.spaceId) ? BigInt(object.spaceId.toString()) : BigInt(0),
-      owner: isSet(object.owner) ? String(object.owner) : ""
+      owner: isSet(object.owner) ? String(object.owner) : "",
+      nonce: isSet(object.nonce) ? BigInt(object.nonce.toString()) : BigInt(0)
     };
   },
   toJSON(message: MsgRemoveSpaceOwner): JsonSafe<MsgRemoveSpaceOwner> {
@@ -1214,6 +1251,7 @@ export const MsgRemoveSpaceOwner = {
     message.authority !== undefined && (obj.authority = message.authority);
     message.spaceId !== undefined && (obj.spaceId = (message.spaceId || BigInt(0)).toString());
     message.owner !== undefined && (obj.owner = message.owner);
+    message.nonce !== undefined && (obj.nonce = (message.nonce || BigInt(0)).toString());
     return obj;
   },
   fromPartial(object: Partial<MsgRemoveSpaceOwner>): MsgRemoveSpaceOwner {
@@ -1221,6 +1259,7 @@ export const MsgRemoveSpaceOwner = {
     message.authority = object.authority ?? "";
     message.spaceId = object.spaceId !== undefined && object.spaceId !== null ? BigInt(object.spaceId.toString()) : BigInt(0);
     message.owner = object.owner ?? "";
+    message.nonce = object.nonce !== undefined && object.nonce !== null ? BigInt(object.nonce.toString()) : BigInt(0);
     return message;
   },
   fromAmino(object: MsgRemoveSpaceOwnerAmino): MsgRemoveSpaceOwner {
@@ -1234,6 +1273,9 @@ export const MsgRemoveSpaceOwner = {
     if (object.owner !== undefined && object.owner !== null) {
       message.owner = object.owner;
     }
+    if (object.nonce !== undefined && object.nonce !== null) {
+      message.nonce = BigInt(object.nonce);
+    }
     return message;
   },
   toAmino(message: MsgRemoveSpaceOwner): MsgRemoveSpaceOwnerAmino {
@@ -1241,6 +1283,7 @@ export const MsgRemoveSpaceOwner = {
     obj.authority = message.authority === "" ? undefined : message.authority;
     obj.space_id = message.spaceId !== BigInt(0) ? message.spaceId.toString() : undefined;
     obj.owner = message.owner === "" ? undefined : message.owner;
+    obj.nonce = message.nonce !== BigInt(0) ? message.nonce.toString() : undefined;
     return obj;
   },
   fromAminoMsg(object: MsgRemoveSpaceOwnerAminoMsg): MsgRemoveSpaceOwner {
@@ -1695,7 +1738,8 @@ function createBaseMsgUpdateSpace(): MsgUpdateSpace {
     authority: "",
     spaceId: BigInt(0),
     adminRuleId: BigInt(0),
-    signRuleId: BigInt(0)
+    signRuleId: BigInt(0),
+    nonce: BigInt(0)
   };
 }
 export const MsgUpdateSpace = {
@@ -1712,6 +1756,9 @@ export const MsgUpdateSpace = {
     }
     if (message.signRuleId !== BigInt(0)) {
       writer.uint32(32).uint64(message.signRuleId);
+    }
+    if (message.nonce !== BigInt(0)) {
+      writer.uint32(40).uint64(message.nonce);
     }
     return writer;
   },
@@ -1734,6 +1781,9 @@ export const MsgUpdateSpace = {
         case 4:
           message.signRuleId = reader.uint64();
           break;
+        case 5:
+          message.nonce = reader.uint64();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -1746,7 +1796,8 @@ export const MsgUpdateSpace = {
       authority: isSet(object.authority) ? String(object.authority) : "",
       spaceId: isSet(object.spaceId) ? BigInt(object.spaceId.toString()) : BigInt(0),
       adminRuleId: isSet(object.adminRuleId) ? BigInt(object.adminRuleId.toString()) : BigInt(0),
-      signRuleId: isSet(object.signRuleId) ? BigInt(object.signRuleId.toString()) : BigInt(0)
+      signRuleId: isSet(object.signRuleId) ? BigInt(object.signRuleId.toString()) : BigInt(0),
+      nonce: isSet(object.nonce) ? BigInt(object.nonce.toString()) : BigInt(0)
     };
   },
   toJSON(message: MsgUpdateSpace): JsonSafe<MsgUpdateSpace> {
@@ -1755,6 +1806,7 @@ export const MsgUpdateSpace = {
     message.spaceId !== undefined && (obj.spaceId = (message.spaceId || BigInt(0)).toString());
     message.adminRuleId !== undefined && (obj.adminRuleId = (message.adminRuleId || BigInt(0)).toString());
     message.signRuleId !== undefined && (obj.signRuleId = (message.signRuleId || BigInt(0)).toString());
+    message.nonce !== undefined && (obj.nonce = (message.nonce || BigInt(0)).toString());
     return obj;
   },
   fromPartial(object: Partial<MsgUpdateSpace>): MsgUpdateSpace {
@@ -1763,6 +1815,7 @@ export const MsgUpdateSpace = {
     message.spaceId = object.spaceId !== undefined && object.spaceId !== null ? BigInt(object.spaceId.toString()) : BigInt(0);
     message.adminRuleId = object.adminRuleId !== undefined && object.adminRuleId !== null ? BigInt(object.adminRuleId.toString()) : BigInt(0);
     message.signRuleId = object.signRuleId !== undefined && object.signRuleId !== null ? BigInt(object.signRuleId.toString()) : BigInt(0);
+    message.nonce = object.nonce !== undefined && object.nonce !== null ? BigInt(object.nonce.toString()) : BigInt(0);
     return message;
   },
   fromAmino(object: MsgUpdateSpaceAmino): MsgUpdateSpace {
@@ -1779,6 +1832,9 @@ export const MsgUpdateSpace = {
     if (object.sign_rule_id !== undefined && object.sign_rule_id !== null) {
       message.signRuleId = BigInt(object.sign_rule_id);
     }
+    if (object.nonce !== undefined && object.nonce !== null) {
+      message.nonce = BigInt(object.nonce);
+    }
     return message;
   },
   toAmino(message: MsgUpdateSpace): MsgUpdateSpaceAmino {
@@ -1787,6 +1843,7 @@ export const MsgUpdateSpace = {
     obj.space_id = message.spaceId !== BigInt(0) ? message.spaceId.toString() : undefined;
     obj.admin_rule_id = message.adminRuleId !== BigInt(0) ? message.adminRuleId.toString() : undefined;
     obj.sign_rule_id = message.signRuleId !== BigInt(0) ? message.signRuleId.toString() : undefined;
+    obj.nonce = message.nonce !== BigInt(0) ? message.nonce.toString() : undefined;
     return obj;
   },
   fromAminoMsg(object: MsgUpdateSpaceAminoMsg): MsgUpdateSpace {
@@ -2399,7 +2456,8 @@ function createBaseMsgNewKeyRequest(): MsgNewKeyRequest {
     keychainId: BigInt(0),
     keyType: 0,
     ruleId: BigInt(0),
-    maxKeychainFees: []
+    maxKeychainFees: [],
+    nonce: BigInt(0)
   };
 }
 export const MsgNewKeyRequest = {
@@ -2422,6 +2480,9 @@ export const MsgNewKeyRequest = {
     }
     for (const v of message.maxKeychainFees) {
       Coin.encode(v!, writer.uint32(50).fork()).ldelim();
+    }
+    if (message.nonce !== BigInt(0)) {
+      writer.uint32(56).uint64(message.nonce);
     }
     return writer;
   },
@@ -2450,6 +2511,9 @@ export const MsgNewKeyRequest = {
         case 6:
           message.maxKeychainFees.push(Coin.decode(reader, reader.uint32()));
           break;
+        case 7:
+          message.nonce = reader.uint64();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -2464,7 +2528,8 @@ export const MsgNewKeyRequest = {
       keychainId: isSet(object.keychainId) ? BigInt(object.keychainId.toString()) : BigInt(0),
       keyType: isSet(object.keyType) ? keyTypeFromJSON(object.keyType) : -1,
       ruleId: isSet(object.ruleId) ? BigInt(object.ruleId.toString()) : BigInt(0),
-      maxKeychainFees: Array.isArray(object?.maxKeychainFees) ? object.maxKeychainFees.map((e: any) => Coin.fromJSON(e)) : []
+      maxKeychainFees: Array.isArray(object?.maxKeychainFees) ? object.maxKeychainFees.map((e: any) => Coin.fromJSON(e)) : [],
+      nonce: isSet(object.nonce) ? BigInt(object.nonce.toString()) : BigInt(0)
     };
   },
   toJSON(message: MsgNewKeyRequest): JsonSafe<MsgNewKeyRequest> {
@@ -2479,6 +2544,7 @@ export const MsgNewKeyRequest = {
     } else {
       obj.maxKeychainFees = [];
     }
+    message.nonce !== undefined && (obj.nonce = (message.nonce || BigInt(0)).toString());
     return obj;
   },
   fromPartial(object: Partial<MsgNewKeyRequest>): MsgNewKeyRequest {
@@ -2489,6 +2555,7 @@ export const MsgNewKeyRequest = {
     message.keyType = object.keyType ?? 0;
     message.ruleId = object.ruleId !== undefined && object.ruleId !== null ? BigInt(object.ruleId.toString()) : BigInt(0);
     message.maxKeychainFees = object.maxKeychainFees?.map(e => Coin.fromPartial(e)) || [];
+    message.nonce = object.nonce !== undefined && object.nonce !== null ? BigInt(object.nonce.toString()) : BigInt(0);
     return message;
   },
   fromAmino(object: MsgNewKeyRequestAmino): MsgNewKeyRequest {
@@ -2509,6 +2576,9 @@ export const MsgNewKeyRequest = {
       message.ruleId = BigInt(object.rule_id);
     }
     message.maxKeychainFees = object.max_keychain_fees?.map(e => Coin.fromAmino(e)) || [];
+    if (object.nonce !== undefined && object.nonce !== null) {
+      message.nonce = BigInt(object.nonce);
+    }
     return message;
   },
   toAmino(message: MsgNewKeyRequest): MsgNewKeyRequestAmino {
@@ -2523,6 +2593,7 @@ export const MsgNewKeyRequest = {
     } else {
       obj.max_keychain_fees = message.maxKeychainFees;
     }
+    obj.nonce = message.nonce !== BigInt(0) ? message.nonce.toString() : undefined;
     return obj;
   },
   fromAminoMsg(object: MsgNewKeyRequestAminoMsg): MsgNewKeyRequest {
@@ -3038,7 +3109,8 @@ function createBaseMsgNewSignRequest(): MsgNewSignRequest {
     input: new Uint8Array(),
     analyzers: [],
     encryptionKey: new Uint8Array(),
-    maxKeychainFees: []
+    maxKeychainFees: [],
+    nonce: BigInt(0)
   };
 }
 export const MsgNewSignRequest = {
@@ -3061,6 +3133,9 @@ export const MsgNewSignRequest = {
     }
     for (const v of message.maxKeychainFees) {
       Coin.encode(v!, writer.uint32(50).fork()).ldelim();
+    }
+    if (message.nonce !== BigInt(0)) {
+      writer.uint32(56).uint64(message.nonce);
     }
     return writer;
   },
@@ -3089,6 +3164,9 @@ export const MsgNewSignRequest = {
         case 6:
           message.maxKeychainFees.push(Coin.decode(reader, reader.uint32()));
           break;
+        case 7:
+          message.nonce = reader.uint64();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -3103,7 +3181,8 @@ export const MsgNewSignRequest = {
       input: isSet(object.input) ? bytesFromBase64(object.input) : new Uint8Array(),
       analyzers: Array.isArray(object?.analyzers) ? object.analyzers.map((e: any) => String(e)) : [],
       encryptionKey: isSet(object.encryptionKey) ? bytesFromBase64(object.encryptionKey) : new Uint8Array(),
-      maxKeychainFees: Array.isArray(object?.maxKeychainFees) ? object.maxKeychainFees.map((e: any) => Coin.fromJSON(e)) : []
+      maxKeychainFees: Array.isArray(object?.maxKeychainFees) ? object.maxKeychainFees.map((e: any) => Coin.fromJSON(e)) : [],
+      nonce: isSet(object.nonce) ? BigInt(object.nonce.toString()) : BigInt(0)
     };
   },
   toJSON(message: MsgNewSignRequest): JsonSafe<MsgNewSignRequest> {
@@ -3122,6 +3201,7 @@ export const MsgNewSignRequest = {
     } else {
       obj.maxKeychainFees = [];
     }
+    message.nonce !== undefined && (obj.nonce = (message.nonce || BigInt(0)).toString());
     return obj;
   },
   fromPartial(object: Partial<MsgNewSignRequest>): MsgNewSignRequest {
@@ -3132,6 +3212,7 @@ export const MsgNewSignRequest = {
     message.analyzers = object.analyzers?.map(e => e) || [];
     message.encryptionKey = object.encryptionKey ?? new Uint8Array();
     message.maxKeychainFees = object.maxKeychainFees?.map(e => Coin.fromPartial(e)) || [];
+    message.nonce = object.nonce !== undefined && object.nonce !== null ? BigInt(object.nonce.toString()) : BigInt(0);
     return message;
   },
   fromAmino(object: MsgNewSignRequestAmino): MsgNewSignRequest {
@@ -3150,6 +3231,9 @@ export const MsgNewSignRequest = {
       message.encryptionKey = bytesFromBase64(object.encryption_key);
     }
     message.maxKeychainFees = object.max_keychain_fees?.map(e => Coin.fromAmino(e)) || [];
+    if (object.nonce !== undefined && object.nonce !== null) {
+      message.nonce = BigInt(object.nonce);
+    }
     return message;
   },
   toAmino(message: MsgNewSignRequest): MsgNewSignRequestAmino {
@@ -3168,6 +3252,7 @@ export const MsgNewSignRequest = {
     } else {
       obj.max_keychain_fees = message.maxKeychainFees;
     }
+    obj.nonce = message.nonce !== BigInt(0) ? message.nonce.toString() : undefined;
     return obj;
   },
   fromAminoMsg(object: MsgNewSignRequestAminoMsg): MsgNewSignRequest {


### PR DESCRIPTION
This PR makes SpaceWard compatible with the changes introduced by Evmos. I.e. it changes the way transaction are built, to support the new public key scheme.

It also switches from `uward` (6 decimals) to `award` (18 decimals).

⚠️ I personally had to remove my keplr account and re-import it using the mnemonic before it actually worked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated asset handling across various components, changing from "uward" to "award" for improved token representation.
	- Enhanced transaction handling capabilities within the Cosmos ecosystem, including new transaction construction methods.
	- Introduced new gRPC services for querying fee market parameters and Ethereum transaction details.

- **Bug Fixes**
	- Adjusted calculations for asset balances and fees to align with new token specifications, ensuring accurate user interactions.

- **Documentation**
	- Added protocol buffer definitions for Ethereum-related events and transactions, improving clarity and integration within the Ethermint framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->