### PR TITLE
feat(faucet): blacklist option

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -244,6 +244,10 @@ func (f *Faucet) Send(addr string, force bool) (string, int, error) {
 		}
 	}
 
+	if strings.Contains(f.config.Blacklist, addr) {
+		return "", http.StatusUnprocessableEntity, fmt.Errorf("address is blacklisted")
+	}
+
 	if len(f.Batch) < f.config.BatchLimit && !force {
 		if err := validAddress(addr); err != nil {
 			return "", http.StatusUnprocessableEntity, err

--- a/cmd/faucet/pkg/config/config.go
+++ b/cmd/faucet/pkg/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Decimals       int           `env:"DECIMALS"       envDefault:"18"                                        mapstructure:"DECIMALS"`
 	DisplayTokens  bool          `env:"DISPLAY_TOKENS" envDefault:"true"                                      mapstructure:"DISPLAY_TOKENS"`
 	Environment    string        `env:"ENVIRONMENT"    envDefault:"development"                               mapstructure:"ENVIRONMENT"`
+	Blacklist      string        `env:"BLACKLIST"      envDefault:""                                          mapstructure:"BLACKLIST"`
 }
 
 func GetEnvironment() string {


### PR DESCRIPTION
this enables a blacklist option to block certain addresses from faucet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a blacklist validation in the token sending process to prevent transactions to blacklisted addresses.
	- Added a configuration option to specify a blacklist via environment variables.

- **Bug Fixes**
	- Enhanced error handling for attempts to send tokens to blacklisted addresses, returning an appropriate error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->