### PR TITLE
feat(faucet): work with 0x addresses

### DIFF
--- a/cmd/faucet/faucet_test.go
+++ b/cmd/faucet/faucet_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestConvertHexToBech32(t *testing.T) {
+	testCases := []struct {
+		name      string
+		addr      string
+		hrp       string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:      "Valid hex address",
+			addr:      "0x8f1ca170120dbe6a9d96554dc763c087935b06cb",
+			expected:  "warden13uw2zuqjpklx48vk24xuwc7qs7f4kpktt25svn",
+			expectErr: false,
+		},
+		{
+			name:      "Invalid hex address",
+			addr:      "0x123abc",
+			expected:  "",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			addr, err := convertHexToBech32(tc.addr)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else {
+					t.Logf("got expected error: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if addr != tc.expected {
+				t.Errorf("expected address %q, got %q", tc.expected, addr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
this adds faucet support for 0x based addresses by adding address conversion to warden address and checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to convert Ethereum hex addresses to Bech32 format, enhancing address handling in the Faucet.
	- Updated the Faucet's Send method to process hex addresses correctly before execution.

- **Tests**
	- Added a new test suite to validate the behavior of the hex-to-Bech32 conversion function, ensuring robust error handling and output accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->