### PR TITLE
fixed the block height

### DIFF
--- a/docs/developer-docs/docs/operate-a-node/chiado-testnet/chiado-overview.md
+++ b/docs/developer-docs/docs/operate-a-node/chiado-testnet/chiado-overview.md
@@ -13,7 +13,7 @@ Chiado is our new and improved testnet. Please make sure to transition all your 
 | Release                                                                         | Block height         | Date          | Upgrade guide                        |
 | ------------------------------------------------------------------------------- | -------------------- | ------------- | ------------------------------------ |
 | [v0.5.4](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.5.4) | genesis              |               |                                      |
-| [v0.6.1](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.6.1) | 10785200             | March 5, 2025 | [Upgrade to v0.6.1](upgrade/v0.6.1)  |
+| [v0.6.1](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.6.1) | 1968800              | March 5, 2025 | [Upgrade to v0.6.1](upgrade/v0.6.1)  |
 
 ## Binary
 

--- a/docs/developer-docs/docs/operate-a-node/chiado-testnet/upgrade/v0.6.1.md
+++ b/docs/developer-docs/docs/operate-a-node/chiado-testnet/upgrade/v0.6.1.md
@@ -66,7 +66,7 @@ To upgrade using [Cosmovisor](https://pkg.go.dev/cosmossdk.io/tools/cosmovisor),
 2. Run Warden v0.5.4 until the upgrade height. The node will panic:
 
    ```shell
-   ERR UPGRADE "v0.6.1" NEEDED at height: 10785200: upgrade to v0.6.1 and applying upgrade "v0.6.1" at height: 10785200 
+   ERR UPGRADE "v0.6.1" NEEDED at height: 1968800: upgrade to v0.6.1 and applying upgrade "v0.6.1" at height: 1968800 
    ```
 
 3. Stop the node and switch the binary to **Warden v0.6.1**. Restart the node:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the block height reference in the version history of the Chiado overview documentation.
	- Revised the error message in the upgrade instructions to reflect the correct block height for the upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->