### PR TITLE
feat(keychain-sdk): log transactions hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features (non-breaking)
 * (precompiles) Add an ability for contracts to approve actions
 * (go-client) Return transaction hash from SendWaitTx
+* (keychain-sdk) Log transaction hashes of broadcasted transactions
 
 ### Consensus Breaking Changes
 * (precompiles) Add slinky precompiled contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features (non-breaking)
 * (precompiles) Add an ability for contracts to approve actions
+* (go-client) Return transaction hash from SendWaitTx
 
 ### Consensus Breaking Changes
 * (precompiles) Add slinky precompiled contract

--- a/go-client/tx_raw_client.go
+++ b/go-client/tx_raw_client.go
@@ -54,17 +54,17 @@ func NewRawTxClient(id Identity, chainID string, c *grpc.ClientConn, accountFetc
 }
 
 // Send a transaction and wait for it to be included in a block.
-func (c *RawTxClient) SendWaitTx(ctx context.Context, txBytes []byte) error {
+func (c *RawTxClient) SendWaitTx(ctx context.Context, txBytes []byte) (string, error) {
 	hash, err := c.SendTx(ctx, txBytes)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if err = c.WaitForTx(ctx, hash); err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return hash, nil
 }
 
 type Msger interface {

--- a/keychain-sdk/internal/writer/writer.go
+++ b/keychain-sdk/internal/writer/writer.go
@@ -136,11 +136,12 @@ func (w *W) sendWaitTx(ctx context.Context, msgs ...client.Msger) error {
 		return err
 	}
 
-	if err = w.Client.SendWaitTx(ctx, tx); err != nil {
+	hash, err := w.Client.SendWaitTx(ctx, tx)
+	if err != nil {
 		return err
 	}
 
-	w.Logger.Info("flush complete")
+	w.Logger.Info("flush complete", "tx_hash", hash)
 
 	return nil
 }


### PR DESCRIPTION
This makes the keychain sdk logs outgoing transaction hashes, which I found to be useful when trying to check what a keychain is doing (e.g. manually checking how much gas it uses).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Contracts can now approve actions.
	- Transaction hashes are returned from the `SendWaitTx` method.
	- Transaction hashes of broadcasted transactions are now logged.
	- Added a new slinky precompiled contract.
	- `SignRequest` structure updated to include `broadcastType`.

- **Bug Fixes**
	- No new entries added.

- **Documentation**
	- Updated `CHANGELOG.md` to reflect new features and changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->