### PR TITLE
Fix typo in Dependencies section Update clichain.md

### DIFF
--- a/docs/developer-docs/docs/build-a-keychain/implementations/clichain.md
+++ b/docs/developer-docs/docs/build-a-keychain/implementations/clichain.md
@@ -85,7 +85,7 @@ The main use cases include the following:
 
 **CLIChain** relies on the following Go packages:
 
-- [`go-ehtereum/crypto`](https://github.com/ethereum/go-ethereum/tree/master/crypto) for cryptographic functions
+- [`go-ethereum/crypto`](https://github.com/ethereum/go-ethereum/tree/master/crypto) for cryptographic functions
 - [`spf13/cobra`](https://github.com/spf13/cobra) for building the command-line interface
 - [`encoding/base64`](https://pkg.go.dev/encoding/base64) and [`encoding/hex`](https://pkg.go.dev/encoding/hex) for encoding
 


### PR DESCRIPTION
### Description:
I came across a small but significant typo in the documentation under the **Dependencies** section. The package name `go-ehtereum/crypto` was written incorrectly. The correct name is `go-ethereum/crypto`.

This fix is important because the misspelling could lead to confusion or issues when users try to install the package, as they might attempt to use a non-existent repository. This correction ensures that the documentation is accurate and users can follow the instructions without any problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and accuracy of the `clichain.md` document.
	- Corrected dependency reference from `go-ehtereum/crypto` to `go-ethereum/crypto`.
	- Retained detailed descriptions and examples for key functionalities: generating a private key, deriving a public key, and signing a message.
	- Emphasized comprehensive error handling for better user troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->