### PR TITLE
feat(ci): add scan images

### DIFF
--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -1,0 +1,29 @@
+---
+name: Daily Scan Images
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  scan-images:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ${{ fromJSON(vars.SCAN_IMAGES_LIST) }}
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest"
+          format: "sarif"
+          output: "trivy.sarif"
+          severity: "CRITICAL,HIGH"
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy.sarif"


### PR DESCRIPTION
Initial version of security improvement by scanning images. 
The task runs daily and scans the images of this repository with the `latest` tag. The task completes successfully even if vulns are found and saves the report in the `security` tab.

[#271](https://github.com/warden-protocol/infra/issues/271)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new automated workflow for daily scanning of container images for vulnerabilities.
	- Enabled manual initiation of the scan through the GitHub interface.
	- Integrated Trivy vulnerability scanner for assessing image security.

- **Improvements**
	- Enhanced security management by automatically uploading vulnerability reports to the GitHub Security tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->