### PR TITLE
chore: remove unused upgrade handler for slinky

### DIFF
--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -67,9 +67,7 @@ import (
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
 	"github.com/warden-protocol/wardenprotocol/warden/x/act/cosmoshield"
 	actmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/act/keeper"
-	acttypes "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	gmpkeeper "github.com/warden-protocol/wardenprotocol/warden/x/gmp/keeper"
-	gmptypes "github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 	"github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/keeper"
 	wardenmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/warden/keeper"
 	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
@@ -458,31 +456,6 @@ func New(
 		app.Logger().Info(fmt.Sprintf("post migrate version map: %v", versionMap))
 		return versionMap, err
 	})
-
-	// Slinky upgrader
-	slinkyUpgrade := createSlinkyUpgrader(app)
-	app.UpgradeKeeper.SetUpgradeHandler(slinkyUpgrade.Name, slinkyUpgrade.Handler) // includes v0.4 upgrade
-
-	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
-	if err != nil {
-		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
-	}
-	if upgradeInfo.Name == slinkyUpgrade.Name {
-		// add slinky stores if this upgrade is the slinky upgrade.
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storetypes.StoreUpgrades{
-			Added: append(
-				slinkyUpgrade.StoreUpgrade.Added,
-				gmptypes.StoreKey,
-				ibchookstypes.StoreKey,
-			),
-			Renamed: []storetypes.StoreRename{
-				{
-					OldKey: "intent",
-					NewKey: acttypes.ModuleName,
-				},
-			},
-		}))
-	}
 
 	if err := app.Load(loadLatest); err != nil {
 		return nil, err

--- a/warden/app/oracle.go
+++ b/warden/app/oracle.go
@@ -2,23 +2,11 @@ package app
 
 import (
 	"context"
-	"fmt"
-	"slices"
 	"time"
 
-	acttypes "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
-
-	storetypes "cosmossdk.io/store/types"
-	upgradetypes "cosmossdk.io/x/upgrade/types"
-	tmtypes "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/server/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/mempool"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
 	oraclepreblock "github.com/skip-mev/slinky/abci/preblock/oracle"
 	"github.com/skip-mev/slinky/abci/proposals"
@@ -26,13 +14,10 @@ import (
 	compression "github.com/skip-mev/slinky/abci/strategies/codec"
 	"github.com/skip-mev/slinky/abci/strategies/currencypair"
 	"github.com/skip-mev/slinky/abci/ve"
-	"github.com/skip-mev/slinky/cmd/constants/marketmaps"
 	oracleconfig "github.com/skip-mev/slinky/oracle/config"
 	"github.com/skip-mev/slinky/pkg/math/voteweighted"
 	oracleclient "github.com/skip-mev/slinky/service/clients/oracle"
 	servicemetrics "github.com/skip-mev/slinky/service/metrics"
-	marketmaptypes "github.com/skip-mev/slinky/x/marketmap/types"
-	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
 )
 
 func (app *App) initializeOracle(appOpts types.AppOptions) {
@@ -160,97 +145,4 @@ func initializeABCIExtensions(app *App, oracleMetrics servicemetrics.Metrics) {
 	)
 	app.SetExtendVoteHandler(voteExtensionsHandler.ExtendVoteHandler())
 	app.SetVerifyVoteExtensionHandler(voteExtensionsHandler.VerifyVoteExtensionHandler())
-}
-
-type AppUpgrade struct {
-	Name         string
-	Handler      upgradetypes.UpgradeHandler
-	StoreUpgrade storetypes.StoreUpgrades
-}
-
-// createSlinkyUpgrader returns the upgrade name and an upgrade handler that:
-// - runs migrations
-// - updates the consensus keeper params with a vote extension enable height. (height of upgrade + 10).
-// - adds the core markets to x/marketmap keeper.
-// additionally, it returns the required StoreUpgrades needed for the new slinky modules added to this chain.
-func createSlinkyUpgrader(app *App) AppUpgrade {
-	return AppUpgrade{
-		Name: "v03-to-v04",
-		Handler: func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			// renamed module
-			fromVM[acttypes.ModuleName] = fromVM["intent"]
-			delete(fromVM, "intent")
-
-			migrations, err := app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)
-			if err != nil {
-				return nil, err
-			}
-			// upgrade consensus params to enable vote extensions
-			consensusParams, err := app.ConsensusParamsKeeper.Params(ctx, nil)
-			if err != nil {
-				return nil, err
-			}
-			sdkCtx := sdk.UnwrapSDKContext(ctx)
-			consensusParams.Params.Abci = &tmtypes.ABCIParams{
-				VoteExtensionsEnableHeight: sdkCtx.BlockHeight() + int64(10),
-			}
-			_, err = app.ConsensusParamsKeeper.UpdateParams(ctx, &consensustypes.MsgUpdateParams{
-				Authority: app.ConsensusParamsKeeper.GetAuthority(),
-				Block:     consensusParams.Params.Block,
-				Evidence:  consensusParams.Params.Evidence,
-				Validator: consensusParams.Params.Validator,
-				Abci:      consensusParams.Params.Abci,
-			})
-			if err != nil {
-				return nil, err
-			}
-
-			// add core markets
-			coreMarkets := marketmaps.CoreMarketMap
-			markets := coreMarkets.Markets
-			keys := make([]string, 0, len(markets))
-			for name := range markets {
-				keys = append(keys, name)
-			}
-			slices.Sort(keys)
-
-			// iterates over slice and not map
-			for _, marketName := range keys {
-				// create market
-				market := markets[marketName]
-				err = app.MarketMapKeeper.CreateMarket(sdkCtx, market)
-				if err != nil {
-					return nil, err
-				}
-
-				// invoke hooks
-				err = app.MarketMapKeeper.Hooks().AfterMarketCreated(sdkCtx, market)
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			err = app.MarketMapKeeper.SetParams(
-				sdkCtx,
-				marketmaptypes.Params{
-					Admin: authtypes.NewModuleAddress(govtypes.ModuleName).String(), // governance. allows gov to add or remove market authorities.
-					// market authority addresses may add and update markets to the x/marketmap module.
-					MarketAuthorities: []string{
-						"warden1ua63s43u2p4v38pxhcxmps0tj2gudyw2rctzk3",          // skip multisig
-						authtypes.NewModuleAddress(govtypes.ModuleName).String(), // governance
-					}},
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to set x/marketmap params: %w", err)
-			}
-
-			return migrations, nil
-		},
-		StoreUpgrade: storetypes.StoreUpgrades{
-			Added: []string{
-				marketmaptypes.ModuleName,
-				oracletypes.ModuleName,
-			},
-		},
-	}
 }


### PR DESCRIPTION
Delete the (now unused) code for the upgrade handler that introduced slinky (i.e. v0.3 to v0.4 upgrade).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined application initialization by removing unnecessary upgrade handling logic.
  
- **Bug Fixes**
	- Simplified error management by eliminating redundant error handling related to upgrades.

- **Chores**
	- Removed unused imports and types, reducing code complexity and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->