### PR TITLE
fix: upgrade to iavl@v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (x/warden) Add broadcastType to SignRequest
 * (precompiles) Add broadcastType to SignRequest
 * (precompiles) #1077 Change status fields from int32 to enums/uint8 in precompile ABIs for improved type safety and consistency
+* (wardend) Bump IAVL to v1.2.2. Fixes some potential apphash mismatches that happen in some rare cases.
 
 ### Bug Fixes
 

--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
-	github.com/cosmos/iavl v1.2.0 // indirect
+	github.com/cosmos/iavl v1.2.2 // indirect
 	github.com/cosmos/ibc-apps/modules/rate-limiting/v8 v8.0.0 // indirect
 	github.com/cosmos/ics23/go v0.11.0 // indirect
 	github.com/cosmos/interchain-security/v5 v5.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -432,8 +432,8 @@ github.com/cosmos/gogogateway v1.2.0/go.mod h1:iQpLkGWxYcnCdz5iAdLcRBSw3h7NXeOkZ
 github.com/cosmos/gogoproto v1.4.2/go.mod h1:cLxOsn1ljAHSV527CHOtaIP91kK6cCrZETRBrkzItWU=
 github.com/cosmos/gogoproto v1.7.0 h1:79USr0oyXAbxg3rspGh/m4SWNyoz/GLaAh0QlCe2fro=
 github.com/cosmos/gogoproto v1.7.0/go.mod h1:yWChEv5IUEYURQasfyBW5ffkMHR/90hiHgbNgrtp4j0=
-github.com/cosmos/iavl v1.2.0 h1:kVxTmjTh4k0Dh1VNL046v6BXqKziqMDzxo93oh3kOfM=
-github.com/cosmos/iavl v1.2.0/go.mod h1:HidWWLVAtODJqFD6Hbne2Y0q3SdxByJepHUOeoH4LiI=
+github.com/cosmos/iavl v1.2.2 h1:qHhKW3I70w+04g5KdsdVSHRbFLgt3yY3qTMd4Xa4rC8=
+github.com/cosmos/iavl v1.2.2/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/cosmos/ibc-apps/modules/ibc-hooks/v8 v8.0.0-20240530162148-4827cf263165 h1:uaW2p383zzr6JjgWa0D4/kUkzOG5p0DyIpNPY6e0mpI=
 github.com/cosmos/ibc-apps/modules/ibc-hooks/v8 v8.0.0-20240530162148-4827cf263165/go.mod h1:9+Z14xz3Y+5uEn5i1CvLcDN1aTthEhYUdI7pphySkY8=
 github.com/cosmos/ibc-apps/modules/rate-limiting/v8 v8.0.0 h1:AQO9NIAP3RFqvBCj7IqM/V1LCxmuvcvGUdu0RIEz/c0=


### PR DESCRIPTION
We have been reporting a apphash mismatch that happens on specific conditions: after a node restart, if pruning is enabled, see https://github.com/cosmos/cosmos-sdk/discussions/22253 for more details.

IAVL v1.2.2 has been released, which fixes the issue: https://github.com/cosmos/iavl/releases/tag/v1.2.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Go toolchain version from `1.22.7` to `1.22.9`.
	- Adjusted various module dependencies to their latest versions for improved performance and security.
- **New Features**
	- Added contract approval capabilities.
	- Enabled transaction hash returns from `SendWaitTx`.
	- Implemented logging of transaction hashes for broadcasted transactions.
	- Introduced a new service for relaying transactions into Ethereum.
- **Consensus Breaking Changes**
	- Added a new precompiled contract.
	- Modified `SignRequest` structure to include a `broadcastType` field.
	- Changed status fields from `int32` to `enums/uint8` for enhanced type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->