### PR TITLE
Fixes for tests

### DIFF
--- a/tests/cases/warden_precompile_action.go
+++ b/tests/cases/warden_precompile_action.go
@@ -269,7 +269,6 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 			1,
 			uint8(types.SignRequestStatus_SIGN_REQUEST_STATUS_PENDING),
 			uint8(types.BroadcastType_BROADCAST_TYPE_AUTOMATIC))
-		require.ErrorContains(t, err, "received nil QuerySignRequestsResponse")
 		require.Len(t, signRequestsAutomatic.SignRequests, 0)
 
 		// updateKey


### PR DESCRIPTION
The behavior changed after https://github.com/warden-protocol/wardenprotocol/pull/1084/files#diff-3399e399c1ab8cf55584e6cf64b6a7a26cf4c60d0500c840ae3e103194f5405b, so I changed test's expectation 