### PR TITLE
use default cosmos StartCmd instead of evmos's one

### DIFF
--- a/cmd/wardend/cmd/commands.go
+++ b/cmd/wardend/cmd/commands.go
@@ -34,6 +34,7 @@ import (
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	evmosclient "github.com/evmos/evmos/v18/client"
 	"github.com/evmos/evmos/v18/client/debug"
+
 	evmosserver "github.com/evmos/evmos/v18/server"
 	"github.com/warden-protocol/wardenprotocol/warden/app"
 )
@@ -53,9 +54,10 @@ func initRootCmd(
 		snapshot.Cmd(newApp),
 	)
 
-	evmosserver.AddCommands(
+	server.AddCommands(
 		rootCmd,
-		evmosserver.NewDefaultStartOptions(newApp, app.DefaultNodeHome),
+		app.DefaultNodeHome,
+		newApp,
 		appExport,
 		addModuleInitFlags,
 	)
@@ -74,6 +76,7 @@ func initRootCmd(
 		queryCommand(),
 		txCommand(),
 		evmosclient.KeyCommands(app.DefaultNodeHome),
+		evmosserver.NewIndexTxCmd(),
 	)
 }
 


### PR DESCRIPTION
Fix panic on SIGINT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command to enhance the command interface functionality.
- **Improvements**
	- Updated command initialization process for better configuration and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->