### PR TITLE
1219 Fix race condition when two vals add result to a future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (x/async) Add handlers storages and corresponding methods.
 
 ### Bug Fixes
+* (x/async) [#1219](https://github.com/warden-protocol/wardenprotocol/issues/1219) Future results are made permanent. Attempting to set a result more than once causes an error.
 
 ## [v0.5.4](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.4) - 2024-11-07
 

--- a/warden/x/async/keeper/abci.go
+++ b/warden/x/async/keeper/abci.go
@@ -191,6 +191,10 @@ func (k Keeper) PreBlocker() sdk.PreBlocker {
 func (k Keeper) processVE(ctx sdk.Context, fromAddr []byte, ve types.AsyncVoteExtension) error {
 	for _, r := range ve.Results {
 		if err := k.AddFutureResult(ctx, r.FutureId, fromAddr, r.Output); err != nil {
+			if err == types.ErrFutureAlreadyHasResult {
+				continue
+			}
+
 			return fmt.Errorf("failed to add future result: %w", err)
 		}
 	}

--- a/warden/x/async/keeper/futures.go
+++ b/warden/x/async/keeper/futures.go
@@ -69,9 +69,14 @@ func (k *FutureKeeper) Set(ctx context.Context, f types.Future) error {
 }
 
 func (k *FutureKeeper) SetResult(ctx context.Context, result types.FutureResult) error {
+	if exists, _ := k.results.Has(ctx, result.Id); exists {
+		return fmt.Errorf("future result already exists: %d", result.Id)
+	}
+
 	if err := k.pendingFutures.Remove(ctx, result.Id); err != nil {
 		return err
 	}
+
 	return k.results.Set(ctx, result.Id, result)
 }
 

--- a/warden/x/async/keeper/futures.go
+++ b/warden/x/async/keeper/futures.go
@@ -9,6 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/warden-protocol/wardenprotocol/warden/repo"
+	"github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
 
@@ -70,7 +71,7 @@ func (k *FutureKeeper) Set(ctx context.Context, f types.Future) error {
 
 func (k *FutureKeeper) SetResult(ctx context.Context, result types.FutureResult) error {
 	if exists, _ := k.results.Has(ctx, result.Id); exists {
-		return fmt.Errorf("future result already exists: %d", result.Id)
+		return v1beta1.ErrFutureAlreadyHasResult
 	}
 
 	if err := k.pendingFutures.Remove(ctx, result.Id); err != nil {

--- a/warden/x/async/types/v1beta1/errors.go
+++ b/warden/x/async/types/v1beta1/errors.go
@@ -8,7 +8,8 @@ import (
 
 // x/async module sentinel errors
 var (
-	ErrInvalidSigner      = sdkerrors.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
-	ErrInvalidHandler     = sdkerrors.Register(ModuleName, 1102, "invalid handler name")
-	ErrInvalidFutureInput = sdkerrors.Register(ModuleName, 1103, "invalid future input")
+	ErrInvalidSigner          = sdkerrors.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
+	ErrInvalidHandler         = sdkerrors.Register(ModuleName, 1102, "invalid handler name")
+	ErrInvalidFutureInput     = sdkerrors.Register(ModuleName, 1103, "invalid future input")
+	ErrFutureAlreadyHasResult = sdkerrors.Register(ModuleName, 1104, "future already has result")
 )


### PR DESCRIPTION
https://github.com/warden-protocol/wardenprotocol/issues/1219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error validation to prevent duplicate result entries, ensuring more reliable processing and data integrity.
	- Future results are now made permanent; attempting to set a result more than once will cause an error.
	- Improved error handling in vote extension processing to allow uninterrupted execution when a future already has a result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->