### PR TITLE
chore(wardend): prepare v0.6.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased changes
 
 ### Features (non-breaking)
+
+### Consensus Breaking Changes
+
+### Bug Fixes
+
+## [v0.6.1](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.6.1) - 2025-03-03
+
+### Features (non-breaking)
 * (precompiles) Add an ability for contracts to approve actions
 * (go-client) Return transaction hash from SendWaitTx
 * (keychain-sdk) Log transaction hashes of broadcasted transactions

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/url"
@@ -15,6 +16,7 @@ import (
 	evidencekeeper "cosmossdk.io/x/evidence/keeper"
 	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -64,10 +66,13 @@ import (
 	ibcfeekeeper "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/keeper"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	"github.com/spf13/cast"
+	asyncprecompile "github.com/warden-protocol/wardenprotocol/precompiles/async"
+	slinkyprecompile "github.com/warden-protocol/wardenprotocol/precompiles/slinky"
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
 	"github.com/warden-protocol/wardenprotocol/warden/x/act/cosmoshield"
 	actmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/act/keeper"
 	asyncmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/async/keeper"
+	asynctypes "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 	gmpkeeper "github.com/warden-protocol/wardenprotocol/warden/x/gmp/keeper"
 	"github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/keeper"
 	wardenmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/warden/keeper"
@@ -497,6 +502,41 @@ func New(
 	maxGasWanted := cast.ToUint64(appOpts.Get(srvflags.EVMMaxTxGasWanted))
 
 	app.setAnteHandler(app.txConfig, wasmConfig, app.GetKey(wasmtypes.StoreKey), maxGasWanted)
+
+	v060UpgradeName := "v054-to-v060"
+	app.UpgradeKeeper.SetUpgradeHandler(v060UpgradeName, func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		toVM, err := app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)
+		if err != nil {
+			return toVM, err
+		}
+
+		// add new x/evm precompiles
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		evmParams := app.EvmKeeper.GetParams(sdkCtx)
+		evmParams.ActiveStaticPrecompiles = append(evmParams.ActiveStaticPrecompiles,
+			slinkyprecompile.PrecompileAddress,
+			asyncprecompile.PrecompileAddress,
+		)
+		if err := evmParams.Validate(); err != nil {
+			return toVM, err
+		}
+		if err := app.EvmKeeper.SetParams(sdkCtx, evmParams); err != nil {
+			return toVM, err
+		}
+
+		return toVM, nil
+	})
+	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
+	}
+	if upgradeInfo.Name == v060UpgradeName {
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storetypes.StoreUpgrades{
+			Added: []string{
+				asynctypes.ModuleName,
+			},
+		}))
+	}
 
 	if err := app.Load(loadLatest); err != nil {
 		return nil, err


### PR DESCRIPTION
Update the CHANGELOG and prepare the upgrade handler to bump from v0.5.4 to v0.6.0.

`x/warden` shouldn't need db migrations as we only added a backward compatible field to SignatureRequests.

`x/async` is registered as a new module.

Added two new x/evm precompiles:
- async
- slinky

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced upgrade process that enables a smoother migration to the new version while maintaining compatibility.
- **Documentation**
	- Updated the release notes for version v0.6.1 with clearly organized sections for new features, breaking changes, and bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->