### PR TITLE
ci: bump setup-go and golangci-lint actions

### DIFF
--- a/.github/workflows/faucet.yml
+++ b/.github/workflows/faucet.yml
@@ -29,14 +29,14 @@ jobs:
     name: lint
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56
+          version: v1.64
           args: --timeout=10m ${{ env.modules }}
 
   unit-test:
@@ -44,9 +44,9 @@ jobs:
     name: test
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Build
         run: go build -v ${{ env.modules }}
       - name: Test (-race)

--- a/.github/workflows/go-client.yml
+++ b/.github/workflows/go-client.yml
@@ -17,14 +17,14 @@ jobs:
     name: lint
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56
+          version: v1.64
           args: --timeout=10m ./go-client/...
 
   unit-test:
@@ -32,9 +32,9 @@ jobs:
     name: test
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.24"
       - name: Build
         run: go build -v ./go-client/...
       - name: Test (-race)

--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -8,5 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
       - uses: katexochen/go-tidy-check@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,9 +11,9 @@ jobs:
     name: test
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Build
         run: go test -run "TestIntegration" -v ./integration_test.go
         working-directory: "tests/"

--- a/.github/workflows/keychain-sdk.yml
+++ b/.github/workflows/keychain-sdk.yml
@@ -17,14 +17,14 @@ jobs:
     name: lint
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56
+          version: v1.64
           args: --timeout=10m ./keychain-sdk/...
 
   unit-test:
@@ -32,9 +32,9 @@ jobs:
     name: test
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.24"
       - name: Build
         run: go build -v ./keychain-sdk/...
       - name: Test (-race)

--- a/.github/workflows/shield.yml
+++ b/.github/workflows/shield.yml
@@ -17,14 +17,14 @@ jobs:
     name: lint
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56
+          version: v1.64
           args: --timeout=10m ./shield/...
 
   unit-test:
@@ -32,9 +32,9 @@ jobs:
     name: test
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Test (-race)
         run: go test -race -v ./shield/...
 

--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -29,12 +29,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56
+          version: v1.64
           args: --timeout=10m ${{ env.modules }}
 
   unit-test:
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Build
         run: go build -v ${{ env.modules }}
       - name: Test (-race)

--- a/.github/workflows/wardenkms.yml
+++ b/.github/workflows/wardenkms.yml
@@ -23,14 +23,14 @@ jobs:
     name: lint
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56
+          version: v1.64
           args: --timeout=10m ./cmd/wardenkms/...
 
   unit-test:
@@ -38,9 +38,9 @@ jobs:
     name: test
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Build
         run: go build -v -o build/wardenkms ./cmd/wardenkms/...
       - name: Test (-race)


### PR DESCRIPTION
Update to latest versions of Go (1.24) and golangci-lint in GitHub actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Modernized the CI/CD pipeline by upgrading the Go runtime to v1.24 and updating related tooling. These improvements streamline code quality checks and testing processes, enhancing overall build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->