### PR TITLE
fix(x/act): use correct uint8-based prefixes to avoid collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Consensus Breaking Changes
 
+* (x/act) Change keys prefix in database to avoid collisions
+
+### Features (non-breaking)
+
+### Bug Fixes
+
+### Misc
+
+## [v0.5.0](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.4.0) - 2024-09-20
+
+### Consensus Breaking Changes
+
 * (x/warden) [#660](https://github.com/warden-protocol/wardenprotocol/660) Added `Nonce` field to Space to avoid race conditions
 * (x/warden) Keychain fees are deducted with escrow account
 * (wardend) Bump Cosmos SDK to v0.50.9

--- a/warden/x/act/keeper/actions_keeper.go
+++ b/warden/x/act/keeper/actions_keeper.go
@@ -25,7 +25,7 @@ func newActionKeeper(storeService store.KVStoreService, cdc codec.BinaryCodec) A
 	sb := collections.NewSchemaBuilder(storeService)
 
 	actionsStore := collections.NewMap(sb, ActionPrefix, "action", collections.Uint64Key, codec.CollValue[types.Action](cdc))
-	actionsCount := collections.NewSequence(sb, types.KeyPrefix(types.ActionCountKey), "actions_count")
+	actionsCount := collections.NewSequence(sb, ActionsSeqPrefix, "actions_count")
 	actions := repo.NewSeqCollection(actionsCount, actionsStore, func(a *types.Action, u uint64) { a.Id = u })
 
 	actionByAddress := collections.NewMap(

--- a/warden/x/act/keeper/keeper.go
+++ b/warden/x/act/keeper/keeper.go
@@ -40,9 +40,11 @@ type (
 
 var (
 	ActionPrefix                   = collections.NewPrefix(0)
-	TemplatePrefix                 = collections.NewPrefix(1)
-	ActionByAddressPrefix          = collections.NewPrefix(2)
-	PreviousPruneBlockHeightPrefix = collections.NewPrefix(3)
+	ActionsSeqPrefix               = collections.NewPrefix(1)
+	TemplatePrefix                 = collections.NewPrefix(2)
+	TemplateSeqPrefix              = collections.NewPrefix(3)
+	ActionByAddressPrefix          = collections.NewPrefix(4)
+	PreviousPruneBlockHeightPrefix = collections.NewPrefix(5)
 )
 
 func NewKeeper(
@@ -66,7 +68,7 @@ func NewKeeper(
 	sb := collections.NewSchemaBuilder(storeService)
 
 	templatesStore := collections.NewMap(sb, TemplatePrefix, "template", collections.Uint64Key, codec.CollValue[types.Template](cdc))
-	templatesCount := collections.NewSequence(sb, types.KeyPrefix(types.TemplateCountKey), "templates_count")
+	templatesCount := collections.NewSequence(sb, TemplateSeqPrefix, "templates_count")
 	templates := repo.NewSeqCollection(templatesCount, templatesStore, func(i *types.Template, u uint64) { i.Id = u })
 
 	_, err := sb.Build()

--- a/warden/x/act/types/v1beta1/keys.go
+++ b/warden/x/act/types/v1beta1/keys.go
@@ -9,18 +9,8 @@ const (
 
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_act"
-
-	ActionCountKey = "action/count"
-	ActionKey      = "action/value/"
-
-	TemplateCountKey = "template/count"
-	TemplateKey      = "template/value/"
 )
 
 var (
 	ParamsKey = []byte("p_act")
 )
-
-func KeyPrefix(p string) []byte {
-	return []byte(p)
-}


### PR DESCRIPTION
Some of the current keys are using ASCII strings, some are using a uint. This definitely can lead to collisions and problems, so we should fix this before releasing the new chain and benefit from the fact that we are starting a new db from scratch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated changelog for version release v0.5.0, dated 2024-09-20.
	- Documented consensus-breaking changes, including modifications to database key prefixes and the addition of a `Nonce` field.
	- Updated Cosmos SDK version to v0.50.9.
	- Removed several constant declarations and a function related to key management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->