### PR TITLE
fix: broken link `wardenjs/README.md`

### DIFF
--- a/wardenjs/README.md
+++ b/wardenjs/README.md
@@ -144,7 +144,7 @@ const stargateClient = await getSigningwardenprotocolClient({
 To broadcast messages, you can create signers with a variety of options:
 
 * [cosmos-kit](https://github.com/cosmology-tech/cosmos-kit/tree/main/packages/react#signing-clients) (recommended)
-* [keplr](https://docs.keplr.app/api/cosmjs.html)
+* [keplr](https://docs.keplr.app/api/use-with/cosmjs)
 * [cosmjs](https://gist.github.com/webmaster128/8444d42a7eceeda2544c8a59fbd7e1d9)
 ### Amino Signer
 


### PR DESCRIPTION
Hi! This PR updates a broken link in the README.md file. The previous link to Keplr documentation was incorrect and has been replaced with the correct one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the reference link for the Keplr wallet in the documentation to ensure users receive more accurate guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->