### PR TITLE
fix(wardend): handle Slinky VE during v0.6 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Consensus Breaking Changes
 
 ### Bug Fixes
+
+## [v0.6.2](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.6.2) - 2025-03-05
+
+### Bug Fixes
 * (x/act) Use constant formatting strings when wrapping errors
+* (wardend) fallback to handle Slinky vote extensions during v0.6.x upgrade
 
 ## [v0.6.1](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.6.1) - 2025-03-03
 

--- a/warden/app/oracle.go
+++ b/warden/app/oracle.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"time"
 
@@ -290,7 +289,14 @@ func (a *WardenSlinkyCodec) Decode(b []byte) (vetypes.OracleVoteExtension, error
 	var w vemanager.VoteExtensions
 
 	if err := w.Unmarshal(b); err != nil {
-		return vetypes.OracleVoteExtension{}, fmt.Errorf("failed to unmarshal vemanager.VoteExtensions: %w", err)
+		// Backwards compatibility: during the upgrade from just Slinky's VE to
+		// the new vemanager.VoteExtensions format, we saw that nodes still
+		// could receive a Slinky VE, from the blocks before the
+		// upgrade.
+		//
+		// After the upgrade to v0.6 the following line should be safe to be
+		// changed to simply return the error.
+		return a.slinkyCodec.Decode(b)
 	}
 
 	if len(w.Extensions) == 0 {

--- a/warden/x/async/keeper/abci.go
+++ b/warden/x/async/keeper/abci.go
@@ -230,7 +230,8 @@ func (k Keeper) PreBlocker() sdk.PreBlocker {
 		for _, v := range tx.ExtendedVotesInfo {
 			var w vemanager.VoteExtensions
 			if err := w.Unmarshal(v.VoteExtension); err != nil {
-				return resp, fmt.Errorf("failed to unmarshal vote extension wrapper: %w", err)
+				log.Error("ignoring vote extension, not a vemanager.VoteExtensions", "err", err)
+				return resp, nil
 			}
 
 			// todo: check VE signature, or maybe do it in the verify ve handler?


### PR DESCRIPTION
This situation happened while upgrading from v0.5 to v0.6:
* at block H the "slinky" vote extensions were submitted
* chain halted, waiting for v0.6 upgrade
* chain restarted with the new binary from block H+1, failing when trying to parse the existing "slinky" vote extensions

This commit introduces a fallback mechanism:
* x/async will ignore vote extensions that are not valid vemanager.VoteExtensions
* slinky codec will try to parse vote extensions as vemanager.VoteExtensions, fallbacking to just slinky vote extension