### PR TITLE
fix typo: Change `verison` to `version` in OpenAPI documentation

### DIFF
--- a/spaceward/src/features/intents/Intent.tsx
+++ b/spaceward/src/features/intents/Intent.tsx
@@ -282,7 +282,7 @@ const IntentComponent = ({
 								)}
 							>
 								{editState === "simple"
-									? `Add Сonditions or Whitelist Addres`
+									? `Add Сonditions or Whitelist Address`
 									: `Add Whitelist Address`}
 							</div>
 

--- a/warden/docs/static/openapi.yml
+++ b/warden/docs/static/openapi.yml
@@ -17579,7 +17579,7 @@ paths:
                     title: list of features compatible with the specified identifier
                 description: >-
                   Version defines the versioning scheme used to negotiate the
-                  IBC verison in
+                  IBC version in
 
                   the connection handshake.
               client_state:
@@ -18395,7 +18395,7 @@ paths:
                     title: list of features compatible with the specified identifier
                 description: >-
                   Version defines the versioning scheme used to negotiate the
-                  IBC verison in
+                  IBC version in
 
                   the connection handshake.
               delay_period:
@@ -18861,7 +18861,7 @@ paths:
                         identifier
                   description: >-
                     Version defines the versioning scheme used to negotiate the
-                    IBC verison in
+                    IBC version in
 
                     the connection handshake.
               proof_height:
@@ -27272,7 +27272,7 @@ definitions:
             title: list of features compatible with the specified identifier
         description: >-
           Version defines the versioning scheme used to negotiate the IBC
-          verison in
+          version in
 
           the connection handshake.
       client_state:
@@ -27643,7 +27643,7 @@ definitions:
             title: list of features compatible with the specified identifier
         description: >-
           Version defines the versioning scheme used to negotiate the IBC
-          verison in
+          version in
 
           the connection handshake.
       delay_period:
@@ -27884,7 +27884,7 @@ definitions:
               title: list of features compatible with the specified identifier
           description: >-
             Version defines the versioning scheme used to negotiate the IBC
-            verison in
+            version in
 
             the connection handshake.
       proof_height:
@@ -28042,7 +28042,7 @@ definitions:
           type: string
         title: list of features compatible with the specified identifier
     description: |-
-      Version defines the versioning scheme used to negotiate the IBC verison in
+      Version defines the versioning scheme used to negotiate the IBC version in
       the connection handshake.
   warden.intent.MsgApproveAction:
     type: object


### PR DESCRIPTION
This pull request fixes a typo in the OpenAPI documentation files:
1. Corrects the misspelling of `verison` to `version` in multiple locations
2. Updates text formatting in the intents feature documentation

**Changes made:**
`spaceward/src/features/intents/intent.tsx:` Fixed text formatting
`warden/docs/static/openapi.yml:` Corrected spelling of `version` in IBC connection descriptions

This is a minor documentation cleanup that improves readability and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a textual error in a dropdown menu to improve clarity for users.

- **Documentation**
  - Fixed multiple spelling mistakes to enhance the accuracy and consistency of displayed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->