### PR TITLE
fix spacesByOwner when no spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (precompiles) Fix address type convert and return derived addresses as strings
 * (precompiles) Fix error with empty keys in space.
 * (precompiles) Return expressions in json encoding.
+* (precompiles) Fix spacesByOwner when no spaces.
 
 ## [v0.5.3](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.3) - 2024-10-31
 

--- a/precompiles/warden/query_types.go
+++ b/precompiles/warden/query_types.go
@@ -512,7 +512,7 @@ type spacesOutput struct {
 }
 
 func (o *spacesOutput) FromResponse(res *types.QuerySpacesResponse) (*spacesOutput, error) {
-	if res == nil || res.Spaces == nil {
+	if res == nil {
 		return nil, errors.New("received nil QuerySpacesResponse")
 	}
 	o.Spaces = make([]Space, len(res.Spaces))

--- a/tests/cases/warden_precompile.go
+++ b/tests/cases/warden_precompile.go
@@ -37,7 +37,7 @@ func (c *Test_WardenPrecompile) Setup(t *testing.T, ctx context.Context, build f
 func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build framework.BuildResult) {
 	alice := exec.NewWardend(c.w, "alice")
 	bob := exec.NewWardend(c.w, "bob")
-	// dave := exec.NewWardend(c.w, "dave")
+	dave := exec.NewWardend(c.w, "dave")
 
 	// client := TestGRPCClient(*c.w.GRPCClient(t))
 	evmClient := c.w.EthClient(t)
@@ -225,6 +225,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 	})
 
 	t.Run("work with space", func(t *testing.T) {
+		spaces, err := iWardenClient.SpacesByOwner(dave.CallOps(t), warden.TypesPageRequest{}, dave.EthAddress(t))
+		require.NoError(t, err)
+		require.Equal(t, []warden.Space{}, spaces.Spaces)
+
 		additionalOwners := []common.Address{}
 		newSpaceTx, err := iWardenClient.NewSpace(alice.TransactOps(t, ctx, evmClient), 0, 0, 0, 0, additionalOwners)
 		require.NoError(t, err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `spacesByOwner` functionality when no spaces are present, ensuring accurate system responses.
  
- **Tests**
	- Enhanced test suite with a new test case for the `SpacesByOwner` method, validating the retrieval and creation of spaces associated with the Warden node "dave."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->