### PR TITLE
increase timeouts

### DIFF
--- a/prophet/handlers/pricepred/client.go
+++ b/prophet/handlers/pricepred/client.go
@@ -53,7 +53,7 @@ type PredictResponse struct {
 }
 
 func (c *client) Predict(ctx context.Context, req PredictRequest) (PredictResponse, error) {
-	reqCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	var res PredictResponse
 	if err := c.post(reqCtx, req, &res, c.predictURL); err != nil {
@@ -133,7 +133,7 @@ type VerifyResponse struct {
 }
 
 func (c *client) Verify(ctx context.Context, req VerifyRequest) (VerifyResponse, error) {
-	reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	var res VerifyResponse
 	if err := c.post(reqCtx, req, &res, c.verifyURL); err != nil {


### PR DESCRIPTION
In devnet we have errors `failed to run future process=exec_futures future=9 err="executing future: Post \"http://devnet-tpc:9001/api/task/inference/solve\": context deadline exceeded"` for new created pricepred futures.

This hotfix just sets 10 seconds deadline for execute and verify. May be we should do this parametrizable later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Extended waiting periods for some operations, aiming to enhance response handling during data processing tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->