### PR TITLE
Fix/new key event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased changes
 
+### Bug Fixes
+* (x/warden) Fix bug with Id=0 in NewKeyEvent
+
 ## [v0.5.1](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.1) - 2024-10-04
 
 ### Consensus Breaking Changes

--- a/warden/x/warden/keeper/genesis.go
+++ b/warden/x/warden/keeper/genesis.go
@@ -28,7 +28,7 @@ func (k *Keeper) ImportState(ctx sdk.Context, genState types.GenesisState) error
 	}
 
 	for _, key := range genState.Keys {
-		err := k.KeysKeeper.Set(ctx, key)
+		err := k.KeysKeeper.Set(ctx, &key)
 		if err != nil {
 			return fmt.Errorf("failed to import keys: %w", err)
 		}

--- a/warden/x/warden/keeper/key_requests.go
+++ b/warden/x/warden/keeper/key_requests.go
@@ -17,7 +17,7 @@ func (k Keeper) fulfillKeyRequest(ctx sdk.Context, msg *types.MsgFulfilKeyReques
 		return nil, err
 	}
 	// setup new key
-	key := types.Key{
+	key := &types.Key{
 		SpaceId:           req.SpaceId,
 		KeychainId:        req.KeychainId,
 		Type:              req.KeyType,
@@ -36,7 +36,7 @@ func (k Keeper) fulfillKeyRequest(ctx sdk.Context, msg *types.MsgFulfilKeyReques
 		return nil, err
 	}
 
-	return &key, nil
+	return key, nil
 }
 
 func ensureKeyFormatting(req types.KeyRequest, pubKey []byte) error {

--- a/warden/x/warden/keeper/keys.go
+++ b/warden/x/warden/keeper/keys.go
@@ -26,7 +26,7 @@ func NewKeysKeeper(sb *collections.SchemaBuilder, cdc codec.BinaryCodec) KeysKee
 	}
 }
 
-func (k KeysKeeper) New(ctx context.Context, key types.Key, keyRequest types.KeyRequest) error {
+func (k KeysKeeper) New(ctx context.Context, key *types.Key, keyRequest types.KeyRequest) error {
 	key.Id = keyRequest.Id
 	return k.Set(ctx, key)
 }
@@ -35,11 +35,11 @@ func (k KeysKeeper) Get(ctx context.Context, id uint64) (types.Key, error) {
 	return k.keys.Get(ctx, id)
 }
 
-func (k KeysKeeper) Set(ctx context.Context, key types.Key) error {
+func (k KeysKeeper) Set(ctx context.Context, key *types.Key) error {
 	if err := k.keysBySpace.Set(ctx, collections.Join(key.SpaceId, key.Id)); err != nil {
 		return err
 	}
-	return k.keys.Set(ctx, key.Id, key)
+	return k.keys.Set(ctx, key.Id, *key)
 }
 
 func (k KeysKeeper) Coll() collections.Map[uint64, v1beta3.Key] {

--- a/warden/x/warden/keeper/msg_server_update_key.go
+++ b/warden/x/warden/keeper/msg_server_update_key.go
@@ -31,7 +31,7 @@ func (k msgServer) UpdateKey(ctx context.Context, msg *types.MsgUpdateKey) (*typ
 		key.RejectTemplateId = msg.RejectTemplateId
 	}
 
-	if err := k.KeysKeeper.Set(ctx, key); err != nil {
+	if err := k.KeysKeeper.Set(ctx, &key); err != nil {
 		return nil, err
 	}
 

--- a/warden/x/warden/keeper/query_all_keys_test.go
+++ b/warden/x/warden/keeper/query_all_keys_test.go
@@ -20,7 +20,7 @@ func Benchmark_QueryAllKeys(b *testing.B) {
 	for i := 0; i < 1_000_000; i++ {
 		err = k.KeysKeeper.New(
 			ctx,
-			types.Key{
+			&types.Key{
 				Type:      types.KeyType_KEY_TYPE_ECDSA_SECP256K1,
 				PublicKey: pk,
 			},

--- a/warden/x/warden/keeper/query_keys_by_space_id_test.go
+++ b/warden/x/warden/keeper/query_keys_by_space_id_test.go
@@ -20,7 +20,7 @@ func Benchmark_QueryKeysBySpaceId(b *testing.B) {
 	for i := 0; i < 100_000; i++ {
 		err = k.KeysKeeper.New(
 			ctx,
-			types.Key{
+			&types.Key{
 				Type:      types.KeyType_KEY_TYPE_ECDSA_SECP256K1,
 				PublicKey: pk,
 				SpaceId:   uint64(i),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `sdk.Coins` fields in autogenerated CLI commands.
  - Introduced a `creator` filter parameter for the `Rules` query.

- **Bug Fixes**
  - Resolved an issue with `Id=0` in `NewKeyEvent`.
  - Removed default parameters from genesis in the `(x/gmp)` module.

- **Improvements**
  - Added a `Nonce` field to the `Space` structure to prevent race conditions.
  - Updated keychain fees to be deducted using an escrow account.
  - Enhanced metadata in the `Keychain` by replacing the `Description` field with a `Name` field and adding new fields.

- **Chores**
  - Updated dependencies, including Cosmos SDK and ibc-go.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->