### PR TITLE
fix(ci): tests and linting failing due to missing env var

### DIFF
--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -16,6 +16,9 @@ on:
       - "warden/**"
       - "precompiles/**"
 
+env:
+  modules: "./warden/... ./cmd/wardend/... ./cmd/faucet/..."
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -79,7 +82,7 @@ jobs:
       - name: Setup just
         uses: extractions/setup-just@v2
         with:
-          just-version: 1.5.0
+          just-version: 1.39.0
 
       - name: ${{ matrix.release }}
         run: just wardend ${{ matrix.release }}

--- a/wardend.just
+++ b/wardend.just
@@ -54,4 +54,4 @@ release:
     	-w /go/src/wardend \
     	ghcr.io/goreleaser/goreleaser-cross:{{ goreleaser_cross_version }} \
       --clean \
-      --skip={{ skip }}
+      {{ skip }}


### PR DESCRIPTION
This PR fixes CI issues were linting and tests were failing due to missing environment.
Also builds were missing due to bad `just` version which did not recognize file separation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced pipeline configuration with a flexible module specification setting to streamline linting, building, and testing.
	- Upgraded tooling used in the release process for improved performance.
	- Adjusted the release command’s parameter handling for more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->