### PR TITLE
fix(ci): job scan-image

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build and Push ${{inputs.service_name }}
     runs-on: ubuntu-latest
     outputs:
-      tags: ${{ steps.meta.outputs.tags }}
+      image: ${{ vars.REGISTRY }}/${{ inputs.service_name }}:${{ steps.meta.outputs.version }}
     permissions:
       id-token: write
       contents: read
@@ -63,7 +63,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: ${{ needs.build-and-push.outputs.tags }}
+          image-ref: ${{ needs.build-and-push.outputs.image }}
           output: "trivy.txt"
           # exit-code: "1"
           severity: "CRITICAL,HIGH"


### PR DESCRIPTION
A small fix to resolve this issue https://github.com/warden-protocol/wardenprotocol/actions/runs/10960507321/job/30435433433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build and push workflow to enhance Docker image reference handling for improved security scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->