### PR TITLE
fix(wardend): don't return errors on empty vote extension

### DIFF
--- a/warden/app/oracle.go
+++ b/warden/app/oracle.go
@@ -294,7 +294,7 @@ func (a *WardenSlinkyCodec) Decode(b []byte) (vetypes.OracleVoteExtension, error
 	}
 
 	if len(w.Extensions) == 0 {
-		return vetypes.OracleVoteExtension{}, fmt.Errorf("no vote extension")
+		return a.slinkyCodec.Decode(nil)
 	}
 
 	return a.slinkyCodec.Decode(w.Extensions[0])


### PR DESCRIPTION
I'm still not sure exactly in what cases this happens (but it did happen) and Slinky apparently just ignores it by trying to decoding an empty byte array (which internally is essentially a no-op).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty vote extensions in the Warden Slinky Codec
	- Modified decoding process to support scenarios with no vote extensions
	- Enabled more flexible processing when no extensions are available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->