### PR TITLE
Fix Token Name

### DIFF
--- a/docs/developer-docs/docs/tokens/introduction.md
+++ b/docs/developer-docs/docs/tokens/introduction.md
@@ -10,4 +10,4 @@ There are two tokens available on the Warden Protocol:
 
 - **WARP**: It's the dynamic counterpart to WARD, adding liquidity and gamification to the Warden Protocol ecosystem. It fuels engagement and participation through innovative tokenomics.
 
-See the sections below to learn how to get WARD and WARD and other details.
+See the sections below to learn how to get WARD and WARP and other details.


### PR DESCRIPTION
Fix: Change "WARD and WARD" to "WARD and WARP" to correctly reference both tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated token details in the documentation to correct information for a clearer and more accurate description of the tokens available in the ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->