### PR TITLE
v0.5.2 -> v.0.5.3, tendermint -> comet

### DIFF
--- a/docs/developer-docs/docs/operate-a-node/chiado-testnet/chiado-overview.md
+++ b/docs/developer-docs/docs/operate-a-node/chiado-testnet/chiado-overview.md
@@ -12,11 +12,11 @@ Chiado is our new and improved testnet. Please make sure to transition all your 
 
 | Release                                                                          |
 | -------------------------------------------------------------------------------- |
-| [v0.5.2](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.2)  |
+| [v0.5.3](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.3)  |
 
 ## Binary
 
-The latest binary version compatible with Chiado is [wardend v.0.5.2](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.2).
+The latest binary version compatible with Chiado is [wardend v.0.5.3](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.3).
 
 
 ## Endpoints

--- a/docs/developer-docs/docs/operate-a-node/chiado-testnet/join-chiado.md
+++ b/docs/developer-docs/docs/operate-a-node/chiado-testnet/join-chiado.md
@@ -29,7 +29,7 @@ To be able to interact with the node, install `wardend` (the Warden binary) usin
 
 ### Option 1: Use the prebuilt binary
 
-1. Download the binary for your platform from the [release page](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.2) and unzip it. The archive contains the `wardend` binary.
+1. Download the binary for your platform from the [release page](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.3) and unzip it. The archive contains the `wardend` binary.
 
 2. Navigate to the directory containing the binary and initialize the node:
   
@@ -46,7 +46,7 @@ To be able to interact with the node, install `wardend` (the Warden binary) usin
 1. Clone the repository and navigate to the root directory:
 
    ```bash
-   git clone --depth 1 --branch v0.5.2 https://github.com/warden-protocol/wardenprotocol
+   git clone --depth 1 --branch v0.5.3 https://github.com/warden-protocol/wardenprotocol
    cd wardenprotocol
    ```
 

--- a/docs/developer-docs/docs/operate-a-node/create-a-validator.md
+++ b/docs/developer-docs/docs/operate-a-node/create-a-validator.md
@@ -62,7 +62,7 @@ To create a validator and initialize it with a self-delegation, you need to crea
 1. Obtain your validator public key by running the following command:
 
    ```bash
-   wardend tendermint show-validator
+   wardend comet show-validator
    ```
 
    The output will be similar to this (with a different key):
@@ -123,7 +123,7 @@ There are certain files you need to backup to be able to restore your validator 
 Check if your validator is in the active set by running this command:
 
 ```bash
-wardend query tendermint-validator-set | grep "$(wardend tendermint show-address)"
+wardend query comet-validator-set | grep "$(wardend comet show-address)"
 ```
 
 If the output is empty, your validator isn't in the active set.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated versioning information for the Chiado testnet in relevant documents.
	- Revised installation instructions to reflect the new Warden binary version `v0.5.3`.
	- Adjusted commands for validator setup to align with new terminology and technology.
	- Emphasized the transition to the Chiado testnet and the updated denomination to `award`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->