### PR TITLE
Docs local chain and more

### DIFF
--- a/docs/developer-docs/docs/build-a-keychain/build-a-keychain-app.md
+++ b/docs/developer-docs/docs/build-a-keychain/build-a-keychain-app.md
@@ -71,7 +71,7 @@ Before starting the app, you need to configure it. You'll find a basic configura
 
 Make the following adjustments in the code:
 
-- Replace `my-chain-id` with the chain ID you used when [running a node](operate-a-keychain/create-a-keychain#1-run-a-node).
+- Replace `chain_123-1` with the chain ID you used when [running a node](operate-a-keychain/create-a-keychain#1-run-a-node).
 - Replace `my-keychain-id` with your Keychain ID obtained when [registering a Keychain](operate-a-keychain/create-a-keychain#2-register-a-keychain).
 - Replace `my-mnemonic-phrase` with the mnemonic phrase obtained when [adding a Keychain Writer](operate-a-keychain/create-a-keychain#3-add-a-keychain-writer).
 
@@ -96,7 +96,7 @@ func main() {
         Logger: logger, // not required, but recommended
 
         // setup the connection to the Warden Protocol node
-        ChainID:      "my-chain-id",
+        ChainID:      "chain_123-1",
         GRPCURL:      "localhost:9090",
         GRPCInsecure: true,
 

--- a/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/create-a-keychain.md
+++ b/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/create-a-keychain.md
@@ -56,20 +56,22 @@ The following steps show how to register a new Keychain entity on-chain.
 
     ```bash
     wardend tx warden new-keychain \
-      --description 'my-keychain-description' \
-      --keychain-fees "{\"key_req\":[{\"amount\":\"100\",\"denom\":\"award\"}],\"sig_req\":[{\"amount\":\"1\",\"denom\":\"award\"}]}" \
+      --name 'my-keychain-name' \
       --from my-key-name \
-      --chain-id chain_123-1
+      --chain-id chain_123-1 \
+      --description 'my-keychain-description' \
+      --keychain-fees "{\"key_req\":[{\"amount\":\"100\",\"denom\":\"award\"}],\"sig_req\":[{\"amount\":\"1\",\"denom\":\"award\"}]}"
     ```
 
     Specify the following details:
 
+    - `name`: The Keychain name
+    - `from`: Your local account name (key name)
+    - `chain-id`: The ID of the chain you're running
     - `description` (optional): The Keychain description
     - `keychainFees`(optional):
          - `key_req`: A fee in aWARD for creating a key pair
          - `key_req`: A fee in aWARD for signing a transaction
-    - `from`: Your local account name (key name)
-    - `chain-id`: The ID of the chain you're running
 
     **Note**: aWARD equals 0.000000000000000001 WARD.
 
@@ -77,19 +79,27 @@ The following steps show how to register a new Keychain entity on-chain.
 
 3. Every Keychain is created with a **Keychain ID** that identifies it in key and signature requests and collects fees from users. You'll need this ID to operate your Keychain. Run the following command and check the `id` field in the output:
 
-    ```bash
-    wardend query warden keychains
-    ```
-    ```bash
-    keychains:
-    - admins:
-      - warden1h7akmejqcrafp3mfpjqamghh89kzmkgjzsy3mc
-      creator: warden1h7akmejqcrafp3mfpjqamghh89kzmkgjzsy3mc
-      description: my-description
-      id: "1"
-    pagination:
-      total: "1"
-    ```
+   ```bash
+   wardend query warden keychains
+   ```
+   ```bash
+   keychains:
+   - admins:
+     - warden1h7akmejqcrafp3mfpjqamghh89kzmkgjzsy3mc
+     creator: warden1h7akmejqcrafp3mfpjqamghh89kzmkgjzsy3mc
+     description: my-keychain-description
+     fees:
+       key_req:
+      - amount: "100"
+        denom: award
+    sig_req:
+      - amount: "1"
+        denom: award
+     id: "1"
+     name: my-keychain-name
+   pagination:
+     total: "1"
+   ```
 
 ## 3. Add a Keychain Writer
 

--- a/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/create-a-keychain.md
+++ b/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/create-a-keychain.md
@@ -107,7 +107,7 @@ A Keychain Writer is an account that can write Keychain results (public keys and
 
 To add a Keychain Writer, take these steps:
 
-1. Initiate a `MsgAddKeychainWriter` transaction. Specify your Keychain Writer name:
+1. Run this command to add a Keychain Writer with a preferred name:
 
     ```bash
     wardend keys add my-keychain-writer-name

--- a/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/create-a-keychain.md
+++ b/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/create-a-keychain.md
@@ -34,7 +34,7 @@ To become a **Keychain operator**, you need to create and configure a Keychain e
     If you used a `just` script or a devnet snapshot to run your node, the local account name is `shulgin`.
     :::
 
-3. In some of the commands, you'll also need to specify your **chain ID**, referenced as `my-chain-id`. The actual value depends on the configuration you used when running your node.
+3. In some of the commands, you'll also need to specify your **chain ID**. The actual value depends on the configuration you used when running your node.
 
     To check your chain ID, run this:
 
@@ -129,7 +129,7 @@ To add a Keychain Writer, take these steps:
     wardend tx bank send my-key-name \
       $(wardend keys show -a my-keychain-writer-name) \
       1000000000000000000award \
-      --chain-id my-chain-id
+      --chain-id chain_123-1
     ```
 
     To check the Keychain Writer balance, run this:

--- a/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/create-a-keychain.md
+++ b/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/create-a-keychain.md
@@ -31,7 +31,7 @@ To become a **Keychain operator**, you need to create and configure a Keychain e
     ```
     
     :::tip
-    In development genesis files, you'll typically find an account named `shulgin` that is preconfigured and ready for use.
+    If you used a `just` script or a devnet snapshot to run your node, the local account name is `shulgin`.
     :::
 
 3. In some of the commands, you'll also need to specify your **chain ID**, referenced as `my-chain-id`. The actual value depends on the configuration you used when running your node.
@@ -45,7 +45,7 @@ To become a **Keychain operator**, you need to create and configure a Keychain e
     See the `network` field in the output.
 
     :::tip
-    In development genesis files, the chain ID is typically `warden`.
+    If you used a `just` script or a devnet snapshot to run your node, the chain ID is `warden_1337-1`.
     :::
 
 ## 2. Register a Keychain
@@ -59,7 +59,7 @@ The following steps show how to register a new Keychain entity on-chain.
       --description 'my-keychain-description' \
       --keychain-fees "{\"key_req\":[{\"amount\":\"100\",\"denom\":\"award\"}],\"sig_req\":[{\"amount\":\"1\",\"denom\":\"award\"}]}" \
       --from my-key-name \
-      --chain-id my-chain-id
+      --chain-id chain_123-1
     ```
 
     Specify the following details:

--- a/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/fulfill-requests-from-cli.md
+++ b/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/fulfill-requests-from-cli.md
@@ -25,7 +25,7 @@ Before you start, complete the following prerequisites:
 
 ## 1. Install CLIChain
 
-To install CLIChain, run this:
+To install CLIChain, navigate to the `wardenprotocol` directory and run this:
 
 ```bash
 go install ./cmd/clichain
@@ -35,13 +35,15 @@ go install ./cmd/clichain
 
 In the next steps, you'll use the following values:
 
+- Your chain ID you used when [running a node](operate-a-keychain/create-a-keychain#1-run-a-node).
 - Your Keychain ID obtained when [registering a Keychain](create-a-keychain#2-register-a-keychain).
 - Your Keychain Writer name you specified when [adding a Keychain Writer](create-a-keychain#3-add-a-keychain-writer).  
 
 Export them as environment variables:
 
 ```bash
-export KEYCHAIN_ID=my-keychain-id
+export CHAIN_ID=chain_123-1 
+export KEYCHAIN_ID=1
 export KEYCHAIN_WRITER_NAME=my-keychain-writer-name  
 ```
 
@@ -54,7 +56,7 @@ When a user requests a new key, the Keychain generates a new private key, stores
 2. Get all key requests: 
 
    ```bash
-   wardend q warden key-requests --keychain-id $KEYCHAIN_ID
+   wardend query warden key-requests --keychain-id $KEYCHAIN_ID
    ```
 
    Your key request ID will be returned in the `id` field of the output:
@@ -85,7 +87,7 @@ When a user requests a new key, the Keychain generates a new private key, stores
    
    ```bash
    wardend tx warden fulfill-key-request $KEY_REQUEST_ID $PUBLIC_KEY /
-     --from $KEYCHAIN_WRITER_NAME --chain-id chain_123-1
+     --from $KEYCHAIN_WRITER_NAME --chain-id $CHAIN_ID
    ```
 
 ## 4. Fulfill a signature request
@@ -97,10 +99,10 @@ When a user requests a new key, the Keychain signs a message with the private ke
 2. Get all signature requests:
 
    ```bash
-   wardend q warden signature-requests --keychain-id $KEYCHAIN_ID
+   wardend query warden sign-requests --keychain-id $KEYCHAIN_ID
    ```
    
-   Your signature request ID and data for signing will be returned in the `id`  and `data_for_signing` fields of the output:
+   Your signature request ID and data for signing will be returned in the `id` and `data_for_signing` fields of the output:
    
    ```bash
    id: 1
@@ -124,5 +126,5 @@ When a user requests a new key, the Keychain signs a message with the private ke
    
    ```bash
    wardend tx warden fulfill-sign-request $SIGNATURE_REQUEST_ID $SIGNATURE \
-     --from $KEYCHAIN_WRITER_NAME --chain-id chain_123-1
+     --from $KEYCHAIN_WRITER_NAME --chain-id $CHAIN_ID
    ```

--- a/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/fulfill-requests-from-cli.md
+++ b/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/fulfill-requests-from-cli.md
@@ -85,7 +85,7 @@ When a user requests a new key, the Keychain generates a new private key, stores
    
    ```bash
    wardend tx warden fulfill-key-request $KEY_REQUEST_ID $PUBLIC_KEY /
-     --from $KEYCHAIN_WRITER_NAME --chain-id wardenprotocol
+     --from $KEYCHAIN_WRITER_NAME --chain-id chain_123-1
    ```
 
 ## 4. Fulfill a signature request
@@ -124,5 +124,5 @@ When a user requests a new key, the Keychain signs a message with the private ke
    
    ```bash
    wardend tx warden fulfill-sign-request $SIGNATURE_REQUEST_ID $SIGNATURE \
-     --from $KEYCHAIN_WRITER_NAME --chain-id wardenprotocol
+     --from $KEYCHAIN_WRITER_NAME --chain-id chain_123-1
    ```

--- a/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/fulfill-requests-from-cli.md
+++ b/docs/developer-docs/docs/build-a-keychain/operate-a-keychain/fulfill-requests-from-cli.md
@@ -35,7 +35,7 @@ go install ./cmd/clichain
 
 In the next steps, you'll use the following values:
 
-- Your chain ID you used when [running a node](operate-a-keychain/create-a-keychain#1-run-a-node).
+- Your chain ID you used when [running a node](create-a-keychain#1-run-a-node).
 - Your Keychain ID obtained when [registering a Keychain](create-a-keychain#2-register-a-keychain).
 - Your Keychain Writer name you specified when [adding a Keychain Writer](create-a-keychain#3-add-a-keychain-writer).  
 

--- a/docs/developer-docs/docs/build-an-app/deploy-a-smart-contract-on-warden/_category_.json
+++ b/docs/developer-docs/docs/build-an-app/deploy-a-smart-contract-on-warden/_category_.json
@@ -1,11 +1,11 @@
 {
   "position": 2,
-  "label": "Build a custom smart contract",
+  "label": "Deploy a smart contract on Warden",
   "collapsible": true,
   "collapsed": false,
   "link": {
     "type": "generated-index",
-    "title": "Build a custom smart contract"
+    "title": "Deploy a smart contract on Warden"
   },
   "customProps": {}
 }

--- a/docs/developer-docs/docs/build-an-app/deploy-a-smart-contract-on-warden/deploy-a-cosmwasm-contract.md
+++ b/docs/developer-docs/docs/build-an-app/deploy-a-smart-contract-on-warden/deploy-a-cosmwasm-contract.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 ---
 
-# Build a CosmWasm contract
+# Deploy a CosmWasm contract
 
 ## Overview
 
@@ -44,7 +44,7 @@ Before you start, complete the following prerequisites:
   wardend keys list
   ```
   :::tip
-  In development genesis files, you'll typically find an account named shulgin that is preconfigured and ready for use.
+  If you used a `just` script or a devnet snapshot to run your node, the local account name is `shulgin`.
   :::
 
 ## 1. Create a CosmWasm project

--- a/docs/developer-docs/docs/build-an-app/deploy-a-smart-contract-on-warden/deploy-an-evm-contract.md
+++ b/docs/developer-docs/docs/build-an-app/deploy-a-smart-contract-on-warden/deploy-an-evm-contract.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Build an EVM contract
+# Deploy an EVM contract
 
 ## Overview
 
@@ -33,9 +33,9 @@ Before you start, complete the following prerequisites:
   ```bash
   wardend keys export my-key-name --unarmored-hex --unsafe
   ```
-   :::tip
-   In development genesis files, you'll typically find an account named `shulgin` that is preconfigured and ready for use. You can check the names of available keys by running `wardend keys list`.
-   :::
+  :::tip
+  If you used a `just` script or a devnet snapshot to run your node, the local account name is `shulgin`. You can check the names of available keys by running `wardend keys list`.
+  :::
 
 ## 1. Create an EVM project
 

--- a/docs/developer-docs/docs/build-an-app/introduction.md
+++ b/docs/developer-docs/docs/build-an-app/introduction.md
@@ -28,8 +28,8 @@ The [`x/wasm`](/learn/warden-protocol-modules/external-modules#xwasm) Warden mod
 
 ## Section overview
 
-- [Build a custom smart contract](/category/build-a-custom-smart-contract)  
-Get started with OApps: build a basic smart CosmWasm or EVM smart contract.
+- [Deploy a smart contract on Warden](/category/deploy-a-smart-contract-on-warden)  
+Get started with OApps: deploy a basic [CosmWasm](deploy-a-smart-contract-on-warden/deploy-a-cosmwasm-contract) or [EVM](deploy-a-smart-contract-on-warden/deploy-an-evm-contract) smart contract on Warden.
 
 - [Build with WardenJS](build-with-wardenjs)  
 Here you'll find information on WardenJS – a tool used for building the frontend part of your application. Stay tuned in for more frontend guides.

--- a/docs/developer-docs/docs/operate-a-node/node-commands.md
+++ b/docs/developer-docs/docs/operate-a-node/node-commands.md
@@ -39,7 +39,7 @@ You can exclude the `--node` flag if you're running a chain on the same machine 
 To get a full list of available `wardend` commands and flags, run `wardend` with the `--help` flag:
 
 ```bash
-wardend --help --node https://rpc.buenavista.wardenprotocol.org:443
+wardend --help
 ```
 
 ## Get details of a command
@@ -49,7 +49,7 @@ To learn more about a command, run `wardend`, followed by the command name and t
 For example, you can execute this to learn more about querying the node with the `query` command:
 
 ```bash
-wardend query --help --node https://rpc.buenavista.wardenprotocol.org:443
+wardend query --help
 ```
 
 In the output, you'll see a list of available subcommands and flags. You can query subcommands the same way.
@@ -63,7 +63,7 @@ This section contains useful examples of `wardend` commands. You'll learn how to
 To get a full list of commands for querying a node, run this:
 
 ```bash
-wardend query --help --node https://rpc.buenavista.wardenprotocol.org:443
+wardend query --help
 ```
 
 For example, the `warden` command allows you to query the [Warden](/learn/warden-protocol-modules/x-warden) module.
@@ -87,7 +87,7 @@ Here are some of the available `wardend query warden` subcommands with examples:
 To get a full list of commands for managing your keys, run this:
 
 ```bash
-wardend keys --help --node https://rpc.buenavista.wardenprotocol.org:443
+wardend keys --help
 ```
 
 Here are some examples of `wardend keys` commands:
@@ -121,7 +121,7 @@ Here are some examples of `wardend keys` commands:
 To get a full list of commands for initiating transactions, run this:
 
 ```bash
-wardend tx --help --node https://rpc.buenavista.wardenprotocol.org:443
+wardend tx --help
 ```
 
 For example, the `warden` command allows you to initiate [Warden](/learn/warden-protocol-modules/x-warden) transactions. Here are some of the available `wardend tx warden` subcommands with examples:

--- a/docs/developer-docs/docs/operate-a-node/run-a-local-chain.md
+++ b/docs/developer-docs/docs/operate-a-node/run-a-local-chain.md
@@ -187,7 +187,7 @@ In this flow, you'll create and configure your chain manually.
 4. Add a genesis (validator) account. Specify your key name and the number of tokens staked:
 
    ```bash
-   wardend genesis add-genesis-account my-key-name 25000000000000000000000award
+   wardend genesis add-genesis-account my-key-name 20000000000000000000000000award
    ```
 
    This will add your address to the `accounts` section of the genesis file.
@@ -195,7 +195,7 @@ In this flow, you'll create and configure your chain manually.
 5. Generate a genesis transaction. Specify your key name, the amount to stake, and the chain ID:
    
    ```bash
-   wardend genesis gentx my-key-name 100000000000000000000award  --chain-id chain_123-1
+   wardend genesis gentx my-key-name 1000000000000000000000award --chain-id chain_123-1
    ```
 
 6. Collect genesis transactions:

--- a/docs/developer-docs/docs/operate-a-node/run-a-local-chain.md
+++ b/docs/developer-docs/docs/operate-a-node/run-a-local-chain.md
@@ -242,7 +242,7 @@ In the previous steps, you configured your node with the minimum settings requir
    
    ```bash
    wardend tx warden new-keychain \
-     --description 'my-description' \
+     --name 'my-keychain-name' \
      --from my-key-name \
      --chain-id chain_123-1
    ```
@@ -262,8 +262,11 @@ In the previous steps, you configured your node with the minimum settings requir
    - admins:
      - warden1h7akmejqcrafp3mfpjqamghh89kzmkgjzsy3mc
      creator: warden1h7akmejqcrafp3mfpjqamghh89kzmkgjzsy3mc
-     description: my-description
+     fees:
+       key_req: []
+       sig_req: []
      id: "1"
+     name: my-keychain-name
    pagination:
      total: "1"
    ```

--- a/docs/developer-docs/docs/operate-a-node/run-a-local-chain.md
+++ b/docs/developer-docs/docs/operate-a-node/run-a-local-chain.md
@@ -77,20 +77,23 @@ cd wardenprotocol
 
 ### 2. Build the binary
 
-Then use `just` to build the chain binary:
+1. Then use `just` to build the chain binary called `wardend`:
+      
+   ```bash
+   just wardend build
+   ```
+
+2. To install the binary in your `$GOPATH`, run this command:
+
+   ```bash
+   just wardend install
+   ```
+3. You can check the binary location and version:
    
-```bash
-just wardend build
-```
-
-This will build the chain binary called `wardend` and install it in your `$GOPATH`.
-
-You can check the binary location and version with these commands:
-
-```bash
-which wardend
-wardend version
-```
+   ```bash
+   which wardend
+   wardend version
+   ```
 
 ### 3. Download the snapshot
 
@@ -135,20 +138,23 @@ cd wardenprotocol
 
 ### 2. Build the binary
 
-Then use `just` to build the chain binary:
-   
-```bash
-just wardend build
-```
-   
-This will build the chain binary called `wardend` and install it in your `$GOPATH`.
+1. Then use `just` to build the chain binary called `wardend`:
+      
+   ```bash
+   just wardend build
+   ```
 
-You can check the binary location and version with these commands:
+2. To install the binary in your `$GOPATH`, run this command:
 
-```bash
-which wardend
-wardend version
-```
+   ```bash
+   just wardend install
+   ```
+3. You can check the binary location and version:
+   
+   ```bash
+   which wardend
+   wardend version
+   ```
 
 ### 3. Create and configure a chain
 


### PR DESCRIPTION
- **Run a local chain**: Fixed amounts to make manual configs correspond to prebuilt configs
- **Run a local chain**, **Create a Keychain**: Mentioned that `--name` is required when creating a Keychain, updated outputs, fixed the instructions for building a binary (`just wardend install` is now required)
- **Node commands**:  deleted the node url for `--help` commands
- **Fulfill requests from CLI**: Fixed details in some steps that were easy to test
- **Build an app**: revisited the titles of the EVM / CosmWasm guides
- Fixed all chain id examples accross the docs to reflect the new chain id format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity in the Keychain creation and operation guide, specifying account names and chain ID.
	- Updated CLI commands for fulfilling key and signature requests, improving usability and flexibility.
	- Adjusted parameters in local blockchain setup documentation, including reduced token amounts and updated keychain creation commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->