### PR TITLE
fix typo in `genesis.proto` comments

### DIFF
--- a/wardenjs/proto/cosmos/gov/v1/genesis.proto
+++ b/wardenjs/proto/cosmos/gov/v1/genesis.proto
@@ -18,15 +18,15 @@ message GenesisState {
   // proposals defines all the proposals present at genesis.
   repeated Proposal proposals = 4;
   // Deprecated: Prefer to use `params` instead.
-  // deposit_params defines all the paramaters of related to deposit.
+  // deposit_params defines all the parameters of related to deposit.
   DepositParams deposit_params = 5 [deprecated = true];
   // Deprecated: Prefer to use `params` instead.
-  // voting_params defines all the paramaters of related to voting.
+  // voting_params defines all the parameters of related to voting.
   VotingParams voting_params = 6 [deprecated = true];
   // Deprecated: Prefer to use `params` instead.
-  // tally_params defines all the paramaters of related to tally.
+  // tally_params defines all the parameters of related to tally.
   TallyParams tally_params = 7 [deprecated = true];
-  // params defines all the paramaters of x/gov module.
+  // params defines all the parameters of x/gov module.
   //
   // Since: cosmos-sdk 0.47
   Params params = 8;


### PR DESCRIPTION
**Description:**
This pull request fixes a typo in the `genesis.proto` file comments:
1. Corrects the misspelling of `paramaters` to `parameters` in multiple comment lines
2. Affects comments for `deposit, voting, tally, and x/gov` module parameter descriptions
3. Changes made in `warden1s/proto/cosmos/gov/v1/genesis.proto:`
4. Fixed spelling in comments for `deposit_params`
5. Fixed spelling in comments for `voting_params`
6. Fixed spelling in comments for `tally_params`
7. Fixed spelling in comments for `x/gov module params`

This is a documentation cleanup that improves code readability and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected typographical errors in parameter descriptions to enhance clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->