### PR TITLE
Fix "Input not Buffer" error

### DIFF
--- a/automated-orders/packages/aws-kms-signer/src/index.ts
+++ b/automated-orders/packages/aws-kms-signer/src/index.ts
@@ -52,7 +52,7 @@ export class AwsKmsSigner {
   }
 
   private getPublicKeyBytes(publicKeyDer: Uint8Array): Uint8Array {
-    const decoded = EcdsaPubKey.decode(publicKeyDer, 'der');
+    const decoded = EcdsaPubKey.decode(Buffer.from(publicKeyDer), 'der');
     const publicKeyBuffer = decoded.pubKey.data;
 
     return new Uint8Array(publicKeyBuffer);

--- a/automated-orders/packages/blockchain-library/src/clients/evm.ts
+++ b/automated-orders/packages/blockchain-library/src/clients/evm.ts
@@ -255,7 +255,7 @@ export class EvmClient {
 
     const signatureDER = await this.awsKmsSigner.signTransactionHash(hashBytes);
 
-    const decodedSignature = EcdsaSigAsnParse.decode(signatureDER, 'der');
+    const decodedSignature = EcdsaSigAsnParse.decode(Buffer.from(signatureDER), 'der');
 
     const r = decodedSignature.r;
     const s = decodedSignature.s;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of ECDSA public key and signature decoding by ensuring inputs are processed as Buffers, enhancing compatibility and reliability in transaction signing and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->