### PR TITLE
Grammar fixes

### DIFF
--- a/docs/developer-docs/docs/learn/bridging.md
+++ b/docs/developer-docs/docs/learn/bridging.md
@@ -12,7 +12,7 @@ This technology utilizes **cross-chain bridges**—smart contracts that receive 
 
 ## Axelar
 
-Thanks to Warden's [x/gmp](/learn/warden-protocol-modules/external-modules#xgmp) module, [Omnichain Applications](/learn/glossary#omnichain-application) support cross-chain token transfers and general message parsing through **Axelar**.
+Thanks to Warden's [x/gmp](/learn/warden-protocol-modules/external-modules#xgmp) module, [Omnichain Applications](/learn/glossary#omnichain-application) support cross-chain token transfers and general message passing through **Axelar**.
 
 More integrations are coming soon.
 

--- a/docs/developer-docs/docs/operate-a-node/delegation-plan.md
+++ b/docs/developer-docs/docs/operate-a-node/delegation-plan.md
@@ -87,4 +87,4 @@ Delegators have several criteria to consider when choosing validators to delegat
 
 **Track records**: Delegators can look at the track record of a validator they plan to delegate to. This includes seniority in the network, past votes on proposals, uptime and the reliability of the validator, how often the node was compromised. Validators with a positive track record are more trusted by delegators.
 
-**Community contribution**: Another criteria is the work validators have contributed to the community, such as educational content, participation in community channels, contributions to open source initiatives etc. Community contribution demonstrates a commitment to the long-term success and growth of the network.
+**Community contribution**: Another criterion is the work validators have contributed to the community, such as educational content, participation in community channels, contributions to open source initiatives etc. Community contribution demonstrates a commitment to the long-term success and growth of the network.


### PR DESCRIPTION
File: docs/developer-docs/docs/learn/bridging.md
Before: general message parsing through Axelar
After: general message passing through Axelar
Reason: "Message parsing" refers to analyzing structure, while "message passing" is the correct term for cross-chain communication.

File: docs/developer-docs/docs/operate-a-node/delegation-plan.md
Before: Another criteria is
After: Another criterion is
Reason: "Criteria" is plural, "criterion" is singular. The sentence refers to a single factor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified terminology for more accurate descriptions.
	- Made minor textual and grammatical improvements for enhanced readability and adherence to formatting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->