### PR TITLE
fix: fix minor typo in authorization description

### DIFF
--- a/warden/docs/static/openapi.yml
+++ b/warden/docs/static/openapi.yml
@@ -1097,7 +1097,7 @@ paths:
                       may apply to invalidate the grant)
                 description: |-
                   Grant gives permissions to execute
-                  the provide method with expiration time.
+                  the provided method with expiration time.
             description: >-
               MsgGrant is a request type for Grant method. It declares
               authorization to the grantee


### PR DESCRIPTION
I’ve corrected a small typo in the description where "the provide method" was used.
It has been updated to "the provided method" to maintain proper grammar and context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the API documentation with corrected wording for improved clarity and grammatical accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->