### PR TITLE
fix(wardend): use NoOp mempool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * 
 
 ### Bug Fixes
+
+## [v0.5.3](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.3) - 2024-10-31
+
+### Bug Fixes
 * Add `comet` alias to `tendermint` command
+* Fix mempool to be NoOp, for evmos' transactions to work, fixing some non-determinism in the network caused by different mempool settings in `app.toml`
 
 ## [v0.5.2](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.2) - 2024-10-22
 


### PR DESCRIPTION
We uncovered some inconsistent behavior when mempool is not explicitly set to NoOp. Evmos requires the mempool to be NoOp, as other mempool implementations are not compatible with MsgEthereumTx.

This lead to apphash mismatches in our Chiado testnet. Depending on the number set in `mempool.size` in `app.toml`, transactions resulted in errors or not (because it actually determined whether or not NoOp mempool was being used).

This PR forces NoOp mempool, essentially ignoring the mempool setting in `app.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the changelog to include a new section for bug fixes and the latest version `v0.5.3`.
- **Bug Fixes**
	- Added a `comet` alias to the `tendermint` command.
	- Fixed the mempool to be a NoOp for Evmos transactions, addressing non-determinism issues.
- **Documentation**
	- Enhanced the structure of the changelog to comply with Semantic Versioning and "Keep a Changelog" format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->