### PR TITLE
Update wardend.yml

### DIFF
--- a/.github/workflows/wardend.yml
+++ b/.github/workflows/wardend.yml
@@ -9,6 +9,7 @@ on:
       - "cmd/faucet/**"
       - "cmd/wardend/**"
       - "warden/**"
+      - "precompiles/**"
     tags:
       - "faucet/v*"
       - "wardend/v*"
@@ -17,6 +18,7 @@ on:
       - "cmd/faucet/**"
       - "cmd/wardend/**"
       - "warden/**"
+      - "precompiles/**"
 
 env:
   modules: "./warden/... ./cmd/wardend/... ./cmd/faucet/..."


### PR DESCRIPTION
I noticed that devnet was not updated after bug fix in precompiles. Suggest to build new image also after changes in precompile/ path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow triggers to include changes in the `precompiles` directory, enhancing responsiveness to relevant updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->