### PR TITLE
refactor(wardend): encapsulate slinky initialization

### DIFF
--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -83,7 +83,6 @@ import (
 	feemarketkeeper "github.com/evmos/evmos/v20/x/feemarket/keeper"
 
 	evmosencodingcodec "github.com/evmos/evmos/v20/encoding/codec"
-	oracleclient "github.com/skip-mev/slinky/service/clients/oracle"
 	marketmapkeeper "github.com/skip-mev/slinky/x/marketmap/keeper"
 	oraclekeeper "github.com/skip-mev/slinky/x/oracle/keeper"
 )
@@ -172,7 +171,7 @@ type App struct {
 	HooksICS4Wrapper ibchooks.ICS4Middleware
 
 	// processes
-	oracleClient oracleclient.OracleClient
+	slinkyClient *SlinkyClient
 }
 
 func init() {
@@ -384,7 +383,7 @@ func New(
 	app.MarketMapKeeper.SetHooks(app.OracleKeeper.Hooks())
 
 	// oracle initialization
-	app.initializeOracle(appOpts)
+	app.initializeOracles(appOpts)
 
 	// register legacy modules
 	wasmConfig := app.registerLegacyModules(appOpts, wasmOpts)

--- a/warden/app/oracle.go
+++ b/warden/app/oracle.go
@@ -2,13 +2,18 @@ package app
 
 import (
 	"context"
+	"math/big"
 	"time"
 
+	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/mempool"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 
 	oraclepreblock "github.com/skip-mev/slinky/abci/preblock/oracle"
 	"github.com/skip-mev/slinky/abci/proposals"
@@ -16,137 +21,200 @@ import (
 	compression "github.com/skip-mev/slinky/abci/strategies/codec"
 	"github.com/skip-mev/slinky/abci/strategies/currencypair"
 	"github.com/skip-mev/slinky/abci/ve"
+	slinkyaggregator "github.com/skip-mev/slinky/aggregator"
 	oracleconfig "github.com/skip-mev/slinky/oracle/config"
 	"github.com/skip-mev/slinky/pkg/math/voteweighted"
 	oracleclient "github.com/skip-mev/slinky/service/clients/oracle"
 	servicemetrics "github.com/skip-mev/slinky/service/metrics"
+	oraclekeeper "github.com/skip-mev/slinky/x/oracle/keeper"
 )
 
-func (app *App) initializeOracle(appOpts types.AppOptions) {
+func (app *App) initializeOracles(appOpts types.AppOptions) {
+	app.setupMempool()
+	baseProposalHandler := app.baseProposalHandler()
+	app.setupSlinkyClient(appOpts)
+	app.setupABCILifecycle(
+		baseProposalHandler.PrepareProposalHandler(),
+		baseProposalHandler.ProcessProposalHandler(),
+	)
+}
+
+func (app *App) setupMempool() {
+	// force NoOpMempool as required by x/evm
+	noopMempool := mempool.NoOpMempool{}
+	app.SetMempool(noopMempool)
+}
+
+func (app *App) setupSlinkyClient(appOpts types.AppOptions) {
+	chainID := app.ChainID()
+	c, err := NewSlinkyClient(app.Logger(), chainID, appOpts, app.StakingKeeper, app.OracleKeeper)
+	if err != nil {
+		panic(err)
+	}
+	app.slinkyClient = c
+}
+
+func (app *App) baseProposalHandler() *baseapp.DefaultProposalHandler {
+	mempool := app.Mempool()
+	return baseapp.NewDefaultProposalHandler(mempool, app)
+}
+
+type SlinkyClient struct {
+	logger         log.Logger
+	cfg            oracleconfig.AppConfig
+	metrics        servicemetrics.Metrics
+	client         oracleclient.OracleClient
+	veCodec        compression.VoteExtensionCodec
+	extCommitCodec compression.ExtendedCommitCodec
+	stakingKeeper  *stakingkeeper.Keeper
+	oracleKeeper   *oraclekeeper.Keeper
+}
+
+func NewSlinkyClient(
+	logger log.Logger,
+	chainID string,
+	appOpts types.AppOptions,
+	stakingKeeper *stakingkeeper.Keeper,
+	oracleKeeper *oraclekeeper.Keeper,
+) (*SlinkyClient, error) {
 	// Read general config from app-opts, and construct oracle service.
 	cfg, err := oracleconfig.ReadConfigFromAppOpts(appOpts)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	// If app level instrumentation is enabled, then wrap the oracle service with a metrics client
 	// to get metrics on the oracle service (for ABCI++). This will allow the instrumentation to track
 	// latency in VerifyVoteExtension requests and more.
-	oracleMetrics, err := servicemetrics.NewMetricsFromConfig(cfg, app.ChainID())
+	metrics, err := servicemetrics.NewMetricsFromConfig(cfg, chainID)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	// Create the oracle service.
-	app.oracleClient, err = oracleclient.NewClientFromConfig(
+	client, err := oracleclient.NewClientFromConfig(
 		cfg,
-		app.Logger().With("client", "oracle"),
-		oracleMetrics,
+		logger.With("client", "oracle"),
+		metrics,
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	// Connect to the oracle service (default timeout of 5 seconds).
 	go func() {
-		if err := app.oracleClient.Start(context.Background()); err != nil {
-			app.Logger().Error("failed to start oracle client", "err", err)
+		if err := client.Start(context.Background()); err != nil {
+			logger.Error("failed to start oracle client", "err", err)
+			// It's okay to panic here because an error here means that the
+			// address was misconfigured.
+			// In case the oracle server is not running, this won't be an error
+			// and the application will continue to run as expected.
 			panic(err)
 		}
 
-		app.Logger().Info("started oracle client", "address", cfg.OracleAddress)
+		logger.Info("started oracle client", "address", cfg.OracleAddress)
 	}()
-	initializeABCIExtensions(app, oracleMetrics)
+
+	return &SlinkyClient{
+		logger:  logger,
+		cfg:     cfg,
+		metrics: metrics,
+		client:  client,
+		veCodec: compression.NewCompressionVoteExtensionCodec(
+			compression.NewDefaultVoteExtensionCodec(),
+			compression.NewZLibCompressor(),
+		),
+		extCommitCodec: compression.NewCompressionExtendedCommitCodec(
+			compression.NewDefaultExtendedCommitCodec(),
+			compression.NewZStdCompressor(),
+		),
+		stakingKeeper: stakingKeeper,
+		oracleKeeper:  oracleKeeper,
+	}, nil
 }
 
-func initializeABCIExtensions(app *App, oracleMetrics servicemetrics.Metrics) {
-	noopMempool := mempool.NoOpMempool{}
-	app.SetMempool(noopMempool)
-	baseHandler := baseapp.NewDefaultProposalHandler(noopMempool, app)
-
-	// Create the proposal handler that will be used to fill proposals with
-	// transactions and oracle data.
-	proposalHandler := proposals.NewProposalHandler(
-		app.Logger(),
-		baseHandler.PrepareProposalHandler(),
-		baseHandler.ProcessProposalHandler(),
-		ve.NewDefaultValidateVoteExtensionsFn(app.StakingKeeper),
-		compression.NewCompressionVoteExtensionCodec(
-			compression.NewDefaultVoteExtensionCodec(),
-			compression.NewZLibCompressor(),
-		),
+func (sc *SlinkyClient) ProposalHandler(
+	prepareProposalHandler sdk.PrepareProposalHandler,
+	processProposalHandler sdk.ProcessProposalHandler,
+) *proposals.ProposalHandler {
+	return proposals.NewProposalHandler(
+		sc.logger,
+		prepareProposalHandler,
+		processProposalHandler,
+		ve.NewDefaultValidateVoteExtensionsFn(sc.stakingKeeper),
+		sc.veCodec,
 		compression.NewCompressionExtendedCommitCodec(
 			compression.NewDefaultExtendedCommitCodec(),
 			compression.NewZStdCompressor(),
 		),
-		currencypair.NewDeltaCurrencyPairStrategy(app.OracleKeeper),
-		oracleMetrics,
+		currencypair.NewDeltaCurrencyPairStrategy(sc.oracleKeeper),
+		sc.metrics,
 	)
-	app.SetPrepareProposal(proposalHandler.PrepareProposalHandler())
-	app.SetProcessProposal(proposalHandler.ProcessProposalHandler())
+}
 
+func (sc *SlinkyClient) AggregatorFn() slinkyaggregator.AggregateFnFromContext[string, map[slinkytypes.CurrencyPair]*big.Int] {
 	// Create the aggregation function that will be used to aggregate oracle data
 	// from each validator.
-	aggregatorFn := voteweighted.MedianFromContext(
-		app.Logger(),
-		app.StakingKeeper,
+	return voteweighted.MedianFromContext(
+		sc.logger,
+		sc.stakingKeeper,
 		voteweighted.DefaultPowerThreshold,
 	)
+}
 
-	// Create the pre-finalize block hook that will be used to apply oracle data
-	// to the state before any transactions are executed (in finalize block).
-	oraclePreBlockHandler := oraclepreblock.NewOraclePreBlockHandler(
-		app.Logger(),
-		aggregatorFn,
-		app.OracleKeeper,
-		oracleMetrics,
-		currencypair.NewDeltaCurrencyPairStrategy(app.OracleKeeper),
-		compression.NewCompressionVoteExtensionCodec(
-			compression.NewDefaultVoteExtensionCodec(),
-			compression.NewZLibCompressor(),
-		),
-		compression.NewCompressionExtendedCommitCodec(
-			compression.NewDefaultExtendedCommitCodec(),
-			compression.NewZStdCompressor(),
-		),
+func (sc *SlinkyClient) PreblockHandler() *oraclepreblock.PreBlockHandler {
+	return oraclepreblock.NewOraclePreBlockHandler(
+		sc.logger,
+		sc.AggregatorFn(),
+		sc.oracleKeeper,
+		sc.metrics,
+		currencypair.NewDeltaCurrencyPairStrategy(sc.oracleKeeper),
+		sc.veCodec,
+		sc.extCommitCodec,
 	)
+}
 
-	app.SetPreBlocker(oraclePreBlockHandler.WrappedPreBlocker(app.ModuleManager))
-
-	// Create the vote extensions handler that will be used to extend and verify
-	// vote extensions (i.e. oracle data).
-	cps := currencypair.NewDeltaCurrencyPairStrategy(app.OracleKeeper)
-	veCodec := compression.NewCompressionVoteExtensionCodec(
-		compression.NewDefaultVoteExtensionCodec(),
-		compression.NewZLibCompressor(),
-	)
-	extCommitCodec := compression.NewCompressionExtendedCommitCodec(
-		compression.NewDefaultExtendedCommitCodec(),
-		compression.NewZStdCompressor(),
-	)
-	voteExtensionsHandler := ve.NewVoteExtensionHandler(
-		app.Logger(),
-		app.oracleClient,
+func (sc *SlinkyClient) VoteExtensionHandler() *ve.VoteExtensionHandler {
+	cps := currencypair.NewDeltaCurrencyPairStrategy(sc.oracleKeeper)
+	return ve.NewVoteExtensionHandler(
+		sc.logger,
+		sc.client,
 		time.Second,
 		cps,
-		veCodec,
+		sc.veCodec,
 		aggregator.NewOraclePriceApplier(
 			aggregator.NewDefaultVoteAggregator(
-				app.Logger(),
-				aggregatorFn,
+				sc.logger,
+				sc.AggregatorFn(),
 				// we need a separate price strategy here, so that we can optimistically apply the latest prices
 				// and extend our vote based on these prices
-				currencypair.NewDeltaCurrencyPairStrategy(app.OracleKeeper),
+				currencypair.NewDeltaCurrencyPairStrategy(sc.oracleKeeper),
 			),
-			app.OracleKeeper,
-			veCodec,
-			extCommitCodec,
-			app.Logger(),
+			sc.oracleKeeper,
+			sc.veCodec,
+			sc.extCommitCodec,
+			sc.logger,
 		),
-		oracleMetrics,
+		sc.metrics,
 	)
-	app.SetExtendVoteHandler(voteExtensionsHandler.ExtendVoteHandler())
-	app.SetVerifyVoteExtensionHandler(voteExtensionsHandler.VerifyVoteExtensionHandler())
+}
+
+func (app *App) setupABCILifecycle(
+	basePrepareProposalHandler sdk.PrepareProposalHandler,
+	baseProcessProposalHandler sdk.ProcessProposalHandler,
+) {
+	slinkyProposalHandler := app.slinkyClient.ProposalHandler(
+		basePrepareProposalHandler,
+		baseProcessProposalHandler,
+	)
+	slinkyPreBlockHandler := app.slinkyClient.PreblockHandler()
+	slinkyVEHandler := app.slinkyClient.VoteExtensionHandler()
+
+	app.SetPrepareProposal(slinkyProposalHandler.PrepareProposalHandler())
+	app.SetProcessProposal(slinkyProposalHandler.ProcessProposalHandler())
+	app.SetPreBlocker(slinkyPreBlockHandler.WrappedPreBlocker(app.ModuleManager))
+	app.SetExtendVoteHandler(slinkyVEHandler.ExtendVoteHandler())
+	app.SetVerifyVoteExtensionHandler(slinkyVEHandler.VerifyVoteExtensionHandler())
 }
 
 type AppUpgrade struct {


### PR DESCRIPTION
This creates a new struct called SlinkyClient that encapsulates everything Slinky-related. This is a first step towards making the app initialization more modular and extensible.

No functionalities have been changed, just the order of some calls that doesn't affect functionalities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `SlinkyClient` for improved oracle service integration.
	- Enhanced error handling during oracle initialization.
	- Added methods for handling proposals, aggregation, pre-block processing, and vote extensions.

- **Bug Fixes**
	- Improved error management by returning errors instead of panicking during client setup.

- **Refactor**
	- Renamed and restructured oracle initialization methods for better clarity and modularity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->