### PR TITLE
ci: disable some CodeRabbit messages

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,25 +1,17 @@
-# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
 language: "en"
 early_access: false
 reviews:
     request_changes_workflow: false
-    high_level_summary: true
+    high_level_summary: false
     poem: false
-    review_status: true
+    review_status: false
     collapse_walkthrough: true
     path_filters:
         - "!api/**"
         - "!wardenjs/src/codegen/**"
         - "!tests/testdata/**"
     path_instructions:
-        - path: "**/*.go"
-          instructions: "Review the Golang code for conformity with the Uber Golang style guide, highlighting any deviations."
-        - path: "tests/**/*"
-          instructions: |
-              "Assess the integration and e2e test code assessing sufficient code coverage for the changes associated in the pull request"
-        - path: "**/*_test.go"
-          instructions: |
-              "Assess the unit test code assessing sufficient code coverage for the changes associated in the pull request"
         - path: "**/*.md"
           instructions: |
               "Assess the documentation for misspellings, grammatical errors, missing documentation and correctness"
@@ -32,4 +24,4 @@ reviews:
         base_branches:
             - "main"
 chat:
-    auto_reply: true
+    auto_reply: false


### PR DESCRIPTION
This PR:
- Disables CodeRabbit updating the PR description. Rationale: I find it to be not 100% accurate, while I expect the top of the top from a PR description. I expect it to explain why these changes should be merged, and some guidance for reviewing it, if needed. CodeRabbit lists the changes being made, but this should be already readable from the commit history.
- Disable review status, the message that CodeRabbit sends to every single PR saying that "review is in progress". Easily reduces the amount of notifications from CR in half (at least).
- Disables CodeRabbit auto replies to comments. They're never useful, they only add noise when humans are chatting under a CodeRabbit's comment.
- Removes specific instructions for the path, I think they don't do much anyway, and the code style will be enforced by actual linters.

It's not possible yet but I wish for them to add the ability to disable cringy ASCII arts (they're fun only the 1st time) and all the "tips" section in comments.