### PR TITLE
save cons address in prophet on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * (go-client) Return transaction hash from SendWaitTx
 * (keychain-sdk) Log transaction hashes of broadcasted transactions
 * (relayer) #992 Added a service to relay transactions into Ethereum
+* (prophet) Add self consensus address to prophet
 
 ### Consensus Breaking Changes
 * (precompiles) Add slinky precompiled contract

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -420,7 +420,7 @@ func New(
 	// oracle initialization
 	app.initializeOracles(appOpts)
 
-	if err := app.prophet.Run(); err != nil {
+	if err := app.prophet.Run(appOpts.Get("rpc.laddr").(string)); err != nil {
 		panic(fmt.Errorf("failed to run prophet: %w", err))
 	}
 


### PR DESCRIPTION
While https://github.com/cosmos/cosmos-sdk/issues/23723 from @Pitasi is not ready we need solution to get consensus address of current node. It should also work for configurations with horcrux.

Idea is to start goroutine in prophet.Run() that will get address from `/status` rpc and save to `P` (prophet process). Then p.SelfAddress can be used in voting extension. Related to https://github.com/warden-protocol/wardenprotocol/issues/1184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added self-consensus address functionality to the prophet component.
  - Implemented continuous background monitoring for validator status via a configurable RPC endpoint.
  - Updated application startup to allow explicit network configuration, enhancing communication reliability.
- **Documentation**
  - Updated CHANGELOG.md to reflect the addition of self-consensus address functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->