### PR TITLE
fix(ci): add free disk space step

### DIFF
--- a/.github/workflows/release-wardend.yaml
+++ b/.github/workflows/release-wardend.yaml
@@ -14,6 +14,11 @@ jobs:
         release: ["release"]
 
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -58,6 +58,11 @@ jobs:
         release: ["release"]
 
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This should fix the issue where build jobs are failing due to lack of disk space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the release automation flow by adding a disk space cleanup step on Ubuntu environments before code checkout, ensuring smoother and more efficient deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->