### PR TITLE
chore(wardend): bump evmos to v20 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.5.3](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.3) - 2024-10-31
 
+### Features (non-breaking)
+* Bump evmos to v20 (stable)
+
 ### Bug Fixes
 * Add `comet` alias to `tendermint` command
 * Fix mempool to be NoOp, for evmos' transactions to work, fixing some non-determinism in the network caused by different mempool settings in `app.toml`

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/cosmos/ibc-go/modules/capability v1.0.1
 	github.com/cosmos/ibc-go/v8 v8.5.1
 	github.com/ethereum/go-ethereum v1.14.7
-	github.com/evmos/evmos/v20 v20.0.0-rc2
+	github.com/evmos/evmos/v20 v20.0.0
 	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -554,8 +554,8 @@ github.com/envoyproxy/protoc-gen-validate v1.0.4 h1:gVPz/FMfvh57HdSJQyvBtF00j8JU
 github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
 github.com/evmos/cosmos-sdk/store v0.0.0-20240718141609-414cbd051fbe h1:CKvjP3CcWckOiwffAARb9qe+t0+VWoVDiicYkQMvZfQ=
 github.com/evmos/cosmos-sdk/store v0.0.0-20240718141609-414cbd051fbe/go.mod h1:Bm6h8ZkYgVTytHK5vhHOMKw9OHyiumm3b1UbkYIJ/Ug=
-github.com/evmos/evmos/v20 v20.0.0-rc2 h1:q7C21asU/XHm6zQo20q7QoJQXYtuqDF8BdU2kGes5FY=
-github.com/evmos/evmos/v20 v20.0.0-rc2/go.mod h1:QslHUHSn613wH4l2axRfoyUxBu+OjyqwbNUM3XW8QsM=
+github.com/evmos/evmos/v20 v20.0.0 h1:/wXGE/wAknT8vbY5MaQoCiGVoUFmYeHkeSUz4opfxzw=
+github.com/evmos/evmos/v20 v20.0.0/go.mod h1:QslHUHSn613wH4l2axRfoyUxBu+OjyqwbNUM3XW8QsM=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=


### PR DESCRIPTION
Update evmos from RC to stable version (the changes should only affect the `gov` precompile)


closes #977 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `evmos` dependency to version `v20`, enhancing stability.
  
- **Bug Fixes**
	- Added a `comet` alias to the `tendermint` command for improved usability.
	- Resolved mempool non-determinism issues, ensuring consistent network performance. 

- **Chores**
	- Updated dependency management for various libraries to align with project requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->