### PR TITLE
ci: ignore consensus-breaking upgrades from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    ignore:
+      - dependency-name: "github.com/cometbft/cometbft"
+      - dependency-name: "github.com/cosmos/cosmos-sdk"
+      - dependency-name: "github.com/CosmWasm/wasmvm/v2"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
trying to make dependabot ignore some dependencies that are not "easy" to upgrade (i.e. we can't just merge the automated PR, it requires additional work and coordination)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced automated management for dependency updates with a weekly schedule.
  - Configured the system to maintain stability by excluding selected dependencies from updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->