### PR TITLE
Documentation Improvements for Clarity and Grammar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -136,8 +136,7 @@
       the terms of any separate license agreement you may have executed
       with Licensor regarding such Contributions.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
+   6. Trademarks. This License does not grant permission to use the names, trademarks, service marks, or product names of the Licensor,
       except as required for reasonable and customary use in describing the
       origin of the Work and reproducing the content of the NOTICE file.
 

--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ If you're going to contribute to the protocol, see [protocol developer docs on G
 
 With the exception of the SpaceWard folder, this project is released under the terms of the Apache 2.0 License - see [LICENSE](./LICENSE) for details.
 
-Elements of this project are based on the work made by Qredo Ltd on [Fusion Chain](https://github.com/qredo/fusionchain) and were released under the Apache 2 license. See [NOTICE](./NOTICE) for more details.
+Elements of this project are based on the done made by Qredo Ltd on [Fusion Chain](https://github.com/qredo/fusionchain) and were released under the Apache 2.0 license. See [NOTICE](./NOTICE) for more details.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -11,7 +11,7 @@ from CosmWasm contracts.
 
 ## Generate Schema
 
-To generate schema files perform following commands:
+To generate schema files perform the following commands:
 
 ```shell
 # generate bindings schema
@@ -85,7 +85,7 @@ You can query its state, for example, let's list all existing keys:
 wardend query wasm contract-state smart $contract '{ "warden_all_keys": {"pagination":{"limit":0,"reverse":false}, "derive_addresses":[]} }'--chain-id warden
 ```
 
-And perform transactions, let's create request for a new key:
+And perform transactions, let's create a request for a new key:
 
 ```shell
 wardend tx wasm execute $contract '{ "new_key_request": { "space_id": 1, "keychain_id": 2, "key_type": 1, "timeout_height": 888, "intent_id": 0 } }' --from alice -y

--- a/contracts/contracts/sample/README.md
+++ b/contracts/contracts/sample/README.md
@@ -4,5 +4,5 @@ This is a sample contract which uses bindings for the core Warden Protocol block
 
 You can deploy it by itself, or you can use it as a starting point for your own contract.
 
-Note that this is a preview, so only limited functionality available right now.
+Note that this is a preview, so only limited functionality is available right now.
 The sample contract exposes `NewKeyRequest` transaction and `AllKeys` query, but more are on the way!


### PR DESCRIPTION
File: LICENSE

Old: "This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor,"
New: "This License does not grant permission to use the names, trademarks, service marks, or product names of the Licensor,"
Reason: Removed "trade" for clarity.
File: SCHEMA.md

Old: "To generate schema files perform following commands:"
New: "To generate schema files perform the following commands:"
Reason: Added "the" for grammatical correctness.
File: TRANSACTIONS.md

Old: "And perform transactions, let's create request for a new key:"
New: "And perform transactions, let's create a request for a new key:"
Reason: Added "a" for grammatical accuracy.
File: PREVIEW.md

Old: "Note that this is a preview, so only limited functionality available right now."
New: "Note that this is a preview, so only limited functionality is available right now."
Reason: Added "is" for completeness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Simplified the wording in the license agreement by updating specific terms.
  - Made minor grammatical improvements in contract-related documentation to enhance clarity and consistency.
  - Corrected typographical errors and ensured consistency in license naming conventions in the README files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->