### PR TITLE
Grammar and Consistency Fixes in Documentation

### DIFF
--- a/docs/developer-docs/docs/learn/whitepaper.md
+++ b/docs/developer-docs/docs/learn/whitepaper.md
@@ -5,5 +5,5 @@ sidebar_position: 8
 # Whitepaper
 
 :::tip
-We're developing a major update to the Warden Protocol, introducing significant architectural and conceptual changes. Stay tuned in for a new whitepaper, where we'll reveal the full scope of the Warden Protocol's new capabilities. We'll provide insights into how we're shaping the future for safe AI through blockchain technology, opening new horizons for dApps, AIs, and users.
+We're developing a major update to the Warden Protocol, introducing significant architectural and conceptual changes. Stay tuned for a new whitepaper, where we'll reveal the full scope of the Warden Protocol's new capabilities. We'll provide insights into how we're shaping the future for safe AI through blockchain technology, opening new horizons for dApps, AIs, and users.
 :::

--- a/docs/developer-docs/docs/operate-a-node/create-a-validator.md
+++ b/docs/developer-docs/docs/operate-a-node/create-a-validator.md
@@ -12,11 +12,11 @@ We're transitioning from [Buenavista](buenavista-testnet/join-buenavista) to our
 
 ## Prerequisites
 
-The following instructions assume you have already set up a full-node and are synchronized to the latest block height. If you haven’t done so, please follow the [Join Chiado](chiado-testnet/join-chiado) instructions.
+The following instructions assume you have already set up a full node and are synchronized to the latest block height. If you haven’t done so, please follow the [Join Chiado](chiado-testnet/join-chiado) instructions.
 
 ## 1. Create/restore a key pair
 
-The first step is creating a new key pair for your validator. Replace `my-key-name` with a key name of your choice and run the following:
+The first step is to create a new key pair for your validator. Replace `my-key-name` with a key name of your choice and run the following:
 
 ```bash
 wardend keys add my-key-name
@@ -111,9 +111,9 @@ To create a validator and initialize it with a self-delegation, you need to crea
    This transaction is just an example. If you want to see an explanation of the parameters values or see all the available flags that can be set to customize your validators you can enter this command: `wardend tx staking create-validator --help`
    :::
 
-## 3. Backup critical files
+## 3. Back up critical files
 
-There are certain files you need to backup to be able to restore your validator if, for some reason, it’s damaged or lost. Please make a secure, encrypted backup of the following files:
+There are certain files you need to back up to be able to restore your validator if, for some reason, it’s damaged or lost. Please make a secure, encrypted backup of the following files:
 
 - `priv_validator_key.json`
 - `node_key.json`

--- a/docs/developer-docs/docs/operate-a-node/node-commands.md
+++ b/docs/developer-docs/docs/operate-a-node/node-commands.md
@@ -12,7 +12,7 @@ These commands allow you to do the following:
 
 - Query the node
 - Initiate transactions
-- Manage your key
+- Manage your keys
 - Edit the genesis file
 - and much more
 
@@ -20,7 +20,7 @@ These commands allow you to do the following:
 
 To interact with the node, you need to install the [Warden binary](https://github.com/warden-protocol/wardenprotocol/releases), `wardend`.
 
-You can follow installations instructions in one of these guides (depending on your goal):
+You can follow installation instructions in one of these guides (depending on your goal):
 
 - [Run a local chain](/operate-a-node/run-a-local-chain)
 - [Join Chiado](/operate-a-node/chiado-testnet/join-chiado#1-install)


### PR DESCRIPTION
“Manage your key” → “Manage your keys”
“installations instructions” → “installation instructions”
“backup” → “back up” (verb form)
“## 3. Backup critical files” → “## 3. Back up critical files”
“full-node” → “full node”
“Stay tuned in for a new whitepaper” → “Stay tuned for a new whitepaper”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved the whitepaper text for clearer and more concise messaging.
  - Refined language and formatting in the validator setup guide to enhance consistency.
  - Enhanced the instructions for node commands with grammatical corrections and formatting adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->