### PR TITLE
feat: enable more golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.jsonschema.json
+linters:
+  enable-all: true
+  disable:
+    - cyclop
+    - err113
+    - exhaustruct
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocyclo
+    - godox
+    - gomoddirectives
+    - ireturn
+    - mnd
+    - musttag
+    - nonamedreturns
+    - paralleltest
+    - protogetter # to be enabled once we start moving towards Opaque API (https://go.dev/blog/protobuf-opaque)
+    - recvcheck
+    - tagalign
+    - tenv
+    - testpackage
+    - varnamelen
+    - wrapcheck
+    
+    # the followings are linters that should be enabled but the codebase
+    # doesn't adhere to and we don't have enough time to fix them all at once
+    - containedctx
+    - contextcheck
+    - depguard
+    - dupl
+    - errname
+    - errorlint
+    - exhaustive
+    - forbidigo
+    - forcetypeassert
+    - gocognit
+    - gocritic
+    - gosec
+    - govet
+    - inamedparam
+    - lll
+    - maintidx
+    - nestif
+    - nilerr
+    - nilnil
+    - nolintlint
+    - prealloc
+    - predeclared
+    - promlinter
+    - revive
+    - stylecheck
+    - tagliatelle
+    - testifylint
+    - thelper
+    - unconvert
+    - unparam
+    - wsl
+    - zerologlint
+
+linters-settings:
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "math/rand$"
+            desc: use math/rand/v2
+          - pkg: "github.com/sirupsen/logrus"
+            desc: not allowed
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by standard lib errors package
+  exhaustive:
+    check-generated: false
+    default-signifies-exhaustive: true
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/warden-protocol) # Custom section: groups all imports with the specified Prefix.
+      - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
+    custom-order: true
+  nlreturn:
+    block-size: 10
+  revive:
+    rules:
+      - name: unused-parameter
+        disabled: true
+      - name: var-naming
+        severity: warning
+        disabled: false
+        exclude: [""]
+        arguments:
+          - ["ID", "setId"] # AllowList
+          - ["VM"] # DenyList
+  tagliatelle:
+    case:
+      rules:
+        json: snake
+        yaml: snake

--- a/cmd/faucet/faucet_test.go
+++ b/cmd/faucet/faucet_test.go
@@ -27,7 +27,7 @@ func TestConvertHexToBech32(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // Capture range variable
+		// Capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			addr, err := convertHexToBech32(tc.addr)
 			if tc.expectErr {
@@ -36,11 +36,14 @@ func TestConvertHexToBech32(t *testing.T) {
 				} else {
 					t.Logf("got expected error: %v", err)
 				}
+
 				return
 			}
+
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
+
 			if addr != tc.expected {
 				t.Errorf("expected address %q, got %q", tc.expected, addr)
 			}

--- a/cmd/faucet/main.go
+++ b/cmd/faucet/main.go
@@ -83,11 +83,14 @@ func newPage() Page {
 
 func main() {
 	e := echo.New()
+
 	logLevel, err := log.ParseLevel(config.GetLogLevel())
 	if err != nil {
 		fmt.Printf("error parsing log level: %s", err)
+
 		logLevel = log.InfoLevel
 	}
+
 	logger := log.New(
 		log.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339},
 	).Level(logLevel).With().Timestamp().Logger()
@@ -95,6 +98,7 @@ func main() {
 	if logger.GetLevel() == log.DebugLevel {
 		e.Use(middleware.Logger())
 	}
+
 	e.Use(middleware.CSRFWithConfig(middleware.CSRFConfig{
 		TokenLookup: "header:X-CSRF-Token",
 	}))
@@ -116,6 +120,7 @@ func main() {
 		Chain:                  f.config.Chain,
 		DisplayTokens:          f.config.DisplayTokens,
 	}
+
 	amount, err := strconv.Atoi(f.config.Amount)
 	if err != nil {
 		logger.Error().Msgf("error converting amount to integer: %s", err)
@@ -147,21 +152,25 @@ func main() {
 		page.Form.CSRFToken = c.Get("csrf").(string)
 		page.Form.Address = c.QueryParam("addr")
 		logger.Debug().Msgf("page.Form: %v", page.Form)
+
 		return c.Render(http.StatusOK, "index", page)
 	})
 
 	e.GET("/check-tx", func(c echo.Context) error {
 		logger.Debug().Msg("checking tx")
 		logger.Debug().Msgf("Batch: %v", f.Batch)
+
 		if len(f.Batch) == 0 {
 			page.Data.TXHash = f.LatestTXHash
 			return c.Render(http.StatusOK, "tx-result", page.Data)
 		}
+
 		return c.Render(http.StatusOK, "spinner", "")
 	})
 
 	e.POST("/send-tokens", func(c echo.Context) error {
 		var txHash string
+
 		var httpStatusCode int
 
 		reqCount.Inc()
@@ -169,18 +178,23 @@ func main() {
 		txHash, httpStatusCode, err = f.Send(c.FormValue("address"), false)
 		if err != nil {
 			logger.Error().Msgf("error sending tokens: %s", err)
+
 			formData := newFormData()
 			formData.Address = ""
 			formData.Errors["address"] = err.Error()
 
 			return c.Render(httpStatusCode, "form", formData)
 		}
+
 		if txHash != "" {
 			page.Data.TokensAvailable -= float64(amount)
 			page.Data.TokensAvailablePercent = page.Data.TokensAvailable / page.Data.TokenSupply * totalPercent
+
 			logger.Info().Msgf("txHash: %s", txHash)
+
 			return c.Render(http.StatusOK, "form", nil)
 		}
+
 		return c.Render(http.StatusOK, "tx-status", "")
 	})
 
@@ -191,6 +205,7 @@ func main() {
 		if page.Data.TokensAvailable <= 0 {
 			return c.Render(http.StatusOK, "red-cross", "")
 		}
+
 		return c.Render(http.StatusOK, "tokens-section", page.Data)
 	})
 

--- a/cmd/faucet/pkg/config/config.go
+++ b/cmd/faucet/pkg/config/config.go
@@ -46,11 +46,13 @@ func GetLogLevel() string {
 	if err != nil {
 		return "Info"
 	}
+
 	return cfg.LogLevel
 }
 
 func LoadConfig() (Config, error) {
 	cfg := Config{}
+
 	var err error
 
 	if err = env.Parse(&cfg); err != nil {
@@ -62,6 +64,7 @@ func LoadConfig() (Config, error) {
 			return Config{}, configError(err.Error())
 		}
 	}
+
 	return cfg, nil
 }
 
@@ -84,6 +87,7 @@ func loadConfigFile(cfg *Config) error {
 	viper.SetConfigType(ext)
 
 	viper.AutomaticEnv()
+
 	err = viper.ReadInConfig()
 	if err != nil {
 		return err
@@ -92,5 +96,6 @@ func loadConfigFile(cfg *Config) error {
 	if err = viper.Unmarshal(&cfg); err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/cmd/wardend/cmd/commands.go
+++ b/cmd/wardend/cmd/commands.go
@@ -4,16 +4,11 @@ import (
 	"errors"
 	"io"
 
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/cast"
-
 	"cosmossdk.io/log"
 	confixcmd "cosmossdk.io/tools/confix/cmd"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/client"
-
-	// "github.com/cosmos/cosmos-sdk/client/debug"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/pruning"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
@@ -24,17 +19,19 @@ import (
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	evmosclient "github.com/evmos/evmos/v20/client"
 	"github.com/evmos/evmos/v20/client/debug"
 	evmosserver "github.com/evmos/evmos/v20/server"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cast"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/warden-protocol/wardenprotocol/warden/app"
 )
 
@@ -92,7 +89,7 @@ func addModuleInitFlags(startCmd *cobra.Command) {
 	crisis.AddModuleInitFlags(startCmd)
 }
 
-// Analog of sdk's CommandsWithCustomMigrationMap without AddGenesisAccountCmd, that should be embeded separately
+// Analog of sdk's CommandsWithCustomMigrationMap without AddGenesisAccountCmd, that should be embedded separately.
 func CommandsWithCustomMigrationMap(txConfig client.TxConfig, moduleBasics module.BasicManager, defaultNodeHome string, migrationMap genutiltypes.MigrationMap) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "genesis",
@@ -113,13 +110,14 @@ func CommandsWithCustomMigrationMap(txConfig client.TxConfig, moduleBasics modul
 	return cmd
 }
 
-// genesisCommand builds genesis-related `wardend genesis` command. Users may provide application specific commands as a parameter
+// genesisCommand builds genesis-related `wardend genesis` command. Users may provide application specific commands as a parameter.
 func genesisCommand(txConfig client.TxConfig, basicManager module.BasicManager, cmds ...*cobra.Command) *cobra.Command {
 	cmd := CommandsWithCustomMigrationMap(txConfig, basicManager, app.DefaultNodeHome, genutilcli.MigrationMap)
 
 	for _, subCmd := range cmds {
 		cmd.AddCommand(subCmd)
 	}
+
 	return cmd
 }
 
@@ -174,7 +172,7 @@ func txCommand() *cobra.Command {
 	return cmd
 }
 
-// newApp creates the application
+// newApp creates the application.
 func newApp(
 	logger log.Logger,
 	db dbm.DB,
@@ -187,6 +185,7 @@ func newApp(
 	if cast.ToBool(appOpts.Get("telemetry.enabled")) {
 		wasmOpts = append(wasmOpts, wasmkeeper.WithVMCacheMetrics(prometheus.DefaultRegisterer))
 	}
+
 	app, err := app.New(
 		logger, db, traceStore, true,
 		appOpts,
@@ -196,6 +195,7 @@ func newApp(
 	if err != nil {
 		panic(err)
 	}
+
 	return app
 }
 

--- a/cmd/wardend/cmd/config.go
+++ b/cmd/wardend/cmd/config.go
@@ -5,7 +5,6 @@ import (
 
 	cmtcfg "github.com/cometbft/cometbft/config"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
-
 	evmservercfg "github.com/evmos/evmos/v20/server/config"
 	oracleconfig "github.com/skip-mev/slinky/oracle/config"
 

--- a/cmd/wardend/cmd/gen-accounts.go
+++ b/cmd/wardend/cmd/gen-accounts.go
@@ -3,26 +3,24 @@ package cmd
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
-
-	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/server"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authvestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
-
 	evmoskr "github.com/evmos/evmos/v20/crypto/keyring"
-
-	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	authvestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	vestingcli "github.com/evmos/evmos/v20/x/vesting/client/cli"
 	vestingtypes "github.com/evmos/evmos/v20/x/vesting/types"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -111,7 +109,7 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 				// Get funder addr which can perform clawback
 				funderStr, err := cmd.Flags().GetString(vestingcli.FlagFunder)
 				if err != nil {
-					return fmt.Errorf("must specify the clawback vesting account funder with the --funder flag")
+					return errors.New("must specify the clawback vesting account funder with the --funder flag")
 				}
 				funder, err := sdktypes.AccAddressFromBech32(funderStr)
 				if err != nil {
@@ -256,6 +254,7 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 			}
 
 			genDoc.AppState = appStateJSON
+
 			return genutil.ExportGenesisFile(genDoc, genFile)
 		},
 	}

--- a/cmd/wardend/cmd/gen-commands.go
+++ b/cmd/wardend/cmd/gen-commands.go
@@ -17,6 +17,7 @@ func setupGenCommand(cmd *cobra.Command) (codec.Codec, string) {
 	serverCtx := server.GetServerContextFromCmd(cmd)
 	config := serverCtx.Config
 	config.SetRoot(clientCtx.HomeDir)
+
 	return clientCtx.Codec, config.GenesisFile()
 }
 
@@ -36,5 +37,6 @@ func updateGenesisState(genesisFileURL string, fn func(appState map[string]json.
 	}
 
 	appGenesis.AppState = appStateJSON
+
 	return genutil.ExportGenesisFile(appGenesis, genesisFileURL)
 }

--- a/cmd/wardend/cmd/gen-keychains.go
+++ b/cmd/wardend/cmd/gen-keychains.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/cmd/wardend/cmd/gen-slinky-markets.go
+++ b/cmd/wardend/cmd/gen-slinky-markets.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/spf13/cobra"
-
 	"github.com/skip-mev/slinky/cmd/constants/marketmaps"
 	marketmaptypes "github.com/skip-mev/slinky/x/marketmap/types"
 	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
+	"github.com/spf13/cobra"
 )
 
 func AddGenesisSlinkyMarketsCmd(defaultNodeHome string) *cobra.Command {

--- a/cmd/wardend/cmd/gen-spaces.go
+++ b/cmd/wardend/cmd/gen-spaces.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/cmd/wardend/cmd/root.go
+++ b/cmd/wardend/cmd/root.go
@@ -21,10 +21,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 	txmodule "github.com/cosmos/cosmos-sdk/x/auth/tx/config"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	evmoskr "github.com/evmos/evmos/v20/crypto/keyring"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	evmoskr "github.com/evmos/evmos/v20/crypto/keyring"
 	"github.com/warden-protocol/wardenprotocol/warden/app"
 )
 
@@ -109,6 +109,7 @@ func NewRootCmd() *cobra.Command {
 		moduleBasicManager[name] = module.CoreAppModuleBasicAdaptor(name, mod)
 		autoCliOpts.Modules[name] = mod
 	}
+
 	initRootCmd(rootCmd, clientCtx.TxConfig, clientCtx.InterfaceRegistry, clientCtx.Codec, moduleBasicManager)
 
 	overwriteFlagDefaults(rootCmd, map[string]string{
@@ -136,6 +137,7 @@ func overwriteFlagDefaults(c *cobra.Command, defaults map[string]string) {
 		set(c.Flags(), key, val)
 		set(c.PersistentFlags(), key, val)
 	}
+
 	for _, c := range c.Commands() {
 		overwriteFlagDefaults(c, defaults)
 	}

--- a/cmd/wardend/cmd/wait.go
+++ b/cmd/wardend/cmd/wait.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -12,13 +13,13 @@ import (
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	tmtypes "github.com/cometbft/cometbft/types"
-	"github.com/spf13/cobra"
-	"github.com/warden-protocol/wardenprotocol/warden/app"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/errors"
+	xerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/warden-protocol/wardenprotocol/warden/app"
 )
 
 const TimeoutFlag = "timeout"
@@ -179,8 +180,9 @@ $ %[1]sd tx [flags] | %[1]sd q wait-tx
 					return clientCtx.PrintProto(newResponseFormatBroadcastTxCommit(res))
 				}
 			case <-ctx.Done():
-				return errors.ErrLogic.Wrapf("timed out waiting for transaction %X to be included in a block", hash)
+				return xerrors.ErrLogic.Wrapf("timed out waiting for transaction %X to be included in a block", hash)
 			}
+
 			return nil
 		},
 	}
@@ -206,5 +208,6 @@ func parseHashFromInput(in []byte) ([]byte, error) {
 			return hex.DecodeString(hash)
 		}
 	}
-	return nil, fmt.Errorf("txhash not found")
+
+	return nil, errors.New("txhash not found")
 }

--- a/precompiles/act/act.go
+++ b/precompiles/act/act.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"cosmossdk.io/log"
-
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -157,6 +156,7 @@ func (p *Precompile) IsTransaction(method string) bool {
 		TemplateByIdQuery:
 		return false
 	}
+
 	panic(fmt.Errorf("act precompile: method not exists: %s", method))
 }
 

--- a/precompiles/act/events.go
+++ b/precompiles/act/events.go
@@ -2,7 +2,7 @@ package act
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"reflect"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -27,7 +27,7 @@ const (
 	EventActionStateChange = "ActionStateChange"
 )
 
-// Map EventCreateTemplate to eth CreateTemplate event and write to eth log
+// Map EventCreateTemplate to eth CreateTemplate event and write to eth log.
 func (p *Precompile) GetCreateTemplateEvent(ctx sdk.Context, writerAddress *ethcmn.Address, sdkEvent sdk.Event) (*ethtypes.Log, error) {
 	b, err := parseCreateTemplateEvent(sdkEvent)
 	if err != nil {
@@ -35,7 +35,7 @@ func (p *Precompile) GetCreateTemplateEvent(ctx sdk.Context, writerAddress *ethc
 	}
 
 	if writerAddress == nil {
-		return nil, fmt.Errorf("writerAddress is nil")
+		return nil, errors.New("writerAddress is nil")
 	}
 
 	topics := make([]ethcmn.Hash, 2)
@@ -62,6 +62,7 @@ func parseCreateTemplateEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 	var b bytes.Buffer
 
 	typedEvent := v1beta1.EventCreateTemplate{}
+
 	err := common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge)
 	if err != nil {
 		return nil, err
@@ -72,7 +73,7 @@ func parseCreateTemplateEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 	return &b, nil
 }
 
-// Map EventUpdateTemplate to eth UpdateTemplate event and write to eth log
+// Map EventUpdateTemplate to eth UpdateTemplate event and write to eth log.
 func (p *Precompile) GetUpdateTemplateEvent(ctx sdk.Context, writerAddress *ethcmn.Address, sdkEvent sdk.Event) (*ethtypes.Log, error) {
 	b, err := parseUpdateTemplateEvent(sdkEvent)
 	if err != nil {
@@ -80,7 +81,7 @@ func (p *Precompile) GetUpdateTemplateEvent(ctx sdk.Context, writerAddress *ethc
 	}
 
 	if writerAddress == nil {
-		return nil, fmt.Errorf("writerAddress is nil")
+		return nil, errors.New("writerAddress is nil")
 	}
 
 	topics := make([]ethcmn.Hash, 2)
@@ -107,6 +108,7 @@ func parseUpdateTemplateEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 	var b bytes.Buffer
 
 	typedEvent := v1beta1.EventUpdateTemplate{}
+
 	err := common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge)
 	if err != nil {
 		return nil, err
@@ -117,7 +119,7 @@ func parseUpdateTemplateEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 	return &b, nil
 }
 
-// Map EventCreateAction to eth CreateAction event and write to eth log
+// Map EventCreateAction to eth CreateAction event and write to eth log.
 func (p *Precompile) GetCreateActionEvent(ctx sdk.Context, writerAddress *ethcmn.Address, sdkEvent sdk.Event) (*ethtypes.Log, error) {
 	b, err := parseCreateActionEvent(sdkEvent)
 	if err != nil {
@@ -125,7 +127,7 @@ func (p *Precompile) GetCreateActionEvent(ctx sdk.Context, writerAddress *ethcmn
 	}
 
 	if writerAddress == nil {
-		return nil, fmt.Errorf("writerAddress is nil")
+		return nil, errors.New("writerAddress is nil")
 	}
 
 	topics := make([]ethcmn.Hash, 2)
@@ -152,6 +154,7 @@ func parseCreateActionEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 	var b bytes.Buffer
 
 	typedEvent := v1beta1.EventCreateAction{}
+
 	err := common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge)
 	if err != nil {
 		return nil, err
@@ -162,7 +165,7 @@ func parseCreateActionEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 	return &b, nil
 }
 
-// Map EventActionVoted to eth ActionVoted event and write to eth log
+// Map EventActionVoted to eth ActionVoted event and write to eth log.
 func (p *Precompile) GetActionVotedEvent(ctx sdk.Context, writerAddress *ethcmn.Address, sdkEvent sdk.Event) (*ethtypes.Log, error) {
 	b, err := parseActionVotedEvent(sdkEvent)
 	if err != nil {
@@ -170,7 +173,7 @@ func (p *Precompile) GetActionVotedEvent(ctx sdk.Context, writerAddress *ethcmn.
 	}
 
 	if writerAddress == nil {
-		return nil, fmt.Errorf("writerAddress is nil")
+		return nil, errors.New("writerAddress is nil")
 	}
 
 	topics := make([]ethcmn.Hash, 2)
@@ -197,6 +200,7 @@ func parseActionVotedEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 	var b bytes.Buffer
 
 	typedEvent := v1beta1.EventActionVoted{}
+
 	err := common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge)
 	if err != nil {
 		return nil, err
@@ -208,7 +212,7 @@ func parseActionVotedEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 	return &b, nil
 }
 
-// Map EventActionStateChange to eth ActionStateChange event and write to eth log
+// Map EventActionStateChange to eth ActionStateChange event and write to eth log.
 func (p *Precompile) GetActionStateChangeEvent(ctx sdk.Context, writerAddress *ethcmn.Address, sdkEvent sdk.Event) (*ethtypes.Log, error) {
 	b, err := parseActionStateChangeEvent(sdkEvent)
 	if err != nil {
@@ -216,7 +220,7 @@ func (p *Precompile) GetActionStateChangeEvent(ctx sdk.Context, writerAddress *e
 	}
 
 	if writerAddress == nil {
-		return nil, fmt.Errorf("writerAddress is nil")
+		return nil, errors.New("writerAddress is nil")
 	}
 
 	topics := make([]ethcmn.Hash, 2)
@@ -243,6 +247,7 @@ func parseActionStateChangeEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 	var b bytes.Buffer
 
 	typedEvent := v1beta1.EventActionStateChange{}
+
 	err := common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge)
 	if err != nil {
 		return nil, err

--- a/precompiles/act/query.go
+++ b/precompiles/act/query.go
@@ -1,11 +1,12 @@
 package act
 
 import (
+	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/evmos/evmos/v20/x/evm/core/vm"
 
 	precommon "github.com/warden-protocol/wardenprotocol/precompiles/common"
@@ -36,8 +37,9 @@ func (p *Precompile) ActionsQuery(
 	if err != nil {
 		return nil, err
 	}
+
 	if res == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(ActionsResponse).FromResponse(res)
@@ -81,8 +83,9 @@ func (p *Precompile) ActionByIdQuery(
 	if err != nil {
 		return nil, err
 	}
+
 	if res == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(ActionByIdResponse).FromResponse(res)
@@ -124,8 +127,9 @@ func (p *Precompile) ActionsByAddressQuery(
 	if err != nil {
 		return nil, err
 	}
+
 	if res == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(ActionsByAddressResponse).FromResponse(res)
@@ -175,8 +179,9 @@ func (p *Precompile) TemplatesQuery(
 	if err != nil {
 		return nil, err
 	}
+
 	if res == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(TemplatesResponse).FromResponse(res)
@@ -228,8 +233,9 @@ func (p *Precompile) TemplateByIdQuery(
 	if err != nil {
 		return nil, err
 	}
+
 	if res == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(TemplateByIdResponse).FromResponse(res)

--- a/precompiles/act/tx.go
+++ b/precompiles/act/tx.go
@@ -22,7 +22,7 @@ const (
 	VoteForActionMethod  = "voteForAction"
 )
 
-// CheckActionMethod constructs MsgCheckAction from args, passes it to msg server and packs corresponding abi output
+// CheckActionMethod constructs MsgCheckAction from args, passes it to msg server and packs corresponding abi output.
 func (p *Precompile) CheckActionMethod(
 	ctx sdk.Context,
 	origin common.Address,
@@ -33,7 +33,6 @@ func (p *Precompile) CheckActionMethod(
 	msgServer := actmodulekeeper.NewMsgServerImpl(p.actmodulekeeper)
 
 	message, err := newMsgCheckAction(args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +84,6 @@ func (p *Precompile) NewTemplateMethod(
 	msgServer := actmodulekeeper.NewMsgServerImpl(p.actmodulekeeper)
 
 	message, err := newMsgNewTemplate(args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +141,6 @@ func (p *Precompile) RevokeActionMethod(
 	msgServer := actmodulekeeper.NewMsgServerImpl(p.actmodulekeeper)
 
 	message, err := newMsgRevokeAction(args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +192,6 @@ func (p *Precompile) UpdateTemplateMethod(
 	msgServer := actmodulekeeper.NewMsgServerImpl(p.actmodulekeeper)
 
 	message, err := newMsgUpdateTemplate(args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +256,6 @@ func (p *Precompile) VoteForActionMethod(
 	msgServer := actmodulekeeper.NewMsgServerImpl(p.actmodulekeeper)
 
 	message, err := newMsgVoteForAction(args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -321,8 +316,8 @@ func (p Precompile) tryVoteAsSender(
 	ctx sdk.Context,
 	msgServer v1beta1.MsgServer,
 	actionId uint64,
-	caller common.Address) error {
-
+	caller common.Address,
+) error {
 	actionResponse, err := p.queryServer.ActionById(ctx, &v1beta1.QueryActionByIdRequest{
 		Id: actionId,
 	})

--- a/precompiles/act/types.go
+++ b/precompiles/act/types.go
@@ -13,15 +13,16 @@ import (
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
-// ActionsInput needed to unmarshal Pagination field and pass it to types.QueryActionsRequest
+// ActionsInput needed to unmarshal Pagination field and pass it to types.QueryActionsRequest.
 type ActionsInput struct {
 	Pagination query.PageRequest `abi:"pagination"`
 }
 
-// FromResponse needed to map QueryActionsResponse to ActionsResponse
+// FromResponse needed to map QueryActionsResponse to ActionsResponse.
 func (r *ActionsResponse) FromResponse(res *types.QueryActionsResponse) (ActionsResponse, error) {
 	if res != nil {
 		actions := make([]Action, 0, len(res.Actions))
+
 		for _, action := range res.Actions {
 			mappedAction, err := mapAction(action)
 			if err != nil {
@@ -38,7 +39,7 @@ func (r *ActionsResponse) FromResponse(res *types.QueryActionsResponse) (Actions
 	return *r, nil
 }
 
-// FromResponse needed to map QueryActionByIdResponse to ActionByIdResponse
+// FromResponse needed to map QueryActionByIdResponse to ActionByIdResponse.
 func (r *ActionByIdResponse) FromResponse(res *types.QueryActionByIdResponse) (ActionByIdResponse, error) {
 	if res != nil && res.Action != nil {
 		mappedAction, err := mapAction(*res.Action)
@@ -52,17 +53,18 @@ func (r *ActionByIdResponse) FromResponse(res *types.QueryActionByIdResponse) (A
 	return *r, nil
 }
 
-// ActionsByAddressInput needed to unmarshal Pagination field and pass it to types.QueryActionsByAddressRequest
+// ActionsByAddressInput needed to unmarshal Pagination field and pass it to types.QueryActionsByAddressRequest.
 type ActionsByAddressInput struct {
 	Pagination query.PageRequest `abi:"pagination"`
 	Address    common.Address    `abi:"addr"`
 	Status     uint8             `abi:"status"`
 }
 
-// FromResponse needed to map QueryActionsByAddressResponse to ActionsByAddressResponse
+// FromResponse needed to map QueryActionsByAddressResponse to ActionsByAddressResponse.
 func (r *ActionsByAddressResponse) FromResponse(res *types.QueryActionsByAddressResponse) (ActionsByAddressResponse, error) {
 	if res != nil {
 		actions := make([]Action, 0, len(res.Actions))
+
 		for _, action := range res.Actions {
 			mappedAction, err := mapAction(action)
 			if err != nil {
@@ -79,16 +81,17 @@ func (r *ActionsByAddressResponse) FromResponse(res *types.QueryActionsByAddress
 	return *r, nil
 }
 
-// TemplatesInput needed to unmarshal Pagination field and pass it to types.QueryTemplatesRequest
+// TemplatesInput needed to unmarshal Pagination field and pass it to types.QueryTemplatesRequest.
 type TemplatesInput struct {
 	Pagination query.PageRequest `abi:"pagination"`
 	Creator    common.Address    `abi:"creator"`
 }
 
-// FromResponse needed to map QueryTemplatesResponse to TemplatesResponse
+// FromResponse needed to map QueryTemplatesResponse to TemplatesResponse.
 func (r *TemplatesResponse) FromResponse(res *types.QueryTemplatesResponse) (TemplatesResponse, error) {
 	if res != nil {
 		templates := make([]Template, 0, len(res.Templates))
+
 		for _, action := range res.Templates {
 			mappedTemplate, err := mapTemplate(action)
 			if err != nil {
@@ -105,7 +108,7 @@ func (r *TemplatesResponse) FromResponse(res *types.QueryTemplatesResponse) (Tem
 	return *r, nil
 }
 
-// FromResponse needed to map QueryTemplateByIdResponse to TemplateByIdResponse
+// FromResponse needed to map QueryTemplateByIdResponse to TemplateByIdResponse.
 func (r *TemplateByIdResponse) FromResponse(res *types.QueryTemplateByIdResponse) (TemplateByIdResponse, error) {
 	if res != nil && res.Template != nil {
 		mappedTemplate, err := mapTemplate(*res.Template)
@@ -121,6 +124,7 @@ func (r *TemplateByIdResponse) FromResponse(res *types.QueryTemplateByIdResponse
 
 func mapAction(action types.Action) (Action, error) {
 	mentions := make([]common.Address, 0, len(action.Mentions))
+
 	for _, mention := range action.Mentions {
 		mentionAddress, err := precommon.AddressFromBech32Str(mention)
 		if err != nil {
@@ -168,6 +172,7 @@ func mapAction(action types.Action) (Action, error) {
 
 func mapVotes(values []*types.ActionVote) ([]ActionVote, error) {
 	result := make([]ActionVote, 0, len(values))
+
 	for _, v := range values {
 		if v != nil {
 			mappedTemplate, err := mapVote(*v)
@@ -178,12 +183,12 @@ func mapVotes(values []*types.ActionVote) ([]ActionVote, error) {
 			result = append(result, mappedTemplate)
 		}
 	}
+
 	return result, nil
 }
 
 func mapVote(value types.ActionVote) (ActionVote, error) {
 	participant, err := precommon.AddressFromBech32Str(value.Participant)
-
 	if err != nil {
 		return ActionVote{}, err
 	}
@@ -197,7 +202,6 @@ func mapVote(value types.ActionVote) (ActionVote, error) {
 
 func mapTemplate(value types.Template) (Template, error) {
 	creator, err := precommon.AddressFromBech32Str(value.Creator)
-
 	if err != nil {
 		return Template{}, err
 	}

--- a/precompiles/async/async.go
+++ b/precompiles/async/async.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"cosmossdk.io/log"
-
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -139,6 +138,7 @@ func (p *Precompile) IsTransaction(method string) bool {
 		PendingFuturesMethod:
 		return false
 	}
+
 	panic(fmt.Errorf("async precompile: method not exists: %s", method))
 }
 

--- a/precompiles/async/events.go
+++ b/precompiles/async/events.go
@@ -2,10 +2,9 @@ package async
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	ethcmn "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	evmoscmn "github.com/evmos/evmos/v20/precompiles/common"
-
-	ethcmn "github.com/ethereum/go-ethereum/common"
 
 	"github.com/warden-protocol/wardenprotocol/precompiles/common"
 	"github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
@@ -16,9 +15,10 @@ const (
 	EventCreateFuture = "CreateFuture"
 )
 
-// GetCreateFutureEvent Map EventCreateFuture to eth CreateFuture event and write to eth log
+// GetCreateFutureEvent Map EventCreateFuture to eth CreateFuture event and write to eth log.
 func (p *Precompile) GetCreateFutureEvent(ctx sdk.Context, writerAddress *ethcmn.Address, sdkEvent sdk.Event) (*ethtypes.Log, error) {
 	var err error
+
 	event := p.ABI.Events[EventCreateFuture]
 
 	topics := make([]ethcmn.Hash, 3)

--- a/precompiles/async/query.go
+++ b/precompiles/async/query.go
@@ -1,15 +1,16 @@
 package async
 
 import (
+	"errors"
 	"fmt"
-
-	wardencommon "github.com/warden-protocol/wardenprotocol/precompiles/common"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+
+	wardencommon "github.com/warden-protocol/wardenprotocol/precompiles/common"
+	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
 
 const (
@@ -33,8 +34,9 @@ func (p Precompile) FutureByIdMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(FutureByIdResponse).FromResponse(response)
@@ -79,8 +81,9 @@ func (p Precompile) FuturesMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(FuturesResponse).FromResponse(response)
@@ -134,8 +137,9 @@ func (p Precompile) PendingFuturesMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(PendingFuturesResponse).FromResponse(response)

--- a/precompiles/async/tx.go
+++ b/precompiles/async/tx.go
@@ -27,7 +27,6 @@ func (p *Precompile) AddFutureMethod(
 ) ([]byte, error) {
 	msgServer := actmodulekeeper.NewMsgServerImpl(p.asyncmodulekeeper)
 	message, err := newMsgAddFuture(args, origin, method)
-
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/async/types.go
+++ b/precompiles/async/types.go
@@ -10,16 +10,17 @@ import (
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
 
-// FuturesInput needed to unmarshal Pagination field and pass it to types.QueryFuturesRequest
+// FuturesInput needed to unmarshal Pagination field and pass it to types.QueryFuturesRequest.
 type FuturesInput struct {
 	Pagination query.PageRequest `abi:"pagination"`
 	Creator    common.Address    `abi:"creator"`
 }
 
-// FromResponse needed to map QueryFuturesResponse to FuturesResponse
+// FromResponse needed to map QueryFuturesResponse to FuturesResponse.
 func (r *FuturesResponse) FromResponse(res *types.QueryFuturesResponse) (FuturesResponse, error) {
 	if res != nil {
 		futures := make([]FutureResponse, 0, len(res.Futures))
+
 		for _, future := range res.Futures {
 			mappedFuture, err := mapFutureResponse(future)
 			if err != nil {
@@ -36,10 +37,11 @@ func (r *FuturesResponse) FromResponse(res *types.QueryFuturesResponse) (Futures
 	return *r, nil
 }
 
-// FromResponse needed to map QueryPendingFuturesResponse to PendingFuturesResponse
+// FromResponse needed to map QueryPendingFuturesResponse to PendingFuturesResponse.
 func (r *PendingFuturesResponse) FromResponse(res *types.QueryPendingFuturesResponse) (PendingFuturesResponse, error) {
 	if res != nil {
 		futures := make([]Future, 0, len(res.Futures))
+
 		for _, future := range res.Futures {
 			mappedFuture, err := mapFuture(future)
 			if err != nil {
@@ -56,7 +58,7 @@ func (r *PendingFuturesResponse) FromResponse(res *types.QueryPendingFuturesResp
 	return *r, nil
 }
 
-// FromResponse needed to map QueryFutureByIdResponse to FutureByIdResponse
+// FromResponse needed to map QueryFutureByIdResponse to FutureByIdResponse.
 func (r *FutureByIdResponse) FromResponse(res *types.QueryFutureByIdResponse) (FutureByIdResponse, error) {
 	if res != nil {
 		mappedFutureResponse, err := mapFutureResponse(res.FutureResponse)
@@ -109,6 +111,7 @@ func mapFutureResponse(futureResponse types.FutureResponse) (FutureResponse, err
 
 func mapVotes(values []types.FutureVote) ([]FutureVote, error) {
 	result := make([]FutureVote, 0, len(values))
+
 	for _, v := range values {
 		mappedTemplate, err := mapVote(v)
 		if err != nil {
@@ -117,6 +120,7 @@ func mapVotes(values []types.FutureVote) ([]FutureVote, error) {
 
 		result = append(result, mappedTemplate)
 	}
+
 	return result, nil
 }
 

--- a/precompiles/common/address.go
+++ b/precompiles/common/address.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// Bech32StrFromAddress Creates bech32 address string from eth address
+// Bech32StrFromAddress Creates bech32 address string from eth address.
 func Bech32StrFromAddress(address common.Address) string {
 	return sdk.AccAddress(address.Bytes()).String()
 }
@@ -14,7 +14,7 @@ func Bech32StrFromBytes(address []byte) string {
 	return sdk.AccAddress(address).String()
 }
 
-// AddressFromBech32Str Creates eth address from bech32 address string
+// AddressFromBech32Str Creates eth address from bech32 address string.
 func AddressFromBech32Str(address string) (common.Address, error) {
 	accAddress, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
@@ -24,7 +24,7 @@ func AddressFromBech32Str(address string) (common.Address, error) {
 	return common.BytesToAddress(accAddress.Bytes()), nil
 }
 
-// AddressesFromBech32StrItemArray tries to create a slice of common.Address values from arbitrary slice
+// AddressesFromBech32StrItemArray tries to create a slice of common.Address values from arbitrary slice.
 func AddressesFromBech32StrItemArray[T any](items []T, addressFunc func(T) string) ([]common.Address, error) {
 	ethAddresses := make([]common.Address, 0, len(items))
 
@@ -40,7 +40,7 @@ func AddressesFromBech32StrItemArray[T any](items []T, addressFunc func(T) strin
 	return ethAddresses, nil
 }
 
-// AddressesFromBech32StrArray tries to create a slice of common.Address values from a string slice
+// AddressesFromBech32StrArray tries to create a slice of common.Address values from a string slice.
 func AddressesFromBech32StrArray(items []string) ([]common.Address, error) {
 	id := func(i string) string {
 		return i

--- a/precompiles/common/eventsRegisty.go
+++ b/precompiles/common/eventsRegisty.go
@@ -7,20 +7,20 @@ import (
 	"github.com/evmos/evmos/v20/x/evm/core/vm"
 )
 
-// EthEventsRegistry maps sdk.Event types to functions that construct and write to log corresponding eth events
+// EthEventsRegistry maps sdk.Event types to functions that construct and write to log corresponding eth events.
 type EthEventsRegistry struct {
 	p map[string]EthEventProvider
 }
 
-// EthEventProvider an event provider func definition
+// EthEventProvider an event provider func definition.
 type EthEventProvider func(sdk.Context, *ethcmn.Address, sdk.Event) (*ethtypes.Log, error)
 
-// RegisterEvent registers a provider for eventType
+// RegisterEvent registers a provider for eventType.
 func (r *EthEventsRegistry) RegisterEvent(eventType string, ethEventProvider EthEventProvider) {
 	r.p[eventType] = ethEventProvider
 }
 
-// getEventProvider returns a provider for a registered event type
+// getEventProvider returns a provider for a registered event type.
 func (r *EthEventsRegistry) getEventProvider(eventType string) EthEventProvider {
 	if provider, ok := r.p[eventType]; ok {
 		return provider
@@ -35,7 +35,7 @@ func NewEthEventsRegistry() *EthEventsRegistry {
 	}
 }
 
-// EmitEvents iterates through current transaction sdk events and writes eth event to log if sdk event registered in events registry
+// EmitEvents iterates through current transaction sdk events and writes eth event to log if sdk event registered in events registry.
 func (r *EthEventsRegistry) EmitEvents(ctx sdk.Context, stateDB vm.StateDB, address *ethcmn.Address) error {
 	for _, x := range ctx.EventManager().Events() {
 		if provider := r.getEventProvider(x.Type); provider != nil {
@@ -43,6 +43,7 @@ func (r *EthEventsRegistry) EmitEvents(ctx sdk.Context, stateDB vm.StateDB, addr
 			if err != nil {
 				return err
 			}
+
 			if log != nil {
 				stateDB.AddLog(log)
 			}

--- a/precompiles/precompiles.go
+++ b/precompiles/precompiles.go
@@ -15,12 +15,13 @@ import (
 	wardenkeeper "github.com/warden-protocol/wardenprotocol/warden/x/warden/keeper"
 )
 
-// Single point of all wardenprotocol precompiles initialization, including precompiles and events registry
+// Single point of all wardenprotocol precompiles initialization, including precompiles and events registry.
 func NewWardenPrecompiles(
 	wardenkeeper wardenkeeper.Keeper,
 	actkeeper actkeeper.Keeper,
 	oraclekeeper oraclekeeper.Keeper,
-	asynckeeper asynckeeper.Keeper) (map[ethcmn.Address]vm.PrecompiledContract, error) {
+	asynckeeper asynckeeper.Keeper,
+) (map[ethcmn.Address]vm.PrecompiledContract, error) {
 	precompiles := make(map[ethcmn.Address]vm.PrecompiledContract)
 	eventsRegistry := cmn.NewEthEventsRegistry()
 
@@ -28,6 +29,7 @@ func NewWardenPrecompiles(
 	if err != nil {
 		return nil, err
 	}
+
 	precompiles[newActPrecompile.Address()] = newActPrecompile
 
 	eventsRegistry.RegisterEvent("warden.act.v1beta1.EventActionStateChange", newActPrecompile.GetActionStateChangeEvent)
@@ -40,6 +42,7 @@ func NewWardenPrecompiles(
 	if err != nil {
 		return nil, err
 	}
+
 	precompiles[newWardenPrecompile.Address()] = newWardenPrecompile
 
 	eventsRegistry.RegisterEvent("warden.warden.v1beta3.EventAddKeychainAdmin", newWardenPrecompile.GetAddKeychainAdminEvent)
@@ -63,12 +66,14 @@ func NewWardenPrecompiles(
 	if err != nil {
 		return nil, err
 	}
+
 	precompiles[newSlinkyPrecompile.Address()] = newSlinkyPrecompile
 
 	newAsyncPrecompile, err := asyncprecompile.NewPrecompile(asynckeeper, eventsRegistry)
 	if err != nil {
 		return nil, err
 	}
+
 	precompiles[newAsyncPrecompile.Address()] = newAsyncPrecompile
 
 	eventsRegistry.RegisterEvent("warden.async.v1beta1.EventCreateFuture", newAsyncPrecompile.GetCreateFutureEvent)

--- a/precompiles/slinky/query.go
+++ b/precompiles/slinky/query.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
-
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
 
@@ -37,8 +36,9 @@ func (p Precompile) GetPriceQuery(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(GetPriceResponse).FromResponse(response)
@@ -80,6 +80,7 @@ func newGetPriceRequest(method *abi.Method, args []interface{}) (*oracletypes.Ge
 		Base  string
 		Quote string
 	}
+
 	if err := method.Inputs.Copy(&input, args); err != nil {
 		return nil, fmt.Errorf("failed to unpack arguments into get price input: %w", err)
 	}

--- a/precompiles/slinky/slinky.go
+++ b/precompiles/slinky/slinky.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evmos/evmos/v20/x/evm/core/vm"
 	oraclekeeper "github.com/skip-mev/slinky/x/oracle/keeper"
 	types "github.com/skip-mev/slinky/x/oracle/types"
+
 	precommon "github.com/warden-protocol/wardenprotocol/precompiles/common"
 )
 
@@ -42,7 +43,8 @@ func LoadABI() (abi.ABI, error) {
 
 func NewPrecompile(
 	oraclekee oraclekeeper.Keeper,
-	eventRegistry *precommon.EthEventsRegistry) (*Precompile, error) {
+	eventRegistry *precommon.EthEventsRegistry,
+) (*Precompile, error) {
 	abi, err := LoadABI()
 	if err != nil {
 		return nil, err

--- a/precompiles/warden/events.go
+++ b/precompiles/warden/events.go
@@ -2,7 +2,7 @@ package warden
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"reflect"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -50,13 +50,13 @@ const (
 	EventUpdateSpace = "UpdateSpace"
 )
 
-// GetAddKeychainAdminEvent maps EventAddKeychainAdmin to eth AddKeychainAdmin event and write to eth log
+// GetAddKeychainAdminEvent maps EventAddKeychainAdmin to eth AddKeychainAdmin event and write to eth log.
 func (p Precompile) GetAddKeychainAdminEvent(ctx sdk.Context, adminAddress *common.Address, eventAddKeychainAdmin sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
 	event := p.ABI.Events[EventTypeAddKeychainAdmin]
 
 	if adminAddress == nil {
-		return nil, fmt.Errorf("adminAddress is nil")
+		return nil, errors.New("adminAddress is nil")
 	}
 
 	topics := make([]common.Hash, 2)
@@ -79,7 +79,6 @@ func (p Precompile) GetAddKeychainAdminEvent(ctx sdk.Context, adminAddress *comm
 	b.Write(evmoscmn.PackNum(reflect.ValueOf(typedEvent.GetAdminsCount())))
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -94,13 +93,13 @@ func (p Precompile) GetAddKeychainAdminEvent(ctx sdk.Context, adminAddress *comm
 	return &log, nil
 }
 
-// GetAddKeychainWriterEvent maps EventAddKeychainWriter to eth AddKeychainWriter event and write to eth log
+// GetAddKeychainWriterEvent maps EventAddKeychainWriter to eth AddKeychainWriter event and write to eth log.
 func (p Precompile) GetAddKeychainWriterEvent(ctx sdk.Context, writerAddress *common.Address, eventAddKeychainWriter sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
 	event := p.ABI.Events[EventTypeAddKeychainWriter]
 
 	if writerAddress == nil {
-		return nil, fmt.Errorf("writerAddress is nil")
+		return nil, errors.New("writerAddress is nil")
 	}
 
 	topics := make([]common.Hash, 2)
@@ -123,7 +122,6 @@ func (p Precompile) GetAddKeychainWriterEvent(ctx sdk.Context, writerAddress *co
 	b.Write(evmoscmn.PackNum(reflect.ValueOf(typedEvent.GetWritersCount())))
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +136,7 @@ func (p Precompile) GetAddKeychainWriterEvent(ctx sdk.Context, writerAddress *co
 	return &log, nil
 }
 
-// GetNewKeyEvent maps EventNewKey to eth NewKey event and write to eth log
+// GetNewKeyEvent maps EventNewKey to eth NewKey event and write to eth log.
 func (p Precompile) GetNewKeyEvent(ctx sdk.Context, _ *common.Address, eventNewKey sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
 	event := p.ABI.Events[EventTypeNewKey]
@@ -159,13 +157,11 @@ func (p Precompile) GetNewKeyEvent(ctx sdk.Context, _ *common.Address, eventNewK
 		typedEvent.GetApproveTemplateId(),
 		typedEvent.GetRejectTemplateId(),
 	)
-
 	if err != nil {
 		return nil, err
 	}
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +176,7 @@ func (p Precompile) GetNewKeyEvent(ctx sdk.Context, _ *common.Address, eventNewK
 	return &log, nil
 }
 
-// GetRejectKeyRequestEvent maps EventRejectKeyRequest to eth RejectKeyRequest event and write to eth log
+// GetRejectKeyRequestEvent maps EventRejectKeyRequest to eth RejectKeyRequest event and write to eth log.
 func (p Precompile) GetRejectKeyRequestEvent(ctx sdk.Context, _ *common.Address, eventRejectKeyRequest sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
 	event := p.ABI.Events[EventRejectKeyRequest]
@@ -196,7 +192,6 @@ func (p Precompile) GetRejectKeyRequestEvent(ctx sdk.Context, _ *common.Address,
 
 	var err error
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +206,7 @@ func (p Precompile) GetRejectKeyRequestEvent(ctx sdk.Context, _ *common.Address,
 	return &log, nil
 }
 
-// GetFulfilSignRequestEvent maps EventFulfilSignRequest to eth FulfilSignRequest event and write to eth log
+// GetFulfilSignRequestEvent maps EventFulfilSignRequest to eth FulfilSignRequest event and write to eth log.
 func (p Precompile) GetFulfilSignRequestEvent(ctx sdk.Context, _ *common.Address, eventFulfilSignRequest sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
 	event := p.ABI.Events[EventFulfilSignRequest]
@@ -227,7 +222,6 @@ func (p Precompile) GetFulfilSignRequestEvent(ctx sdk.Context, _ *common.Address
 
 	var err error
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +236,7 @@ func (p Precompile) GetFulfilSignRequestEvent(ctx sdk.Context, _ *common.Address
 	return &log, nil
 }
 
-// GetRejectSignRequestEvent maps EventRejectSignRequest to eth RejectSignRequest event and write to eth log
+// GetRejectSignRequestEvent maps EventRejectSignRequest to eth RejectSignRequest event and write to eth log.
 func (p Precompile) GetRejectSignRequestEvent(ctx sdk.Context, _ *common.Address, eventRejectSignRequest sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
 	event := p.ABI.Events[EventRejectSignRequest]
@@ -258,7 +252,6 @@ func (p Precompile) GetRejectSignRequestEvent(ctx sdk.Context, _ *common.Address
 
 	var err error
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -273,14 +266,14 @@ func (p Precompile) GetRejectSignRequestEvent(ctx sdk.Context, _ *common.Address
 	return &log, nil
 }
 
-// GetNewKeychainEvent maps EventNewKeychain to eth NewKeychain event and write to eth log
+// GetNewKeychainEvent maps EventNewKeychain to eth NewKeychain event and write to eth log.
 func (p Precompile) GetNewKeychainEvent(ctx sdk.Context, creator *common.Address, eventNewKeychain sdk.Event) (*ethtypes.Log, error) {
 	var err error
 	// Prepare the event topics
 	event := p.ABI.Events[EventNewKeychain]
 
 	if creator == nil {
-		return nil, fmt.Errorf("creator is nil")
+		return nil, errors.New("creator is nil")
 	}
 
 	topics := make([]common.Hash, 2)
@@ -297,7 +290,6 @@ func (p Precompile) GetNewKeychainEvent(ctx sdk.Context, creator *common.Address
 	b.Write(append(make([]byte, 12), creator.Bytes()...))
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -312,14 +304,14 @@ func (p Precompile) GetNewKeychainEvent(ctx sdk.Context, creator *common.Address
 	return &log, nil
 }
 
-// GetNewSpaceEvent maps EventNewSpace to eth NewSpace event and writes to eth log
+// GetNewSpaceEvent maps EventNewSpace to eth NewSpace event and writes to eth log.
 func (p Precompile) GetNewSpaceEvent(ctx sdk.Context, creator *common.Address, eventNewSpace sdk.Event) (*ethtypes.Log, error) {
 	var err error
 	// Prepare the event topics
 	event := p.ABI.Events[EventNewSpace]
 
 	if creator == nil {
-		return nil, fmt.Errorf("creator is nil")
+		return nil, errors.New("creator is nil")
 	}
 
 	topics := make([]common.Hash, 2)
@@ -341,7 +333,6 @@ func (p Precompile) GetNewSpaceEvent(ctx sdk.Context, creator *common.Address, e
 	b.Write(evmoscmn.PackNum(reflect.ValueOf(typedEvent.GetRejectSignTemplateId())))
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -356,14 +347,14 @@ func (p Precompile) GetNewSpaceEvent(ctx sdk.Context, creator *common.Address, e
 	return &log, nil
 }
 
-// GetRemoveKeychainAdminEvent maps EventRemoveKeychainAdmin to eth RemoveKeychainAdmin event and write to eth log
+// GetRemoveKeychainAdminEvent maps EventRemoveKeychainAdmin to eth RemoveKeychainAdmin event and write to eth log.
 func (p Precompile) GetRemoveKeychainAdminEvent(ctx sdk.Context, admin *common.Address, eventRemoveKeychainAdmin sdk.Event) (*ethtypes.Log, error) {
 	var err error
 	// Prepare the event topics
 	event := p.ABI.Events[EventRemoveKeychainAdmin]
 
 	if admin == nil {
-		return nil, fmt.Errorf("admin is nil")
+		return nil, errors.New("admin is nil")
 	}
 
 	topics := make([]common.Hash, 2)
@@ -386,7 +377,6 @@ func (p Precompile) GetRemoveKeychainAdminEvent(ctx sdk.Context, admin *common.A
 	b.Write(evmoscmn.PackNum(reflect.ValueOf(typedEvent.GetAdminsCount())))
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +391,7 @@ func (p Precompile) GetRemoveKeychainAdminEvent(ctx sdk.Context, admin *common.A
 	return &log, nil
 }
 
-// GetUpdateKeychainEvent maps EventUpdateKeychain to eth UpdateKeychain event and write to eth log
+// GetUpdateKeychainEvent maps EventUpdateKeychain to eth UpdateKeychain event and write to eth log.
 func (p Precompile) GetUpdateKeychainEvent(ctx sdk.Context, _ *common.Address, eventUpdateKeychain sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
 	event := p.ABI.Events[EventUpdateKeychain]
@@ -409,12 +399,16 @@ func (p Precompile) GetUpdateKeychainEvent(ctx sdk.Context, _ *common.Address, e
 	topics := make([]common.Hash, 2)
 	// The first topic is always the signature of the event.
 	topics[0] = event.ID
+
 	var b bytes.Buffer
+
 	typedEvent := wardentypes.EventUpdateKeychain{}
 
 	// use Marshal/Unmarshal here cause big.Word=uint inside big.Int is not correctly merged in cosmos.gogoproto
 	var err error
+
 	var marshaled []byte
+
 	if err := precommon.ParseSdkEventSafe(eventUpdateKeychain, func(m proto.Message) error {
 		marshaled, err = proto.Marshal(m)
 		return typedEvent.Unmarshal(marshaled)
@@ -423,7 +417,6 @@ func (p Precompile) GetUpdateKeychainEvent(ctx sdk.Context, _ *common.Address, e
 	}
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -434,6 +427,7 @@ func (p Precompile) GetUpdateKeychainEvent(ctx sdk.Context, _ *common.Address, e
 	if err != nil {
 		return nil, err
 	}
+
 	b.Write(packedKeychainFees)
 
 	log := ethtypes.Log{
@@ -446,7 +440,7 @@ func (p Precompile) GetUpdateKeychainEvent(ctx sdk.Context, _ *common.Address, e
 	return &log, nil
 }
 
-// GetAddSpaceOwnerEvent maps EventAddSpaceOwner to eth AddSpaceOwner event and write to eth log
+// GetAddSpaceOwnerEvent maps EventAddSpaceOwner to eth AddSpaceOwner event and write to eth log.
 func (p Precompile) GetAddSpaceOwnerEvent(ctx sdk.Context, _ *common.Address, addSpaceOwnerEvent sdk.Event) (*ethtypes.Log, error) {
 	event := p.ABI.Events[EventAddSpaceOwner]
 
@@ -468,7 +462,6 @@ func (p Precompile) GetAddSpaceOwnerEvent(ctx sdk.Context, _ *common.Address, ad
 	b.Write(append(make([]byte, 12), newOwner.Bytes()...))
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetSpaceId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -483,7 +476,7 @@ func (p Precompile) GetAddSpaceOwnerEvent(ctx sdk.Context, _ *common.Address, ad
 	return &log, nil
 }
 
-// GetRemoveSpaceOwnerEvent maps EventRemoveSpaceOwner to eth RemoveSpaceOwner event and write to eth log
+// GetRemoveSpaceOwnerEvent maps EventRemoveSpaceOwner to eth RemoveSpaceOwner event and write to eth log.
 func (p Precompile) GetRemoveSpaceOwnerEvent(ctx sdk.Context, _ *common.Address, removeSpaceOwnerEvent sdk.Event) (*ethtypes.Log, error) {
 	event := p.ABI.Events[EventRemoveSpaceOwner]
 
@@ -505,7 +498,6 @@ func (p Precompile) GetRemoveSpaceOwnerEvent(ctx sdk.Context, _ *common.Address,
 	b.Write(append(make([]byte, 12), removedOwnerAddress.Bytes()...))
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetSpaceId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -520,7 +512,7 @@ func (p Precompile) GetRemoveSpaceOwnerEvent(ctx sdk.Context, _ *common.Address,
 	return &log, nil
 }
 
-// GetNewKeyRequestEvent maps EventNewKeyRequest to eth NewKeyRequest event and write to eth log
+// GetNewKeyRequestEvent maps EventNewKeyRequest to eth NewKeyRequest event and write to eth log.
 func (p Precompile) GetNewKeyRequestEvent(ctx sdk.Context, _ *common.Address, newKeyRequestEvent sdk.Event) (*ethtypes.Log, error) {
 	event := p.ABI.Events[EventNewKeyRequest]
 
@@ -547,7 +539,6 @@ func (p Precompile) GetNewKeyRequestEvent(ctx sdk.Context, _ *common.Address, ne
 	b.Write(append(make([]byte, 12), creatorAddress.Bytes()...))
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -562,7 +553,7 @@ func (p Precompile) GetNewKeyRequestEvent(ctx sdk.Context, _ *common.Address, ne
 	return &log, nil
 }
 
-// GetNewSignRequestEvent maps EventNewSignRequest to eth NewSignRequest event and write to eth log
+// GetNewSignRequestEvent maps EventNewSignRequest to eth NewSignRequest event and write to eth log.
 func (p Precompile) GetNewSignRequestEvent(ctx sdk.Context, _ *common.Address, newSignRequestEvent sdk.Event) (*ethtypes.Log, error) {
 	event := p.ABI.Events[EventNewSignRequest]
 
@@ -585,7 +576,6 @@ func (p Precompile) GetNewSignRequestEvent(ctx sdk.Context, _ *common.Address, n
 	b.Write(append(make([]byte, 12), creatorAddress.Bytes()...))
 	b.Write(evmoscmn.PackNum(reflect.ValueOf(typedEvent.GetBroadcastType())))
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -600,7 +590,7 @@ func (p Precompile) GetNewSignRequestEvent(ctx sdk.Context, _ *common.Address, n
 	return &log, nil
 }
 
-// GetUpdateKeyEvent maps EventUpdateKey to eth UpdateKey event and write to eth log
+// GetUpdateKeyEvent maps EventUpdateKey to eth UpdateKey event and write to eth log.
 func (p Precompile) GetUpdateKeyEvent(ctx sdk.Context, _ *common.Address, updateKeyEvent sdk.Event) (*ethtypes.Log, error) {
 	event := p.ABI.Events[EventUpdateKey]
 
@@ -621,7 +611,6 @@ func (p Precompile) GetUpdateKeyEvent(ctx sdk.Context, _ *common.Address, update
 	}
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetId())
-
 	if err != nil {
 		return nil, err
 	}
@@ -636,7 +625,7 @@ func (p Precompile) GetUpdateKeyEvent(ctx sdk.Context, _ *common.Address, update
 	return &log, nil
 }
 
-// GetUpdateSpaceEvent maps EventUpdateSpace to eth UpdateSpace event and write to eth log
+// GetUpdateSpaceEvent maps EventUpdateSpace to eth UpdateSpace event and write to eth log.
 func (p Precompile) GetUpdateSpaceEvent(ctx sdk.Context, _ *common.Address, updateSpaceEvent sdk.Event) (*ethtypes.Log, error) {
 	event := p.ABI.Events[EventUpdateSpace]
 
@@ -659,7 +648,6 @@ func (p Precompile) GetUpdateSpaceEvent(ctx sdk.Context, _ *common.Address, upda
 	}
 
 	topics[1], err = evmoscmn.MakeTopic(typedEvent.GetSpaceId())
-
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/warden/query.go
+++ b/precompiles/warden/query.go
@@ -1,7 +1,7 @@
 package warden
 
 import (
-	"fmt"
+	"errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -41,8 +41,9 @@ func (p Precompile) AllKeysMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(keysOutput).FromResponse(response)
@@ -70,8 +71,9 @@ func (p Precompile) KeyByIdMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(KeyResponse).FromResponse(response)
@@ -99,8 +101,9 @@ func (p Precompile) KeysBySpaceIdMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(keysOutput).FromResponse(response)
@@ -128,8 +131,9 @@ func (p Precompile) KeyRequestMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(KeyRequest).FromResponse(response)
@@ -157,8 +161,9 @@ func (p Precompile) KeyRequestsMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(keyRequestsOutput).FromResponse(response)
@@ -186,8 +191,9 @@ func (p Precompile) KeychainMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(Keychain).FromResponse(response)
@@ -215,8 +221,9 @@ func (p Precompile) KeychainsMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(keychainsOutput).FromResponse(response)
@@ -244,8 +251,9 @@ func (p Precompile) SignRequestByIdMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(SignRequest).FromResponse(response)
@@ -273,8 +281,9 @@ func (p Precompile) SignRequestsMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(signRequestsOutput).FromResponse(response)
@@ -302,8 +311,9 @@ func (p Precompile) SpaceByIdMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(Space).FromResponse(response)
@@ -331,8 +341,9 @@ func (p Precompile) SpacesMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(spacesOutput).FromResponse(response)
@@ -360,8 +371,9 @@ func (p Precompile) SpacesByOwnerMethod(
 	if err != nil {
 		return nil, err
 	}
+
 	if response == nil {
-		return nil, fmt.Errorf("received nil response from query server")
+		return nil, errors.New("received nil response from query server")
 	}
 
 	out, err := new(spacesOutput).FromResponse(response)

--- a/precompiles/warden/query_types.go
+++ b/precompiles/warden/query_types.go
@@ -28,6 +28,7 @@ func newAllKeysRequest(method *abi.Method, args []interface{}) (*types.QueryAllK
 	}
 
 	pagination := mapEthPageRequest(input.PageRequest)
+
 	return &types.QueryAllKeysRequest{
 		Pagination:      &pagination,
 		DeriveAddresses: deriveAddresses,
@@ -83,6 +84,7 @@ func (o *keysOutput) FromResponse(res *types.QueryKeysResponse) (*keysOutput, er
 	}
 
 	o.KeysResponse = make([]KeyResponse, len(res.Keys))
+
 	for i, k := range res.Keys {
 		keyResponse, err := new(KeyResponse).FromResponse(&k)
 		if err != nil {
@@ -177,6 +179,7 @@ func (kr *KeyRequest) FromResponse(res *types.QueryKeyRequestByIdResponse) (*Key
 	if res == nil || res.KeyRequest == nil {
 		return nil, errors.New("received nil response or key request")
 	}
+
 	return kr.mapKeyRequest(*res.KeyRequest)
 }
 
@@ -224,9 +227,9 @@ func (o *keyRequestsOutput) FromResponse(res *types.QueryKeyRequestsResponse) (*
 	}
 
 	o.KeyRequests = make([]KeyRequest, len(res.KeyRequests))
+
 	for i, k := range res.KeyRequests {
 		keyRequestResponse, err := new(KeyRequest).mapKeyRequest(*k)
-
 		if err != nil {
 			return nil, err
 		}
@@ -264,6 +267,7 @@ func (k *Keychain) FromResponse(res *types.QueryKeychainByIdResponse) (*Keychain
 	if res == nil || res.Keychain == nil {
 		return nil, errors.New("received nil response or keychain")
 	}
+
 	return k.mapKeychain(*res.Keychain)
 }
 
@@ -307,6 +311,7 @@ func (o *keychainsOutput) FromResponse(res *types.QueryKeychainsResponse) (*keyc
 		if err != nil {
 			return nil, err
 		}
+
 		o.Keychains[i] = *keychain
 	}
 
@@ -340,6 +345,7 @@ func (o *SignRequest) FromResponse(res *types.QuerySignRequestByIdResponse) (*Si
 	if res == nil || res.SignRequest == nil {
 		return nil, errors.New("received nil QuerySignRequestByIdResponse")
 	}
+
 	return o.mapSignRequest(res.SignRequest)
 }
 
@@ -405,6 +411,7 @@ func newSignRequestsRequest(method *abi.Method, args []interface{}) (*types.Quer
 		querySignRequestBroadcastType := types.QuerySignRequestsRequest_BroadcastType{
 			BroadcastType: *convertToBroadcastType(input.OptionalBroadcastType),
 		}
+
 		return &types.QuerySignRequestsRequest{
 			Pagination:            &input.PageRequest,
 			KeychainId:            input.KeychainId,
@@ -429,6 +436,7 @@ func convertToBroadcastType(obt optionalBroadcastType) *types.BroadcastType {
 	}
 
 	broadcastType := types.BroadcastType(int32(obt - 1))
+
 	return &broadcastType
 }
 
@@ -450,11 +458,13 @@ func (o *signRequestsOutput) FromResponse(res *types.QuerySignRequestsResponse) 
 	}
 
 	o.SignRequests = make([]SignRequest, len(res.SignRequests))
+
 	for i, k := range res.SignRequests {
 		signRequest, err := new(SignRequest).mapSignRequest(k)
 		if err != nil {
 			return nil, err
 		}
+
 		o.SignRequests[i] = *signRequest
 	}
 
@@ -488,6 +498,7 @@ func (o *Space) FromResponse(res *types.QuerySpaceByIdResponse) (*Space, error) 
 	if res == nil || res.Space == nil {
 		return nil, errors.New("received nil QuerySpaceByIdResponse")
 	}
+
 	return o.mapSpace(res.Space)
 }
 
@@ -546,7 +557,9 @@ func (o *spacesOutput) FromResponse(res *types.QuerySpacesResponse) (*spacesOutp
 	if res == nil {
 		return nil, errors.New("received nil QuerySpacesResponse")
 	}
+
 	o.Spaces = make([]Space, len(res.Spaces))
+
 	for i, k := range res.Spaces {
 		space, err := new(Space).mapSpace(&k)
 		if err != nil {
@@ -594,7 +607,6 @@ func (kr *KeyRequest) mapKeyRequest(keyRequest types.KeyRequest) (*KeyRequest, e
 	}
 
 	ethCreator, err := wardencommon.AddressFromBech32Str(keyRequest.Creator)
-
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/warden/tx.go
+++ b/precompiles/warden/tx.go
@@ -43,7 +43,6 @@ func (p Precompile) AddKeychainAdminMethod(
 	msgServer := wardenkeeper.NewMsgServerImpl(p.wardenkeeper)
 
 	msgAddKeychainAdmin, newAdmin, err := newMsgAddKeychainAdmin(args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +75,6 @@ func (p Precompile) AddKeychainWriterMethod(
 	msgServer := wardenkeeper.NewMsgServerImpl(p.wardenkeeper)
 
 	msgAddKeychainWriter, newWriterAddress, err := newMsgAddKeychainWriter(args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +108,6 @@ func (p Precompile) FulfilKeyRequestMethod(
 	msgServer := wardenkeeper.NewMsgServerImpl(p.wardenkeeper)
 
 	msgFulfilKeyRequest, err := newMsgFulfilKeyRequest(args, keyRequestStatus, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +141,6 @@ func (p Precompile) FulfilSignRequestMethod(
 	msgServer := wardenkeeper.NewMsgServerImpl(p.wardenkeeper)
 
 	msgFulfilSignRequest, err := newMsgFulfilSignRequest(args, signRequestStatus, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +173,6 @@ func (p Precompile) NewKeychainMethod(
 	msgServer := wardenkeeper.NewMsgServerImpl(p.wardenkeeper)
 
 	msgNewKeychain, err := newMsgNewKeychain(method, args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +184,6 @@ func (p Precompile) NewKeychainMethod(
 	)
 
 	msgNewKeychainResponse, err := msgServer.NewKeychain(ctx, msgNewKeychain)
-
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +206,6 @@ func (p Precompile) NewSpaceMethod(
 	msgServer := wardenkeeper.NewMsgServerImpl(p.wardenkeeper)
 
 	msgNewSpace, err := newMsgNewSpace(args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +217,6 @@ func (p Precompile) NewSpaceMethod(
 	)
 
 	msgNewSpaceResponse, err := msgServer.NewSpace(ctx, msgNewSpace)
-
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +239,6 @@ func (p Precompile) RemoveKeychainAdminMethod(
 	msgServer := wardenkeeper.NewMsgServerImpl(p.wardenkeeper)
 
 	msgRemoveKeychainAdmin, admin, err := newMsgRemoveKeychainAdmin(args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +271,6 @@ func (p Precompile) UpdateKeychainMethod(
 	msgServer := wardenkeeper.NewMsgServerImpl(p.wardenkeeper)
 
 	msgUpdateKeychain, err := newMsgUpdateKeychain(method, args, origin)
-
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +304,6 @@ func (p Precompile) AddSpaceOwnerMethod(
 	msgServer := actkeeper.NewMsgServerImpl(p.actkeeper)
 
 	msgNewAction, err := newMsgAddSpaceOwner(args, origin, p.actkeeper.GetModuleAddress())
-
 	if err != nil {
 		return nil, err
 	}
@@ -351,8 +340,8 @@ func (p Precompile) tryVoteAsSender(
 	ctx sdk.Context,
 	msgServer v1beta1.MsgServer,
 	actionId uint64,
-	caller common.Address) error {
-
+	caller common.Address,
+) error {
 	actionResponse, err := p.actQueryServer.ActionById(ctx, &v1beta1.QueryActionByIdRequest{
 		Id: actionId,
 	})
@@ -392,7 +381,6 @@ func (p Precompile) RemoveSpaceOwnerMethod(
 	msgServer := actkeeper.NewMsgServerImpl(p.actkeeper)
 
 	msgNewAction, err := newMsgRemoveSpaceOwner(args, origin, p.actkeeper.GetModuleAddress())
-
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +419,6 @@ func (p Precompile) NewKeyRequestMethod(
 	msgServer := actkeeper.NewMsgServerImpl(p.actkeeper)
 
 	msgNewAction, err := newMsgNewKeyRequest(method, args, origin, p.actkeeper.GetModuleAddress())
-
 	if err != nil {
 		return nil, err
 	}
@@ -470,7 +457,6 @@ func (p Precompile) NewSignRequestMethod(
 	msgServer := actkeeper.NewMsgServerImpl(p.actkeeper)
 
 	msgNewAction, err := newMsgNewSignRequest(method, args, origin, p.actkeeper.GetModuleAddress())
-
 	if err != nil {
 		return nil, err
 	}
@@ -509,7 +495,6 @@ func (p Precompile) UpdateKeyMethod(
 	msgServer := actkeeper.NewMsgServerImpl(p.actkeeper)
 
 	msgNewAction, err := newMsgUpdateKey(args, origin, p.actkeeper.GetModuleAddress())
-
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +533,6 @@ func (p Precompile) UpdateSpaceMethod(
 	msgServer := actkeeper.NewMsgServerImpl(p.actkeeper)
 
 	msgNewAction, err := newMsgUpdateSpace(args, origin, p.actkeeper.GetModuleAddress())
-
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/warden/tx_types.go
+++ b/precompiles/warden/tx_types.go
@@ -167,6 +167,7 @@ func newMsgNewKeychain(method *abi.Method, args []interface{}, origin common.Add
 	}
 
 	creator := wardencommon.Bech32StrFromAddress(origin)
+
 	var input newKeyChainInput
 	if err := method.Inputs.Copy(&input, args); err != nil {
 		return nil, fmt.Errorf("error while unpacking args to newKeyChainInput struct: %w", err)
@@ -267,6 +268,7 @@ func newMsgUpdateKeychain(method *abi.Method, args []interface{}, origin common.
 	}
 
 	creator := wardencommon.Bech32StrFromAddress(origin)
+
 	var input updateKeyChainInput
 	if err := method.Inputs.Copy(&input, args); err != nil {
 		return nil, fmt.Errorf("error while unpacking args to updateKeyChainInput struct: %w", err)

--- a/precompiles/warden/types.go
+++ b/precompiles/warden/types.go
@@ -2,7 +2,6 @@ package warden
 
 import (
 	"cosmossdk.io/math"
-
 	sdkTypes "github.com/cosmos/cosmos-sdk/types"
 	sdkQuery "github.com/cosmos/cosmos-sdk/types/query"
 

--- a/precompiles/warden/warden.go
+++ b/precompiles/warden/warden.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"cosmossdk.io/log"
-
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -50,7 +49,8 @@ func LoadABI() (abi.ABI, error) {
 func NewPrecompile(
 	wardenkeeper wardenmodulekeeper.Keeper,
 	actkeeper actmodulekeeper.Keeper,
-	e *precommon.EthEventsRegistry) (*Precompile, error) {
+	e *precommon.EthEventsRegistry,
+) (*Precompile, error) {
 	abi, err := LoadABI()
 	if err != nil {
 		return nil, err

--- a/prophet/abiutil.go
+++ b/prophet/abiutil.go
@@ -15,6 +15,7 @@ func DecodeInputFromABI[T any](inputData []byte, metaData *bind.MetaData, method
 	var wrapper struct {
 		Data T
 	}
+
 	var result T
 
 	contractABI, err := metaData.GetAbi()
@@ -31,6 +32,7 @@ func DecodeInputFromABI[T any](inputData []byte, metaData *bind.MetaData, method
 	if err != nil {
 		return result, fmt.Errorf("failed to unpack input data: %w", err)
 	}
+
 	if len(vals) != 1 {
 		return result, fmt.Errorf("expected 1 argument, got %d", len(vals))
 	}
@@ -38,6 +40,7 @@ func DecodeInputFromABI[T any](inputData []byte, metaData *bind.MetaData, method
 	if err := method.Inputs.Copy(&wrapper, vals); err != nil {
 		return result, fmt.Errorf("failed to copy input data: %w", err)
 	}
+
 	return wrapper.Data, nil
 }
 
@@ -59,6 +62,7 @@ func EncodeInputToABI[T any](val T, metaData *bind.MetaData, methodName string) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to pack input data: %w", err)
 	}
+
 	return packed, nil
 }
 
@@ -68,6 +72,7 @@ func DecodeOutputFromABI[T any](outputData []byte, metaData *bind.MetaData, meth
 	var wrapper struct {
 		Data T
 	}
+
 	var result T
 
 	contractABI, err := metaData.GetAbi()
@@ -92,6 +97,7 @@ func DecodeOutputFromABI[T any](outputData []byte, metaData *bind.MetaData, meth
 	if err := method.Outputs.Copy(&wrapper, vals); err != nil {
 		return result, fmt.Errorf("failed to copy output data: %w", err)
 	}
+
 	return wrapper.Data, nil
 }
 
@@ -111,5 +117,6 @@ func EncodeOutputToABI[T any](val T, metaData *bind.MetaData, methodName string)
 	if err != nil {
 		return nil, fmt.Errorf("failed to pack output data: %w", err)
 	}
+
 	return packed, nil
 }

--- a/prophet/dedup.go
+++ b/prophet/dedup.go
@@ -32,10 +32,12 @@ func newDedup[T getIDer](ch <-chan T) (*dedup[T], error) {
 
 	go func() {
 		defer close(out)
+
 		for req := range ch {
 			if c.Contains(req.getID()) {
 				continue
 			}
+
 			c.Add(req.getID(), struct{}{})
 			out <- req
 		}
@@ -59,6 +61,7 @@ func newDedupFutureReader(r FutureReader) (*dedupFutureReader, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &dedupFutureReader{d: d}, nil
 }
 
@@ -77,6 +80,7 @@ func newDedupFutureResultReader(r FutureResultReader) (*dedupFutureResultReader,
 	if err != nil {
 		return nil, err
 	}
+
 	return &dedupFutureResultReader{d: d}, nil
 }
 

--- a/prophet/exec.go
+++ b/prophet/exec.go
@@ -22,11 +22,13 @@ func ExecFutures(r FutureReader, w FutureResultWriter) error {
 			log := log.With("future", future.ID)
 
 			log.Debug("running future")
+
 			output, err := Execute(context.TODO(), future)
 			if err != nil {
 				log.Error("failed to run future", "err", err)
 				continue
 			}
+
 			err = w.Write(output)
 			if err != nil {
 				log.Error("failed to write future result", "err", err)
@@ -55,6 +57,7 @@ func ExecVotes(r FutureResultReader, w VoteWriter) error {
 			plog := log.With("future", proposal.ID)
 
 			plog.Debug("verifying future proposal")
+
 			err := Verify(context.TODO(), proposal)
 			if err := w.Write(Vote{
 				ID:  proposal.ID,

--- a/prophet/handlers.go
+++ b/prophet/handlers.go
@@ -34,6 +34,7 @@ func Execute(ctx context.Context, f Future) (res FutureResult, err error) {
 
 	log := slog.With("task", "Execute", "future", f.ID, "handler", f.Handler)
 	log.Debug("start")
+
 	start := time.Now()
 
 	output, err := s.Execute(ctx, f.Input)
@@ -64,6 +65,7 @@ func Verify(ctx context.Context, f FutureResult) (err error) {
 
 	log := slog.With("task", "Verify", "future", f.ID, "handler", f.Handler)
 	log.Debug("start")
+
 	start := time.Now()
 
 	if err := s.Verify(ctx, f.Input, f.Output); err != nil {

--- a/prophet/handlers/echo/echo.go
+++ b/prophet/handlers/echo/echo.go
@@ -5,7 +5,7 @@ package echo
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/warden-protocol/wardenprotocol/prophet"
 )
@@ -20,7 +20,8 @@ func (s Handler) Execute(ctx context.Context, input []byte) ([]byte, error) {
 
 func (s Handler) Verify(ctx context.Context, input []byte, output []byte) error {
 	if !bytes.Equal(input, output) {
-		return fmt.Errorf("input and output do not match")
+		return errors.New("input and output do not match")
 	}
+
 	return nil
 }

--- a/prophet/handlers/http/config/config.go
+++ b/prophet/handlers/http/config/config.go
@@ -18,18 +18,4 @@ func DefaultConfig() *Config {
 	}
 }
 
-const DefaultEVMConfigTemplate = `
-###############################################################################
-###                      HTTP configuration                     ###
-###############################################################################
-[http]
-
-# Is HTTP handler enabled
-enabled = "{{ .Http.Enabled }}"
-
-# URLs used for HTTP handler
-urls = ["{{ range $i, $url := .Http.URLs }}{{if $i}},{{end}}{{$url}}{{end}}"]
-
-# Timeout in seconds for the HTTP client
-timeout_sec = {{ .Http.TimeoutSec }}
-`
+const DefaultEVMConfigTemplate = "\n###############################################################################\n###                      HTTP configuration                     ###\n###############################################################################\n[http]\n\n# Is HTTP handler enabled\n= \"{{ .Http.Enabled }}\"\n\n# URLs used for HTTP handler\nurls = [\"{{ range $i, $url := .Http.URLs }}{{if $i}},{{end}}{{$url}}{{end}}\"]\n\n# Timeout in seconds for the HTTP client\ntimeout_sec = {{ .Http.TimeoutSec"

--- a/prophet/handlers/http/http_test.go
+++ b/prophet/handlers/http/http_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/prophet"
 	"github.com/warden-protocol/wardenprotocol/prophet/handlers/http/generated"
 )
@@ -37,9 +37,10 @@ func TestHandler_Execute(t *testing.T) {
 
 	parsedURL, err := url.Parse(mockServer.URL)
 	require.NoError(t, err)
+
 	h := NewHandler([]*url.URL{parsedURL}, 5*time.Second)
 
-	abiEncodedOutput, execErr := h.Execute(context.Background(), input)
+	abiEncodedOutput, execErr := h.Execute(t.Context(), input)
 	require.NoError(t, execErr, "Execute should not fail")
 
 	// First decode the ABI encoding
@@ -92,6 +93,7 @@ func TestHandler_Execute_WithCborBody(t *testing.T) {
 		require.Equal(t, originalPayload.Bar, received.Bar, "Bar should match")
 
 		respJSON := `{"result":"ok"}`
+
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(respJSON))
 	}))
@@ -108,9 +110,10 @@ func TestHandler_Execute_WithCborBody(t *testing.T) {
 
 	parsedURL, err := url.Parse(mockServer.URL)
 	require.NoError(t, err)
+
 	h := NewHandler([]*url.URL{parsedURL}, 5*time.Second)
 
-	abiEncodedOutput, execErr := h.Execute(context.Background(), input)
+	abiEncodedOutput, execErr := h.Execute(t.Context(), input)
 	require.NoError(t, execErr, "Execute with CBOR body should not fail")
 
 	decodedOutput, err := prophet.DecodeOutputFromABI[generated.HttpResponse](
@@ -152,7 +155,7 @@ func TestHandler_Execute_URLNotAllowed(t *testing.T) {
 	)
 	require.NoError(t, err, "Failed to encode input")
 
-	_, execErr := h.Execute(context.Background(), input)
+	_, execErr := h.Execute(t.Context(), input)
 	require.Error(t, execErr)
 	require.Contains(t, execErr.Error(), "URL not allowed by whitelist")
 }

--- a/prophet/handlers/pricepred/client.go
+++ b/prophet/handlers/pricepred/client.go
@@ -55,6 +55,7 @@ type PredictResponse struct {
 func (c *client) Predict(ctx context.Context, req PredictRequest) (PredictResponse, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
+
 	var res PredictResponse
 	if err := c.post(reqCtx, req, &res, c.predictURL); err != nil {
 		return PredictResponse{}, err
@@ -113,6 +114,7 @@ type BacktestingResponse struct {
 func (c *client) Backtesting(ctx context.Context, req BacktestingRequest) (BacktestingResponse, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, 320*time.Second)
 	defer cancel()
+
 	var res BacktestingResponse
 	if err := c.post(reqCtx, req, &res, c.backtestingURL); err != nil {
 		return BacktestingResponse{}, err
@@ -135,6 +137,7 @@ type VerifyResponse struct {
 func (c *client) Verify(ctx context.Context, req VerifyRequest) (VerifyResponse, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
+
 	var res VerifyResponse
 	if err := c.post(reqCtx, req, &res, c.verifyURL); err != nil {
 		return VerifyResponse{}, err
@@ -149,7 +152,7 @@ func (c *client) post(ctx context.Context, req, res any, URL string) error {
 		return err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", URL, bytes.NewReader(reqBody))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, URL, bytes.NewReader(reqBody))
 	if err != nil {
 		return err
 	}
@@ -163,6 +166,7 @@ func (c *client) post(ctx context.Context, req, res any, URL string) error {
 	}
 
 	defer response.Body.Close()
+
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err

--- a/prophet/handlers/pricepred/client_test.go
+++ b/prophet/handlers/pricepred/client_test.go
@@ -1,7 +1,6 @@
 package pricepred
 
 import (
-	"context"
 	"encoding/base64"
 	"net/http"
 	"net/url"
@@ -18,7 +17,7 @@ func TestPredict(t *testing.T) {
 		Host:   "tpc.devnet.wardenprotocol.org",
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	res, err := c.Predict(ctx, PredictRequest{
 		SolverInput: RequestSolverInput{
 			Tokens:        []string{"bitcoin", "tether", "uniswap"},
@@ -43,7 +42,7 @@ func TestBacktesting(t *testing.T) {
 		Host:   "tpc.devnet.wardenprotocol.org",
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	res, err := c.Backtesting(ctx, BacktestingRequest{
 		SolverInput: RequestSolverInput{
 			Tokens:        []string{"bitcoin", "tether", "uniswap"},
@@ -65,7 +64,7 @@ func TestVerify(t *testing.T) {
 		Host:   "tpc.devnet.wardenprotocol.org",
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	res, err := c.Verify(ctx, VerifyRequest{
 		SolverRequest: PredictRequest{
 			SolverInput: RequestSolverInput{

--- a/prophet/handlers/pricepred/config/config.go
+++ b/prophet/handlers/pricepred/config/config.go
@@ -16,15 +16,4 @@ func DefaultConfig() *Config {
 	}
 }
 
-const DefaultEVMConfigTemplate = `
-###############################################################################
-###                      Price prediction configuration                     ###
-###############################################################################
-[pricepred]
-
-# Is price prediction enabled
-enabled = "{{ .PricePred.Enabled }}"
-
-# URL used for price prediction handler
-url = "{{ .PricePred.URL }}"
-`
+const DefaultEVMConfigTemplate = "\n###############################################################################\n###                      Price prediction configuration                     ###\n###############################################################################\n[pricepred]\n\n# Is price prediction enabled\n= \"{{ .PricePred.Enabled }}\"\n\n# URL used for price prediction handler\nurl = \"{{ .PricePred.URL"

--- a/prophet/handlers/pricepred/pricepred.go
+++ b/prophet/handlers/pricepred/pricepred.go
@@ -3,6 +3,7 @@ package pricepred
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -67,8 +68,9 @@ func (i *PricePredictorInputData) ToPredictRequest() (PredictRequest, error) {
 	dateStr := tm.Format("2006-01-02")
 
 	if i.FalsePositiveRate[1] == 0 {
-		return PredictRequest{}, fmt.Errorf("invalid false positive rate")
+		return PredictRequest{}, errors.New("invalid false positive rate")
 	}
+
 	fpr := float64(i.FalsePositiveRate[0]) / float64(i.FalsePositiveRate[1])
 
 	return PredictRequest{
@@ -102,6 +104,7 @@ func (s PricePredictorSolidity) Execute(ctx context.Context, input []byte) ([]by
 	}
 
 	var backtestingRes *BacktestingResponse
+
 	if len(inputData.Metrics) > 0 {
 		res, err := s.c.Backtesting(ctx, BacktestingRequest(req))
 		if err != nil {
@@ -165,9 +168,11 @@ func (s PricePredictorSolidity) Verify(ctx context.Context, input []byte, output
 	if err != nil {
 		return err
 	}
+
 	if !res.IsVerified {
-		return fmt.Errorf("pricepred: verification failed")
+		return errors.New("pricepred: verification failed")
 	}
+
 	return nil
 }
 
@@ -190,6 +195,7 @@ func buildOutputData(
 		for i, v := range req.SolverInput.Tokens {
 			metrics[i] = make([]*big.Int, len(inputData.Metrics))
 			tokenMetrics := backtestingRes.SolverOutput.Tokens[v]
+
 			for j, m := range inputData.Metrics {
 				m := MetricNameFromBigInt(m)
 				switch m {

--- a/prophet/handlers/pricepred/pricepred_test.go
+++ b/prophet/handlers/pricepred/pricepred_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/prophet"
 )
 
@@ -40,9 +41,11 @@ func TestDecodeInput(t *testing.T) {
 			require.NoError(t, err)
 			requireEqualInt(t, c.expected.Date, decodedInput.Date)
 			require.Equal(t, c.expected.Tokens, decodedInput.Tokens)
+
 			for i := range c.expected.Metrics {
 				requireEqualInt(t, c.expected.Metrics[i], decodedInput.Metrics[i])
 			}
+
 			require.Equal(t, c.expected.FalsePositiveRate, decodedInput.FalsePositiveRate)
 		})
 	}
@@ -135,9 +138,11 @@ func TestBuildOutput(t *testing.T) {
 			actual, err := buildOutputData(c.inputData, c.req, c.res, c.backtestingRes)
 			require.NoError(t, err)
 			require.Len(t, actual.Metrics, len(c.expected.Metrics))
+
 			for i := range actual.Metrics {
 				requireEqualInts(t, c.expected.Metrics[i], actual.Metrics[i])
 			}
+
 			requireEqualInts(t, c.expected.Predictions, actual.Predictions)
 		})
 	}
@@ -147,6 +152,7 @@ func TestAllMetricNamesCovered(t *testing.T) {
 	// this test assumes that the MetricName enum is mapped to the field IDs of
 	// the [BacktestingMetrics] struct
 	bmType := reflect.TypeOf(BacktestingMetrics{})
+
 	n := bmType.NumField()
 	for i := range n {
 		inputData := PricePredictorInputData{Metrics: []*big.Int{big.NewInt(int64(i))}}
@@ -170,6 +176,7 @@ func TestAllMetricNamesCovered(t *testing.T) {
 func requireEqualInts(t *testing.T, expected, actual []*big.Int) {
 	t.Helper()
 	require.Len(t, actual, len(expected))
+
 	for i := range expected {
 		requireEqualInt(t, expected[i], actual[i])
 	}

--- a/prophet/handlers/stoicquote/stoicquote.go
+++ b/prophet/handlers/stoicquote/stoicquote.go
@@ -5,6 +5,7 @@ package stoicquote
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -47,7 +48,7 @@ func (h StoicQuoteSolidity) Verify(ctx context.Context, input []byte, output []b
 	}
 
 	if decoded.Data.Author == "" || decoded.Data.Quote == "" {
-		return fmt.Errorf("missing author or quote in output")
+		return errors.New("missing author or quote in output")
 	}
 
 	return nil

--- a/prophet/handlers/stoicquote/stoicquote_test.go
+++ b/prophet/handlers/stoicquote/stoicquote_test.go
@@ -1,13 +1,13 @@
 package stoicquote
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/prophet"
 	"github.com/warden-protocol/wardenprotocol/prophet/handlers/stoicquote/generated"
 )
@@ -27,7 +27,7 @@ func TestHandler_Execute(t *testing.T) {
 		QuoteApiUrl: mockServer.URL,
 	}
 
-	encodedOutput, execErr := h.Execute(context.Background(), emptyInput)
+	encodedOutput, execErr := h.Execute(t.Context(), emptyInput)
 	require.NoError(t, execErr, "Execute should not fail")
 
 	decodedOutput, err := prophet.DecodeOutputFromABI[generated.StoicQuoteResponse](
@@ -56,9 +56,9 @@ func TestHandler_Verify(t *testing.T) {
 
 	h := StoicQuoteSolidity{QuoteApiUrl: mockServer.URL}
 
-	encodedOutput, err := h.Execute(context.Background(), emptyInput)
+	encodedOutput, err := h.Execute(t.Context(), emptyInput)
 	require.NoError(t, err, "Execute should not fail")
 
-	err = h.Verify(context.Background(), emptyInput, encodedOutput)
+	err = h.Verify(t.Context(), emptyInput, encodedOutput)
 	require.NoError(t, err, "Verify should not fail with valid quote")
 }

--- a/prophet/prophet.go
+++ b/prophet/prophet.go
@@ -7,9 +7,8 @@ import (
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
-
 	"github.com/cosmos/cosmos-sdk/client"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 // queueBufferSize sets the default size for incoming queues, i.e. the number
@@ -79,19 +78,24 @@ func (p *P) Run(tendermintRpc string) error {
 		if err != nil {
 			panic(err)
 		}
+
 		timeout := time.Now().Add(30 * time.Second)
+
 		for {
 			if time.Now().After(timeout) {
 				return
 			}
+
 			status, err := client.Status(context.Background())
 			if err != nil {
 				time.Sleep(100 * time.Millisecond)
 				continue
 			}
+
 			p.selfAddressRwLock.Lock()
 			defer p.selfAddressRwLock.Unlock()
 			p.selfAddress = status.ValidatorInfo.Address
+
 			return
 		}
 	}()
@@ -129,6 +133,7 @@ func (p *P) Results() ([]FutureResult, func()) {
 func (p *P) SelfAddress() []byte {
 	p.selfAddressRwLock.RLock()
 	defer p.selfAddressRwLock.RUnlock()
+
 	return p.selfAddress
 }
 
@@ -182,12 +187,14 @@ func newS[T getIDer]() (*s[T], error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &s[T]{l: l}, nil
 }
 
 func (s *s[T]) Write(value T) error {
 	id := value.getID()
 	s.l.Add(id, value)
+
 	return nil
 }
 

--- a/prophet/registry.go
+++ b/prophet/registry.go
@@ -16,24 +16,29 @@ type r struct {
 func Register(name string, future FutureHandler) {
 	registry.rw.Lock()
 	defer registry.rw.Unlock()
+
 	if _, found := registry.futures[name]; found {
 		panic("future already registered")
 	}
+
 	registry.futures[name] = future
 }
 
 func getHandler(name string) FutureHandler {
 	registry.rw.RLock()
 	defer registry.rw.RUnlock()
+
 	return registry.futures[name]
 }
 
 func RegisteredHandlers() []string {
 	registry.rw.RLock()
 	defer registry.rw.RUnlock()
+
 	handlers := make([]string, 0, len(registry.futures))
 	for name := range registry.futures {
 		handlers = append(handlers, name)
 	}
+
 	return handlers
 }

--- a/warden/app/ante.go
+++ b/warden/app/ante.go
@@ -3,25 +3,20 @@ package app
 import (
 	"errors"
 
-	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
-	"github.com/cosmos/ibc-go/v8/modules/core/keeper"
-
 	corestoretypes "cosmossdk.io/core/store"
+	errorsmod "cosmossdk.io/errors"
 	circuitante "cosmossdk.io/x/circuit/ante"
 	circuitkeeper "cosmossdk.io/x/circuit/keeper"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth/ante"
-
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
-
-	evmante "github.com/evmos/evmos/v20/app/ante/evm"
-
-	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
+	"github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	cosmosante "github.com/evmos/evmos/v20/app/ante/cosmos"
+	evmante "github.com/evmos/evmos/v20/app/ante/evm"
 	anteutils "github.com/evmos/evmos/v20/app/ante/utils"
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 )
@@ -95,36 +90,47 @@ func ValidateAnteHandlerOptions(options HandlerOptions) error {
 	if options.AccountKeeper == nil {
 		return errors.New("account keeper is required for ante builder")
 	}
+
 	if options.BankKeeper == nil {
 		return errors.New("bank keeper is required for ante builder")
 	}
+
 	if options.SignModeHandler == nil {
 		return errors.New("sign mode handler is required for ante builder")
 	}
+
 	if options.WasmConfig == nil {
 		return errors.New("wasm config is required for ante builder")
 	}
+
 	if options.TXCounterStoreService == nil {
 		return errors.New("wasm store service is required for ante builder")
 	}
+
 	if options.CircuitKeeper == nil {
 		return errors.New("circuit keeper is required for ante builder")
 	}
+
 	if options.EvmKeeper == nil {
 		return errors.New("evm keeper is required for ante builder")
 	}
+
 	if options.FeeMarketKeeper == nil {
 		return errors.New("feemarket keeper is required for ante builder")
 	}
+
 	if options.TxFeeChecker == nil {
 		return errors.New("tx fee checker is required for ante builder")
 	}
+
 	if options.StakingKeeper == nil {
 		return errors.New("tx fee checker is required for ante builder")
 	}
+
 	if options.DistributionKeeper == nil {
 		return errors.New("tx fee checker is required for ante builder")
 	}
+
 	if options.StakingKeeper == nil {
 		return errors.New("tx fee checker is required for ante builder")
 	}
@@ -132,7 +138,7 @@ func ValidateAnteHandlerOptions(options HandlerOptions) error {
 	return nil
 }
 
-// NewAnteHandler constructor
+// NewAnteHandler constructor.
 func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 	return func(
 		ctx sdk.Context, tx sdk.Tx, sim bool,
@@ -168,5 +174,4 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 
 		return anteHandler(ctx, tx, sim)
 	}
-
 }

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -65,10 +65,26 @@ import (
 	icahostkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/keeper"
 	ibcfeekeeper "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/keeper"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
+	evmosante "github.com/evmos/evmos/v20/app/ante"
+	ethante "github.com/evmos/evmos/v20/app/ante/evm"
+	evmosencodingcodec "github.com/evmos/evmos/v20/encoding/codec"
+	srvflags "github.com/evmos/evmos/v20/server/flags"
+	evmostypes "github.com/evmos/evmos/v20/types"
+	erc20keeper "github.com/evmos/evmos/v20/x/erc20/keeper"
+	evmkeeper "github.com/evmos/evmos/v20/x/evm/keeper"
+	feemarketkeeper "github.com/evmos/evmos/v20/x/feemarket/keeper"
+	marketmapkeeper "github.com/skip-mev/slinky/x/marketmap/keeper"
+	oraclekeeper "github.com/skip-mev/slinky/x/oracle/keeper"
 	"github.com/spf13/cast"
+
 	asyncprecompile "github.com/warden-protocol/wardenprotocol/precompiles/async"
 	slinkyprecompile "github.com/warden-protocol/wardenprotocol/precompiles/slinky"
+	"github.com/warden-protocol/wardenprotocol/prophet"
+	"github.com/warden-protocol/wardenprotocol/prophet/handlers/echo"
+	"github.com/warden-protocol/wardenprotocol/prophet/handlers/http"
+	"github.com/warden-protocol/wardenprotocol/prophet/handlers/pricepred"
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
+	"github.com/warden-protocol/wardenprotocol/warden/docs"
 	"github.com/warden-protocol/wardenprotocol/warden/x/act/cosmoshield"
 	actmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/act/keeper"
 	asyncmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/async/keeper"
@@ -77,27 +93,6 @@ import (
 	"github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/keeper"
 	wardenmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/warden/keeper"
 	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
-
-	// this line is used by starport scaffolding # stargate/app/moduleImport
-
-	"github.com/warden-protocol/wardenprotocol/warden/docs"
-
-	evmosante "github.com/evmos/evmos/v20/app/ante"
-	ethante "github.com/evmos/evmos/v20/app/ante/evm"
-	srvflags "github.com/evmos/evmos/v20/server/flags"
-	evmostypes "github.com/evmos/evmos/v20/types"
-	erc20keeper "github.com/evmos/evmos/v20/x/erc20/keeper"
-	evmkeeper "github.com/evmos/evmos/v20/x/evm/keeper"
-	feemarketkeeper "github.com/evmos/evmos/v20/x/feemarket/keeper"
-
-	evmosencodingcodec "github.com/evmos/evmos/v20/encoding/codec"
-	marketmapkeeper "github.com/skip-mev/slinky/x/marketmap/keeper"
-	oraclekeeper "github.com/skip-mev/slinky/x/oracle/keeper"
-
-	"github.com/warden-protocol/wardenprotocol/prophet"
-	"github.com/warden-protocol/wardenprotocol/prophet/handlers/echo"
-	"github.com/warden-protocol/wardenprotocol/prophet/handlers/http"
-	"github.com/warden-protocol/wardenprotocol/prophet/handlers/pricepred"
 )
 
 const (
@@ -105,10 +100,8 @@ const (
 	Name                 = "warden"
 )
 
-var (
-	// DefaultNodeHome default home directories for the application daemon
-	DefaultNodeHome string
-)
+// DefaultNodeHome default home directories for the application daemon.
+var DefaultNodeHome string
 
 var (
 	_ runtime.AppI            = (*App)(nil)
@@ -229,6 +222,7 @@ func registerProphetHanlders(appOpts servertypes.AppOptions) {
 		if err != nil {
 			panic(fmt.Errorf("invalid pricepred url: %s", u))
 		}
+
 		prophet.Register("pricepred", pricepred.NewPricePredictorSolidity(url))
 	}
 
@@ -237,13 +231,16 @@ func registerProphetHanlders(appOpts servertypes.AppOptions) {
 		timeout := cast.ToInt(appOpts.Get("http.timeout"))
 
 		parsedURLs := make([]*url.URL, len(urls))
+
 		for i, u := range urls {
 			parsedURL, err := url.Parse(u)
 			if err != nil {
 				panic(fmt.Errorf("invalid http url: %s", u))
 			}
+
 			parsedURLs[i] = parsedURL
 		}
+
 		parsedTimeout := time.Duration(timeout) * time.Second
 
 		prophet.Register("http", http.NewHandler(parsedURLs, parsedTimeout))
@@ -496,6 +493,7 @@ func New(
 		if err := app.UpgradeKeeper.SetModuleVersionMap(ctx, app.ModuleManager.GetVersionMap()); err != nil {
 			return nil, err
 		}
+
 		return app.App.InitChainer(ctx, req)
 	})
 
@@ -517,19 +515,23 @@ func New(
 			slinkyprecompile.PrecompileAddress,
 			asyncprecompile.PrecompileAddress,
 		)
+
 		if err := evmParams.Validate(); err != nil {
 			return toVM, err
 		}
+
 		if err := app.EvmKeeper.SetParams(sdkCtx, evmParams); err != nil {
 			return toVM, err
 		}
 
 		return toVM, nil
 	})
+
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {
 		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
 	}
+
 	if upgradeInfo.Name == v060UpgradeName {
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storetypes.StoreUpgrades{
 			Added: []string{
@@ -576,6 +578,7 @@ func (app *App) GetKey(storeKey string) *storetypes.KVStoreKey {
 	if !ok {
 		return nil
 	}
+
 	return kvStoreKey
 }
 
@@ -601,6 +604,7 @@ func (app *App) GetTransientKey(storeKey string) *storetypes.TransientStoreKey {
 // kvStoreKeys returns all the kv store keys registered inside App.
 func (app *App) kvStoreKeys() map[string]*storetypes.KVStoreKey {
 	keys := make(map[string]*storetypes.KVStoreKey)
+
 	for _, k := range app.GetStoreKeys() {
 		if kv, ok := k.(*storetypes.KVStoreKey); ok {
 			keys[kv.Name()] = kv
@@ -672,12 +676,14 @@ func GetMaccPerms() map[string][]string {
 	for _, perms := range moduleAccPerms {
 		dup[perms.Account] = perms.Permissions
 	}
+
 	return dup
 }
 
 // BlockedAddresses returns all the app's blocked account addresses.
 func BlockedAddresses() map[string]bool {
 	result := make(map[string]bool)
+
 	if len(blockAccAddrs) > 0 {
 		for _, addr := range blockAccAddrs {
 			result[addr] = true
@@ -687,6 +693,7 @@ func BlockedAddresses() map[string]bool {
 			result[addr] = true
 		}
 	}
+
 	return result
 }
 
@@ -713,7 +720,7 @@ func (app *App) setAnteHandler(txConfig client.TxConfig, wasmConfig wasmtypes.Wa
 	}
 
 	if err := ValidateAnteHandlerOptions(options); err != nil {
-		panic(fmt.Errorf("failed to create AnteHandler: %s", err))
+		panic(fmt.Errorf("failed to create AnteHandler: %w", err))
 	}
 
 	anteHandler := NewAnteHandler(options)

--- a/warden/app/app_config.go
+++ b/warden/app/app_config.go
@@ -35,6 +35,7 @@ import (
 	"cosmossdk.io/x/tx/signing"
 	_ "cosmossdk.io/x/upgrade" // import for side-effects
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/cosmos/cosmos-sdk/x/auth/tx/config" // import for side-effects
@@ -72,9 +73,15 @@ import (
 	ibcfeetypes "github.com/cosmos/ibc-go/v8/modules/apps/29-fee/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
+	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
+	feemarkettypes "github.com/evmos/evmos/v20/x/feemarket/types"
+	marketmapmodulev1 "github.com/skip-mev/slinky/api/slinky/marketmap/module/v1"
+	oraclemodulev1 "github.com/skip-mev/slinky/api/slinky/oracle/module/v1"
+	_ "github.com/skip-mev/slinky/x/marketmap" // import for side-effects
+	marketmaptypes "github.com/skip-mev/slinky/x/marketmap/types"
+	_ "github.com/skip-mev/slinky/x/oracle" // import for side-effects
+	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
 	"google.golang.org/protobuf/types/known/durationpb"
-
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
 	actmodulev1 "github.com/warden-protocol/wardenprotocol/api/warden/act/module"
 	asyncmodulev1 "github.com/warden-protocol/wardenprotocol/api/warden/async/module"
@@ -86,18 +93,6 @@ import (
 	gmpmoduletypes "github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 	_ "github.com/warden-protocol/wardenprotocol/warden/x/warden/module" // import for side-effects
 	wardenmoduletypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
-
-	// this line is used by starport scaffolding # stargate/app/moduleImport
-
-	marketmapmodulev1 "github.com/skip-mev/slinky/api/slinky/marketmap/module/v1"
-	oraclemodulev1 "github.com/skip-mev/slinky/api/slinky/oracle/module/v1"
-	_ "github.com/skip-mev/slinky/x/marketmap" // import for side-effects
-	marketmaptypes "github.com/skip-mev/slinky/x/marketmap/types"
-	_ "github.com/skip-mev/slinky/x/oracle" // import for side-effects
-	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
-
-	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
-	feemarkettypes "github.com/evmos/evmos/v20/x/feemarket/types"
 )
 
 func init() {
@@ -178,11 +173,7 @@ var (
 		// this line is used by starport scaffolding # stargate/app/initGenesis
 	}
 
-	// During begin block slashing happens after distr.BeginBlocker so that
-	// there is nothing left over in the validator fee pool, so as to keep the
-	// CanWithdrawInvariant invariant.
-	// NOTE: staking module is required if HistoricalEntries param > 0
-	// NOTE: capability module's beginblocker must come before any modules using capabilities (e.g. IBC)
+	// NOTE: capability module's beginblocker must come before any modules using capabilities (e.g. IBC).
 	beginBlockers = []string{
 		// cosmos sdk modules
 		minttypes.ModuleName,
@@ -251,7 +242,7 @@ var (
 		// this line is used by starport scaffolding # stargate/app/preBlockers
 	}
 
-	// module account permissions
+	// module account permissions.
 	moduleAccPerms = []*authmodulev1.ModuleAccountPermission{
 		{Account: authtypes.FeeCollectorName},
 		{Account: distrtypes.ModuleName},
@@ -270,7 +261,7 @@ var (
 		// this line is used by starport scaffolding # stargate/app/maccPerms
 	}
 
-	// blocked account addresses
+	// blocked account addresses.
 	blockAccAddrs = []string{
 		authtypes.FeeCollectorName,
 		distrtypes.ModuleName,
@@ -427,5 +418,6 @@ func moduleConfig() depinject.Config {
 				// this line is used by starport scaffolding # stargate/app/moduleConfig
 			},
 		})
+
 	return cfg
 }

--- a/warden/app/export.go
+++ b/warden/app/export.go
@@ -25,6 +25,7 @@ func (app *App) ExportAppStateAndValidators(forZeroHeight bool, jailAllowedAddrs
 	height := app.LastBlockHeight() + 1
 	if forZeroHeight {
 		height = 0
+
 		app.prepForZeroHeightGenesis(ctx, jailAllowedAddrs)
 	}
 
@@ -39,6 +40,7 @@ func (app *App) ExportAppStateAndValidators(forZeroHeight bool, jailAllowedAddrs
 	}
 
 	validators, err := staking.WriteValidators(ctx, app.StakingKeeper)
+
 	return servertypes.ExportedApp{
 		AppState:        appState,
 		Validators:      validators,
@@ -66,6 +68,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		if err != nil {
 			log.Fatal(err)
 		}
+
 		allowedAddrsMap[addr] = true
 	}
 
@@ -80,7 +83,9 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		if err != nil {
 			panic(err)
 		}
+
 		_, _ = app.DistrKeeper.WithdrawValidatorCommission(ctx, valBz)
+
 		return false
 	})
 	if err != nil {
@@ -125,10 +130,12 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		if err != nil {
 			panic(err)
 		}
+
 		feePool, err := app.DistrKeeper.FeePool.Get(ctx)
 		if err != nil {
 			panic(err)
 		}
+
 		feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
 		if err := app.DistrKeeper.FeePool.Set(ctx, feePool); err != nil {
 			panic(err)
@@ -137,6 +144,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		if err := app.DistrKeeper.Hooks().AfterValidatorCreated(ctx, valBz); err != nil {
 			panic(err)
 		}
+
 		return false
 	})
 
@@ -146,6 +154,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		if err != nil {
 			panic(err)
 		}
+
 		delAddr := sdk.MustAccAddressFromBech32(del.DelegatorAddress)
 
 		if err := app.DistrKeeper.Hooks().BeforeDelegationCreated(ctx, delAddr, valAddr); err != nil {
@@ -169,10 +178,12 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		for i := range red.Entries {
 			red.Entries[i].CreationHeight = 0
 		}
+
 		err = app.StakingKeeper.SetRedelegation(ctx, red)
 		if err != nil {
 			panic(err)
 		}
+
 		return false
 	})
 	if err != nil {
@@ -184,10 +195,12 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		for i := range ubd.Entries {
 			ubd.Entries[i].CreationHeight = 0
 		}
+
 		err = app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
 		if err != nil {
 			panic(err)
 		}
+
 		return false
 	})
 	if err != nil {
@@ -202,6 +215,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 
 	for ; iter.Valid(); iter.Next() {
 		addr := sdk.ValAddress(stakingtypes.AddressFromValidatorsKey(iter.Key()))
+
 		validator, err := app.StakingKeeper.GetValidator(ctx, addr)
 		if err != nil {
 			panic("expected validator, not found")
@@ -215,6 +229,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		if err := app.StakingKeeper.SetValidator(ctx, validator); err != nil {
 			panic(err)
 		}
+
 		counter++
 	}
 
@@ -238,6 +253,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 			if err := app.SlashingKeeper.SetValidatorSigningInfo(ctx, addr, info); err != nil {
 				panic(err)
 			}
+
 			return false
 		},
 	)

--- a/warden/app/genesis_account.go
+++ b/warden/app/genesis_account.go
@@ -26,7 +26,7 @@ type GenesisAccount struct {
 	ModulePermissions []string `json:"module_permissions" yaml:"module_permissions"` // permissions of module account
 }
 
-// Validate checks for errors on the vesting and module account parameters
+// Validate checks for errors on the vesting and module account parameters.
 func (sga GenesisAccount) Validate() error {
 	if !sga.OriginalVesting.IsZero() {
 		if sga.StartTime >= sga.EndTime {

--- a/warden/app/gmp/gmp_middleware.go
+++ b/warden/app/gmp/gmp_middleware.go
@@ -12,6 +12,7 @@ import (
 	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
+
 	gmptypes "github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 )
 
@@ -27,7 +28,7 @@ func NewIBCMiddleware(app porttypes.IBCModule, handler GeneralMessageHandler) IB
 	}
 }
 
-// OnChanOpenInit implements the IBCModule interface
+// OnChanOpenInit implements the IBCModule interface.
 func (im IBCMiddleware) OnChanOpenInit(
 	ctx sdk.Context,
 	order channeltypes.Order,
@@ -51,7 +52,7 @@ func (im IBCMiddleware) OnChanOpenInit(
 	)
 }
 
-// OnChanOpenTry implements the IBCMiddleware interface
+// OnChanOpenTry implements the IBCMiddleware interface.
 func (im IBCMiddleware) OnChanOpenTry(
 	ctx sdk.Context,
 	order channeltypes.Order,
@@ -74,7 +75,7 @@ func (im IBCMiddleware) OnChanOpenTry(
 	)
 }
 
-// OnChanOpenAck implements the IBCMiddleware interface
+// OnChanOpenAck implements the IBCMiddleware interface.
 func (im IBCMiddleware) OnChanOpenAck(
 	ctx sdk.Context,
 	portID,
@@ -91,7 +92,7 @@ func (im IBCMiddleware) OnChanOpenAck(
 	)
 }
 
-// OnChanOpenConfirm implements the IBCMiddleware interface
+// OnChanOpenConfirm implements the IBCMiddleware interface.
 func (im IBCMiddleware) OnChanOpenConfirm(
 	ctx sdk.Context,
 	portID,
@@ -100,7 +101,7 @@ func (im IBCMiddleware) OnChanOpenConfirm(
 	return im.app.OnChanOpenConfirm(ctx, portID, channelID)
 }
 
-// OnChanCloseInit implements the IBCMiddleware interface
+// OnChanCloseInit implements the IBCMiddleware interface.
 func (im IBCMiddleware) OnChanCloseInit(
 	ctx sdk.Context,
 	portID,
@@ -109,7 +110,7 @@ func (im IBCMiddleware) OnChanCloseInit(
 	return im.app.OnChanCloseInit(ctx, portID, channelID)
 }
 
-// OnChanCloseConfirm implements the IBCMiddleware interface
+// OnChanCloseConfirm implements the IBCMiddleware interface.
 func (im IBCMiddleware) OnChanCloseConfirm(
 	ctx sdk.Context,
 	portID,
@@ -118,7 +119,7 @@ func (im IBCMiddleware) OnChanCloseConfirm(
 	return im.app.OnChanCloseConfirm(ctx, portID, channelID)
 }
 
-// OnRecvPacket implements the IBCMiddleware interface
+// OnRecvPacket implements the IBCMiddleware interface.
 func (im IBCMiddleware) OnRecvPacket(
 	ctx sdk.Context,
 	packet channeltypes.Packet,
@@ -136,6 +137,7 @@ func (im IBCMiddleware) OnRecvPacket(
 	}
 
 	var msg Message
+
 	var err error
 
 	if err = json.Unmarshal([]byte(data.GetMemo()), &msg); err != nil {
@@ -166,6 +168,7 @@ func (im IBCMiddleware) OnRecvPacket(
 				),
 			)
 		}
+
 		denom := parseDenom(packet, data.Denom)
 
 		err = im.handler.HandleGeneralMessageWithToken(
@@ -182,6 +185,7 @@ func (im IBCMiddleware) OnRecvPacket(
 		ctx.Logger().With(
 			fmt.Errorf("unrecognized message type: %d", msg.Type)).
 			Error("unrecognized gmp message")
+
 		return ack
 	}
 
@@ -192,7 +196,7 @@ func (im IBCMiddleware) OnRecvPacket(
 	return ack
 }
 
-// OnAcknowledgementPacket implements the IBCMiddleware interface
+// OnAcknowledgementPacket implements the IBCMiddleware interface.
 func (im IBCMiddleware) OnAcknowledgementPacket(
 	ctx sdk.Context,
 	packet channeltypes.Packet,
@@ -202,7 +206,7 @@ func (im IBCMiddleware) OnAcknowledgementPacket(
 	return im.app.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
 }
 
-// OnTimeoutPacket implements the IBCMiddleware interface
+// OnTimeoutPacket implements the IBCMiddleware interface.
 func (im IBCMiddleware) OnTimeoutPacket(
 	ctx sdk.Context,
 	packet channeltypes.Packet,

--- a/warden/app/gmp/handler.go
+++ b/warden/app/gmp/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 )
 
@@ -50,10 +51,12 @@ func (h GmpHandler) HandleGeneralMessage(
 	if err != nil {
 		return err
 	}
+
 	msg, err := types.NewGmpDecoder(payload)
 	if err != nil {
 		return err
 	}
+
 	ctx.Logger().Info("HandleGeneralMessage GMP Decoder", "msg", msg)
 	tx := &types.MsgBridge{
 		Relayer:                     h.relayer,
@@ -62,14 +65,16 @@ func (h GmpHandler) HandleGeneralMessage(
 		DestinationContractAddress:  msg.DestinationContractAddress.Hex(),
 		DestinationContractCalldata: msg.DestinationContractCalldata,
 	}
+
 	err = tx.ValidateBasic()
 	if err != nil {
 		return err
 	}
+
 	ctx.Logger().Info("HandleGeneralMessage GMP Decoder", "tx", tx)
 
 	// TODO: add custom logic to handle GMP
-	//_, err = h.gmp.Bridge(ctx, tx)
+	// _, err = h.gmp.Bridge(ctx, tx)
 	return err
 }
 
@@ -97,10 +102,12 @@ func (h GmpHandler) HandleGeneralMessageWithToken(
 	if err != nil {
 		return err
 	}
+
 	msg, err := types.NewGmpDecoder(payload)
 	if err != nil {
 		return err
 	}
+
 	ctx.Logger().Info("HandleGeneralMessageWithToken GMP Decoder", "msg", msg)
 	tx := &types.MsgBridge{
 		Relayer:                     h.relayer,
@@ -110,13 +117,15 @@ func (h GmpHandler) HandleGeneralMessageWithToken(
 		DestinationContractCalldata: msg.DestinationContractCalldata,
 		Token:                       coin,
 	}
+
 	err = tx.ValidateBasic()
 	if err != nil {
 		return err
 	}
+
 	ctx.Logger().Info("HandleGeneralMessage GMP Decoder", "tx", tx)
 
 	// TODO: add custom logic to handle GMP
-	//_, err = h.gmp.Bridge(ctx, tx)
+	// _, err = h.gmp.Bridge(ctx, tx)
 	return err
 }

--- a/warden/app/gmp/types.go
+++ b/warden/app/gmp/types.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
+
 	gmptypes "github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 )
 
@@ -33,7 +34,7 @@ type GeneralMessageHandler interface {
 	) error
 }
 
-// Message is attached in ICS20 packet memo field
+// Message is attached in ICS20 packet memo field.
 type Message struct {
 	SourceChain   string `json:"source_chain"`
 	SourceAddress string `json:"source_address"`
@@ -45,13 +46,15 @@ func verifyParams(params gmptypes.Params, sender string, channel string) error {
 	if !strings.EqualFold(params.GmpAddress, sender) {
 		return fmt.Errorf("invalid sender address: %s", sender)
 	}
+
 	if !strings.EqualFold(params.GmpChannel, channel) {
 		return fmt.Errorf("invalid channel: %s", channel)
 	}
+
 	return nil
 }
 
-// parseDenom convert denom to receiver chain representation
+// parseDenom convert denom to receiver chain representation.
 func parseDenom(packet channeltypes.Packet, denom string) string {
 	if types.ReceiverChainIsSource(packet.GetSourcePort(), packet.GetSourceChannel(), denom) {
 		// remove prefix added by sender chain

--- a/warden/app/legacy.go
+++ b/warden/app/legacy.go
@@ -5,8 +5,6 @@ import (
 	"maps"
 	"path/filepath"
 
-	"github.com/evmos/evmos/v20/x/evm/core/vm"
-
 	"cosmossdk.io/core/appmodule"
 	storetypes "cosmossdk.io/store/types"
 	"github.com/CosmWasm/wasmd/x/wasm"
@@ -21,7 +19,9 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	ibchooks "github.com/cosmos/ibc-apps/modules/ibc-hooks/v8"
 	ibchookskeeper "github.com/cosmos/ibc-apps/modules/ibc-hooks/v8/keeper"
+	ibchookstypes "github.com/cosmos/ibc-apps/modules/ibc-hooks/v8/types"
 	"github.com/cosmos/ibc-go/modules/capability"
 	capabilitykeeper "github.com/cosmos/ibc-go/modules/capability/keeper"
 	capabilitytypes "github.com/cosmos/ibc-go/modules/capability/types"
@@ -39,17 +39,25 @@ import (
 	ibctransferkeeper "github.com/cosmos/ibc-go/v8/modules/apps/transfer/keeper"
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	ibc "github.com/cosmos/ibc-go/v8/modules/core"
-	ibcclienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types" //nolint:all
+	ibcclienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	ibcconnectiontypes "github.com/cosmos/ibc-go/v8/modules/core/03-connection/types"
 	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	solomachine "github.com/cosmos/ibc-go/v8/modules/light-clients/06-solomachine"
 	ibctm "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
+	srvflags "github.com/evmos/evmos/v20/server/flags"
+	erc20keeper "github.com/evmos/evmos/v20/x/erc20/keeper"
+	erc20types "github.com/evmos/evmos/v20/x/erc20/types"
+	"github.com/evmos/evmos/v20/x/evm"
+	"github.com/evmos/evmos/v20/x/evm/core/vm"
+	evmkeeper "github.com/evmos/evmos/v20/x/evm/keeper"
+	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
+	"github.com/evmos/evmos/v20/x/feemarket"
+	feemarketkeeper "github.com/evmos/evmos/v20/x/feemarket/keeper"
+	feemarkettypes "github.com/evmos/evmos/v20/x/feemarket/types"
 	"github.com/spf13/cast"
 
-	ibchooks "github.com/cosmos/ibc-apps/modules/ibc-hooks/v8"
-	ibchookstypes "github.com/cosmos/ibc-apps/modules/ibc-hooks/v8/types"
 	wardenprecompiles "github.com/warden-protocol/wardenprotocol/precompiles"
 	gmpmiddleware "github.com/warden-protocol/wardenprotocol/warden/app/gmp"
 	wasminterop "github.com/warden-protocol/wardenprotocol/warden/app/wasm-interop"
@@ -59,18 +67,6 @@ import (
 	"github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/keeper"
 	ibctransfer "github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/module"
 	wardenkeeper "github.com/warden-protocol/wardenprotocol/warden/x/warden/keeper"
-
-	// evmos
-	srvflags "github.com/evmos/evmos/v20/server/flags"
-	erc20keeper "github.com/evmos/evmos/v20/x/erc20/keeper"
-	erc20types "github.com/evmos/evmos/v20/x/erc20/types"
-	"github.com/evmos/evmos/v20/x/evm"
-	evmkeeper "github.com/evmos/evmos/v20/x/evm/keeper"
-	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
-	"github.com/evmos/evmos/v20/x/feemarket"
-	feemarketkeeper "github.com/evmos/evmos/v20/x/feemarket/keeper"
-	feemarkettypes "github.com/evmos/evmos/v20/x/feemarket/types"
-	// this line is used by starport scaffolding # ibc/app/import
 )
 
 // registerLegacyModules register IBC and WASM keepers and non dependency inject modules.
@@ -235,6 +231,7 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 
 	homePath := cast.ToString(appOpts.Get(flags.FlagHome))
 	wasmDir := filepath.Join(homePath, "wasm")
+
 	wasmConfig, err := wasm.ReadWasmConfig(appOpts)
 	if err != nil {
 		panic(fmt.Sprintf("error while reading wasm config: %s", err))
@@ -340,6 +337,7 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 	// NOTE: we are just adding the default Ethereum precompiles here.
 	// Additional precompiles could be added if desired.
 	precompiles := maps.Clone(vm.PrecompiledContractsBerlin)
+
 	wardenprecompiles, err := wardenprecompiles.NewWardenPrecompiles(
 		app.WardenKeeper,
 		app.ActKeeper,
@@ -349,11 +347,13 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 	if err != nil {
 		panic(err)
 	}
+
 	for a, p := range wardenprecompiles {
 		_, found := precompiles[a]
 		if found {
 			panic(fmt.Errorf("precompiles address already registered: %v", a))
 		}
+
 		precompiles[a] = p
 	}
 
@@ -372,7 +372,7 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 		ibctm.AppModule{},
 		solomachine.AppModule{},
 		ibchooks.NewAppModule(app.AccountKeeper),
-		//wasm module
+		// wasm module
 		wasm.NewAppModule(app.AppCodec(), &app.WasmKeeper, app.StakingKeeper, app.AccountKeeper, app.BankKeeper, app.MsgServiceRouter(), app.GetSubspace(wasmtypes.ModuleName)),
 		// evmOS modules
 		feemarket.NewAppModule(app.FeeMarketKeeper, app.GetSubspace(feemarkettypes.ModuleName)),
@@ -380,6 +380,7 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 	); err != nil {
 		panic(err)
 	}
+
 	return wasmConfig
 }
 

--- a/warden/app/oracle.go
+++ b/warden/app/oracle.go
@@ -49,10 +49,12 @@ func (app *App) setupMempool() {
 
 func (app *App) setupSlinkyClient(appOpts types.AppOptions) {
 	chainID := app.ChainID()
+
 	c, err := NewSlinkyClient(app.Logger(), chainID, appOpts, app.StakingKeeper, app.OracleKeeper)
 	if err != nil {
 		panic(err)
 	}
+
 	app.slinkyClient = c
 }
 
@@ -181,6 +183,7 @@ func (sc *SlinkyClient) PreblockHandler() *oraclepreblock.PreBlockHandler {
 
 func (sc *SlinkyClient) VoteExtensionHandler() *ve.VoteExtensionHandler {
 	cps := currencypair.NewDeltaCurrencyPairStrategy(sc.oracleKeeper)
+
 	return ve.NewVoteExtensionHandler(
 		sc.logger,
 		sc.client,

--- a/warden/app/sim_bench_test.go
+++ b/warden/app/sim_bench_test.go
@@ -17,8 +17,7 @@ import (
 	"github.com/warden-protocol/wardenprotocol/warden/app"
 )
 
-// Profile with:
-// `go test -benchmem -run=^$ -bench ^BenchmarkFullAppSimulation ./app -Commit=true -cpuprofile cpu.out`
+// `go test -benchmem -run=^$ -bench ^BenchmarkFullAppSimulation ./app -Commit=true -cpuprofile cpu.out`.
 func BenchmarkFullAppSimulation(b *testing.B) {
 	b.ReportAllocs()
 
@@ -137,7 +136,6 @@ func BenchmarkInvariants(b *testing.B) {
 	// NOTE: We use the crisis keeper as it has all the invariants registered with
 	// their respective metadata which makes it useful for testing/benchmarking.
 	for _, cr := range bApp.CrisisKeeper.Routes() {
-		cr := cr
 		b.Run(fmt.Sprintf("%s/%s", cr.ModuleName, cr.Route), func(b *testing.B) {
 			if res, stop := cr.Invar(ctx); stop {
 				b.Fatalf(

--- a/warden/app/wasm-interop/custom_msg.go
+++ b/warden/app/wasm-interop/custom_msg.go
@@ -2,11 +2,12 @@ package wasm_interop
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
 	acttypes "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
@@ -39,17 +40,19 @@ type NewSignRequest struct {
 
 func EncodeCustomMsg(sender sdk.AccAddress, rawMsg json.RawMessage) ([]sdk.Msg, error) {
 	var msg WardenProtocolMsg
+
 	err := json.Unmarshal(rawMsg, &msg)
 	if err != nil {
 		return nil, err
 	}
+
 	switch {
 	case msg.Warden.NewKeyRequest != nil:
 		return handleNewKeyRequest(sender, msg)
 	case msg.Warden.NewSignRequest != nil:
 		return handleNewSignRequest(sender, msg)
 	default:
-		return nil, fmt.Errorf("unknown variant of WardenProtocolMsg")
+		return nil, errors.New("unknown variant of WardenProtocolMsg")
 	}
 }
 
@@ -64,6 +67,7 @@ func handleNewKeyRequest(sender sdk.AccAddress, msg WardenProtocolMsg) ([]sdk.Ms
 		ApproveTemplateId: newKeyRequest.ApproveTemplateId,
 		RejectTemplateId:  newKeyRequest.RejectTemplateId,
 	}
+
 	msgAny, err := codectypes.NewAnyWithValue(newKeyMsg)
 	if err != nil {
 		return nil, err
@@ -74,6 +78,7 @@ func handleNewKeyRequest(sender sdk.AccAddress, msg WardenProtocolMsg) ([]sdk.Ms
 		Message:             msgAny,
 		ActionTimeoutHeight: newKeyRequest.TimeoutHeight,
 	}
+
 	return []sdk.Msg{newActionMsg}, nil
 }
 
@@ -87,6 +92,7 @@ func handleNewSignRequest(sender sdk.AccAddress, msg WardenProtocolMsg) ([]sdk.M
 		Analyzers:     newSignRequest.Analyzers,
 		EncryptionKey: newSignRequest.EncryptionKey,
 	}
+
 	msgAny, err := codectypes.NewAnyWithValue(newKeyMsg)
 	if err != nil {
 		return nil, err
@@ -97,5 +103,6 @@ func handleNewSignRequest(sender sdk.AccAddress, msg WardenProtocolMsg) ([]sdk.M
 		Message:             msgAny,
 		ActionTimeoutHeight: newSignRequest.TimeoutHeight,
 	}
+
 	return []sdk.Msg{newActionMsg}, nil
 }

--- a/warden/app/wasm-interop/custom_query.go
+++ b/warden/app/wasm-interop/custom_query.go
@@ -2,8 +2,10 @@ package wasm_interop
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	wardenkeeper "github.com/warden-protocol/wardenprotocol/warden/x/warden/keeper"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
@@ -23,43 +25,50 @@ type WardenQuery struct {
 func CustomQuerier(wardenKeeper wardenkeeper.Keeper) func(ctx sdk.Context, rawRequest json.RawMessage) ([]byte, error) {
 	return func(ctx sdk.Context, rawRequest json.RawMessage) ([]byte, error) {
 		var query WardenProtocolQuery
+
 		err := json.Unmarshal(rawRequest, &query)
 		if err != nil {
 			return nil, err
 		}
+
 		switch {
 		case query.Warden.AllKeys != nil:
 			response, err := wardenKeeper.AllKeys(ctx, query.Warden.AllKeys)
 			if err != nil {
 				return nil, err
 			}
+
 			return json.Marshal(response)
 		case query.Warden.KeysBySpaceId != nil:
 			response, err := wardenKeeper.KeysBySpaceId(ctx, query.Warden.KeysBySpaceId)
 			if err != nil {
 				return nil, err
 			}
+
 			return json.Marshal(response)
 		case query.Warden.KeyById != nil:
 			response, err := wardenKeeper.KeyById(ctx, query.Warden.KeyById)
 			if err != nil {
 				return nil, err
 			}
+
 			return json.Marshal(response)
 		case query.Warden.SignRequests != nil:
 			response, err := wardenKeeper.SignRequests(ctx, query.Warden.SignRequests)
 			if err != nil {
 				return nil, err
 			}
+
 			return json.Marshal(response)
 		case query.Warden.SignRequestById != nil:
 			response, err := wardenKeeper.SignRequestById(ctx, query.Warden.SignRequestById)
 			if err != nil {
 				return nil, err
 			}
+
 			return json.Marshal(response)
 		default:
-			return nil, fmt.Errorf("unknown variant of WardenProtocolQuery")
+			return nil, errors.New("unknown variant of WardenProtocolQuery")
 		}
 	}
 }

--- a/warden/repo/seqcollection.go
+++ b/warden/repo/seqcollection.go
@@ -2,14 +2,13 @@ package repo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"cosmossdk.io/collections"
 )
 
-var (
-	ErrInvalidID = fmt.Errorf("invalid ID")
-)
+var ErrInvalidID = errors.New("invalid ID")
 
 // SeqCollection is an opinionated collection built on top of Cosmos SDK's Collections that uses a Sequence as ID for the Map.
 //
@@ -37,6 +36,7 @@ func (c SeqCollection[V]) Set(ctx context.Context, id uint64, obj V) error {
 	if id == 0 {
 		return ErrInvalidID
 	}
+
 	return c.Map.Set(ctx, id, obj)
 }
 
@@ -45,7 +45,9 @@ func (c SeqCollection[V]) Append(ctx context.Context, obj *V) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	c.setId(obj, id)
+
 	return id, c.Map.Set(ctx, id, *obj)
 }
 
@@ -70,6 +72,7 @@ func (c SeqCollection[V]) Import(ctx context.Context, values []V, getIDFn func(V
 			return fmt.Errorf("ID mismatch: expected %d, got %d. Cannot import this list of values.", id, actualID)
 		}
 	}
+
 	return nil
 }
 
@@ -78,5 +81,6 @@ func (c SeqCollection[V]) Export(ctx context.Context) ([]V, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return iter.Values()
 }

--- a/warden/testutil/network/network.go
+++ b/warden/testutil/network/network.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/testutil/network"
@@ -19,43 +18,51 @@ type (
 // Accepts optional config, that will be used in place of the DefaultConfig() if provided.
 func New(t *testing.T, configs ...Config) *Network {
 	t.Helper()
+
 	if len(configs) > 1 {
 		panic("at most one config should be provided")
 	}
+
 	var cfg network.Config
 	if len(configs) == 0 {
 		cfg = DefaultConfig()
 	} else {
 		cfg = configs[0]
 	}
+
 	net, err := network.New(t, t.TempDir(), cfg)
 	require.NoError(t, err)
 	_, err = net.WaitForHeight(1)
 	require.NoError(t, err)
 	t.Cleanup(net.Cleanup)
+
 	return net
 }
 
-// DefaultConfig will initialize config for the network with custom application,
-// genesis and single validator. All other parameters are inherited from cosmos-sdk/testutil/network.DefaultConfig
+// genesis and single validator. All other parameters are inherited from cosmos-sdk/testutil/network.DefaultConfig.
 func DefaultConfig() network.Config {
 	cfg, err := network.DefaultConfigWithAppConfig(app.AppConfig())
 	if err != nil {
 		panic(err)
 	}
+
 	ports, err := freePorts(3)
 	if err != nil {
 		panic(err)
 	}
+
 	if cfg.APIAddress == "" {
-		cfg.APIAddress = fmt.Sprintf("tcp://0.0.0.0:%s", ports[0])
+		cfg.APIAddress = "tcp://0.0.0.0:" + ports[0]
 	}
+
 	if cfg.RPCAddress == "" {
-		cfg.RPCAddress = fmt.Sprintf("tcp://0.0.0.0:%s", ports[1])
+		cfg.RPCAddress = "tcp://0.0.0.0:" + ports[1]
 	}
+
 	if cfg.GRPCAddress == "" {
-		cfg.GRPCAddress = fmt.Sprintf("0.0.0.0:%s", ports[2])
+		cfg.GRPCAddress = "0.0.0.0:" + ports[2]
 	}
+
 	return cfg
 }
 
@@ -63,18 +70,22 @@ func DefaultConfig() network.Config {
 func freePorts(n int) ([]string, error) {
 	closeFns := make([]func() error, n)
 	ports := make([]string, n)
-	for i := 0; i < n; i++ {
+
+	for i := range n {
 		_, port, closeFn, err := network.FreeTCPAddr()
 		if err != nil {
 			return nil, err
 		}
+
 		ports[i] = port
 		closeFns[i] = closeFn
 	}
+
 	for _, closeFn := range closeFns {
 		if err := closeFn(); err != nil {
 			return nil, err
 		}
 	}
+
 	return ports, nil
 }

--- a/warden/testutil/nullify/nullify.go
+++ b/warden/testutil/nullify/nullify.go
@@ -20,18 +20,19 @@ func Fill(x interface{}) interface{} {
 	v := reflect.Indirect(reflect.ValueOf(x))
 	switch v.Kind() {
 	case reflect.Slice:
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			obj := v.Index(i)
 			objPt := reflect.NewAt(obj.Type(), unsafe.Pointer(obj.UnsafeAddr())).Interface()
 			objPt = Fill(objPt)
 			obj.Set(reflect.ValueOf(objPt))
 		}
 	case reflect.Struct:
-		for i := 0; i < v.NumField(); i++ {
+		for i := range v.NumField() {
 			f := reflect.Indirect(v.Field(i))
 			if !f.CanSet() {
 				continue
 			}
+
 			switch f.Kind() {
 			case reflect.Slice:
 				f.Set(reflect.MakeSlice(f.Type(), 0, 0))
@@ -53,5 +54,6 @@ func Fill(x interface{}) interface{} {
 			}
 		}
 	}
+
 	return reflect.Indirect(v).Interface()
 }

--- a/warden/testutil/sample/sample.go
+++ b/warden/testutil/sample/sample.go
@@ -5,9 +5,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// AccAddress returns a sample account address
+// AccAddress returns a sample account address.
 func AccAddress() string {
 	pk := ed25519.GenPrivKey().PubKey()
 	addr := pk.Address()
+
 	return sdk.AccAddress(addr).String()
 }

--- a/warden/x/act/cosmoshield/cosmosshield.go
+++ b/warden/x/act/cosmoshield/cosmosshield.go
@@ -68,5 +68,6 @@ func path(name string) (string, string) {
 	if len(parts) == 1 {
 		return "", name
 	}
+
 	return parts[0], parts[1]
 }

--- a/warden/x/act/keeper/abci.go
+++ b/warden/x/act/keeper/abci.go
@@ -2,8 +2,9 @@ package keeper
 
 import (
 	"context"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (k Keeper) EndBlocker(ctx context.Context) error {
@@ -29,7 +30,8 @@ func (k Keeper) pruneActions(
 	ctx context.Context,
 	blockHeight int64,
 	pruneCheckBlockFrequency int64,
-	maxPendingTime, maxCompletedTime time.Duration) error {
+	maxPendingTime, maxCompletedTime time.Duration,
+) error {
 	latestPruneHeight, err := k.ActionKeeper.GetLatestPruneHeight(ctx)
 	if err != nil {
 		return err
@@ -40,6 +42,7 @@ func (k Keeper) pruneActions(
 	}
 
 	blockTime := k.getBlockTime(ctx)
+
 	expiredActions, err := k.ActionKeeper.ExpiredActions(ctx, blockTime, maxPendingTime, maxCompletedTime)
 	if err != nil {
 		return err

--- a/warden/x/act/keeper/actions_keeper.go
+++ b/warden/x/act/keeper/actions_keeper.go
@@ -10,8 +10,8 @@ import (
 	"cosmossdk.io/core/store"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/warden-protocol/wardenprotocol/warden/repo"
 
+	"github.com/warden-protocol/wardenprotocol/warden/repo"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
@@ -82,6 +82,7 @@ func (k *ActionKeeper) updateMentions(ctx context.Context, action *types.Action,
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -93,7 +94,6 @@ func (k ActionKeeper) Import(ctx sdk.Context, actions []types.Action) error {
 	err := k.Coll().Import(ctx, actions, func(action types.Action) uint64 {
 		return action.Id
 	})
-
 	if err != nil {
 		return err
 	}
@@ -141,6 +141,7 @@ func (k ActionKeeper) GetLatestPruneHeight(ctx context.Context) (int64, error) {
 	if errors.Is(err, collections.ErrNotFound) {
 		return 0, nil
 	}
+
 	return h, err
 }
 
@@ -152,11 +153,13 @@ func (k ActionKeeper) ExpiredActions(ctx context.Context, blockTime time.Time, p
 	defer it.Close()
 
 	var actions []types.Action
+
 	for ; it.Valid(); it.Next() {
 		act, err := it.Value()
 		if err != nil {
 			return nil, err
 		}
+
 		if isExpired(act, blockTime, pendingTimeout, completedTimeout) {
 			actions = append(actions, act)
 		}

--- a/warden/x/act/keeper/genesis.go
+++ b/warden/x/act/keeper/genesis.go
@@ -2,7 +2,9 @@ package keeper
 
 import (
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
@@ -27,12 +29,14 @@ func (k *Keeper) ExportState(ctx sdk.Context, genState *types.GenesisState) erro
 	if err != nil {
 		return fmt.Errorf("failed to export templates: %w", err)
 	}
+
 	genState.Templates = templates
 
 	actions, err := k.ActionKeeper.Coll().Export(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to export actions: %w", err)
 	}
+
 	genState.Actions = actions
 
 	return nil

--- a/warden/x/act/keeper/keeper.go
+++ b/warden/x/act/keeper/keeper.go
@@ -56,11 +56,11 @@ func NewKeeper(
 	templatesRegistry *types.TemplatesRegistry,
 ) Keeper {
 	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
-		panic(fmt.Sprintf("invalid authority address: %s", authority))
+		panic("invalid authority address: " + authority)
 	}
 
 	if _, err := sdk.AccAddressFromBech32(actModuleAddress); err != nil {
-		panic(fmt.Sprintf("invalid x/act module address: %s", actModuleAddress))
+		panic("invalid x/act module address: " + actModuleAddress)
 	}
 
 	sb := collections.NewSchemaBuilder(storeService)
@@ -101,7 +101,7 @@ func (k Keeper) GetModuleAddress() string {
 
 // Logger returns a module-specific logger.
 func (k Keeper) Logger() log.Logger {
-	return k.logger.With("module", fmt.Sprintf("x/%s", types.ModuleName))
+	return k.logger.With("module", "x/"+types.ModuleName)
 }
 
 func (k Keeper) getBlockTime(ctx context.Context) time.Time {

--- a/warden/x/act/keeper/msg_server_check_action.go
+++ b/warden/x/act/keeper/msg_server_check_action.go
@@ -5,11 +5,13 @@ import (
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
 func (k msgServer) CheckAction(goCtx context.Context, msg *types.MsgCheckAction) (*types.MsgCheckActionResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
 	act, err := k.ActionKeeper.Get(ctx, msg.ActionId)
 	if err != nil {
 		return nil, err
@@ -18,10 +20,12 @@ func (k msgServer) CheckAction(goCtx context.Context, msg *types.MsgCheckAction)
 	if act.Status != types.ActionStatus_ACTION_STATUS_PENDING {
 		return nil, errors.Wrapf(types.ErrInvalidActionStatus, "action not pending")
 	}
+
 	if act.TimeoutHeight > 0 && act.TimeoutHeight < uint64(ctx.BlockHeight()) {
 		if err := act.SetStatus(ctx, types.ActionStatus_ACTION_STATUS_TIMEOUT); err != nil {
 			return nil, err
 		}
+
 		err := k.ActionKeeper.Set(ctx, act)
 		if err != nil {
 			return nil, err

--- a/warden/x/act/keeper/msg_server_new_action.go
+++ b/warden/x/act/keeper/msg_server_new_action.go
@@ -6,12 +6,14 @@ import (
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/warden-protocol/wardenprotocol/shield"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
 func (k msgServer) NewAction(ctx context.Context, msg *types.MsgNewAction) (*types.MsgNewActionResponse, error) {
 	var message sdk.Msg
+
 	err := k.cdc.UnpackAny(msg.Message, &message)
 	if err != nil {
 		return nil, fmt.Errorf("can't unpack any: %w", err)

--- a/warden/x/act/keeper/msg_server_new_template.go
+++ b/warden/x/act/keeper/msg_server_new_template.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/warden-protocol/wardenprotocol/shield"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )

--- a/warden/x/act/keeper/msg_server_revoke_action.go
+++ b/warden/x/act/keeper/msg_server_revoke_action.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 

--- a/warden/x/act/keeper/msg_server_vote_for_action.go
+++ b/warden/x/act/keeper/msg_server_vote_for_action.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
@@ -10,8 +11,8 @@ import (
 
 func (k msgServer) VoteForAction(goCtx context.Context, msg *types.MsgVoteForAction) (*types.MsgVoteForActionResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	act, err := k.ActionKeeper.Get(ctx, msg.ActionId)
 
+	act, err := k.ActionKeeper.Get(ctx, msg.ActionId)
 	if err != nil {
 		return nil, err
 	}
@@ -20,6 +21,7 @@ func (k msgServer) VoteForAction(goCtx context.Context, msg *types.MsgVoteForAct
 		if err := act.SetStatus(ctx, types.ActionStatus_ACTION_STATUS_TIMEOUT); err != nil {
 			return nil, err
 		}
+
 		if err := k.ActionKeeper.Set(ctx, act); err != nil {
 			return nil, err
 		}

--- a/warden/x/act/keeper/params.go
+++ b/warden/x/act/keeper/params.go
@@ -8,25 +8,29 @@ import (
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
-// GetParams get all parameters as types.Params
+// GetParams get all parameters as types.Params.
 func (k Keeper) GetParams(ctx context.Context) (params types.Params) {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+
 	bz := store.Get(types.ParamsKey)
 	if bz == nil {
 		return params
 	}
 
 	k.cdc.MustUnmarshal(bz, &params)
+
 	return params
 }
 
-// SetParams set the params
+// SetParams set the params.
 func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+
 	bz, err := k.cdc.Marshal(&params)
 	if err != nil {
 		return err
 	}
+
 	store.Set(types.ParamsKey, bz)
 
 	return nil

--- a/warden/x/act/keeper/query_action_by_id.go
+++ b/warden/x/act/keeper/query_action_by_id.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
 func (k Keeper) ActionById(goCtx context.Context, req *types.QueryActionByIdRequest) (*types.QueryActionByIdResponse, error) {

--- a/warden/x/act/keeper/query_actions.go
+++ b/warden/x/act/keeper/query_actions.go
@@ -5,9 +5,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
 func (k Keeper) Actions(goCtx context.Context, req *types.QueryActionsRequest) (*types.QueryActionsResponse, error) {
@@ -20,7 +21,6 @@ func (k Keeper) Actions(goCtx context.Context, req *types.QueryActionsRequest) (
 	actions, pageRes, err := query.CollectionPaginate(ctx, k.ActionKeeper.Coll(), req.Pagination, func(key uint64, action types.Action) (types.Action, error) {
 		return action, nil
 	})
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/act/keeper/query_actions_by_address.go
+++ b/warden/x/act/keeper/query_actions_by_address.go
@@ -6,9 +6,10 @@ import (
 	"cosmossdk.io/collections"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
 func (k Keeper) ActionsByAddress(goCtx context.Context, req *types.QueryActionsByAddressRequest) (*types.QueryActionsByAddressResponse, error) {
@@ -35,10 +36,12 @@ func (k Keeper) ActionsByAddress(goCtx context.Context, req *types.QueryActionsB
 	}
 
 	var result []types.Action
+
 	for _, action := range actions {
 		if req.Status != types.ActionStatus_ACTION_STATUS_UNSPECIFIED && action.Status != req.Status {
 			continue
 		}
+
 		result = append(result, action)
 	}
 

--- a/warden/x/act/keeper/query_actions_by_address_test.go
+++ b/warden/x/act/keeper/query_actions_by_address_test.go
@@ -21,7 +21,7 @@ func Benchmark_QueryActionsByAddress(b *testing.B) {
 	k, ctx := keepertest.ActKeeper(b)
 
 	// create many actions, each with a unique address
-	for i := 0; i < 100_000; i++ {
+	for i := range 100_000 {
 		addr := sdk.MustBech32ifyAddressBytes(sdk.GetConfig().GetBech32AccountAddrPrefix(), []byte(fmt.Sprintf("address-%d", i)))
 
 		_, err := k.ActionKeeper.New(
@@ -45,8 +45,10 @@ func Benchmark_QueryActionsByAddress(b *testing.B) {
 			Limit:      1,
 		},
 	}
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for range b.N {
 		res, err := k.ActionsByAddress(ctx, req)
 		require.NoError(b, err)
 		require.NotNil(b, res)

--- a/warden/x/act/keeper/query_params.go
+++ b/warden/x/act/keeper/query_params.go
@@ -14,6 +14,7 @@ func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*t
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil

--- a/warden/x/act/keeper/query_simulate_template.go
+++ b/warden/x/act/keeper/query_simulate_template.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/warden-protocol/wardenprotocol/shield"
 	"github.com/warden-protocol/wardenprotocol/shield/object"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func (k Keeper) SimulateTemplate(goCtx context.Context, req *types.QuerySimulateTemplateRequest) (*types.QuerySimulateTemplateResponse, error) {

--- a/warden/x/act/keeper/query_template_by_id.go
+++ b/warden/x/act/keeper/query_template_by_id.go
@@ -4,13 +4,15 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
-// nolint:stylecheck,st1003
 // revive:disable-next-line var-naming
+//
+//nolint:stylecheck,st1003
 func (k Keeper) TemplateById(goCtx context.Context, req *types.QueryTemplateByIdRequest) (*types.QueryTemplateByIdResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")

--- a/warden/x/act/keeper/query_templates.go
+++ b/warden/x/act/keeper/query_templates.go
@@ -5,9 +5,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
 func (k Keeper) Templates(goCtx context.Context, req *types.QueryTemplatesRequest) (*types.QueryTemplatesResponse, error) {
@@ -27,7 +28,6 @@ func (k Keeper) Templates(goCtx context.Context, req *types.QueryTemplatesReques
 		func(key uint64, value types.Template) (types.Template, error) {
 			return value, nil
 		})
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/act/keeper/templates.go
+++ b/warden/x/act/keeper/templates.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/warden-protocol/wardenprotocol/shield"
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
@@ -15,7 +16,9 @@ func (k Keeper) IsValidTemplate(ctx context.Context, id uint64) error {
 		// we consider 0 as a valid template id for the "default" template
 		return nil
 	}
+
 	_, err := k.GetTemplate(ctx, id)
+
 	return err
 }
 
@@ -41,9 +44,11 @@ func (k *Keeper) preprocessTemplate(ctx context.Context, template types.Template
 	// map addresses into bech32 strings
 	addresses := resolveAddresses(metadata.Identifiers)
 	addressesBech32 := make([]string, 0, len(addresses))
+
 	for _, addr := range addresses {
 		addressesBech32 = append(addressesBech32, addr.String())
 	}
+
 	sort.Strings(addressesBech32)
 
 	return rootAst, addressesBech32, nil
@@ -52,11 +57,13 @@ func (k *Keeper) preprocessTemplate(ctx context.Context, template types.Template
 // resolveAddresses filters a list of string by returning only the ones that are valid bech32 addresses.
 func resolveAddresses(identifiers []string) []sdk.AccAddress {
 	addresses := make([]sdk.AccAddress, 0, len(identifiers))
+
 	for _, ident := range identifiers {
 		addr, err := sdk.AccAddressFromBech32(ident)
 		if err == nil {
 			addresses = append(addresses, addr)
 		}
 	}
+
 	return addresses
 }

--- a/warden/x/act/module/genesis_test.go
+++ b/warden/x/act/module/genesis_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	keepertest "github.com/warden-protocol/wardenprotocol/warden/testutil/keeper"
 	"github.com/warden-protocol/wardenprotocol/warden/testutil/nullify"
 	act "github.com/warden-protocol/wardenprotocol/warden/x/act/module"
@@ -24,6 +25,5 @@ func TestGenesis(t *testing.T) {
 
 	nullify.Fill(&genesisState)
 	nullify.Fill(got)
-
 	// this line is used by starport scaffolding # genesis/test/assert
 }

--- a/warden/x/act/module/module.go
+++ b/warden/x/act/module/module.go
@@ -2,12 +2,13 @@ package act
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
-	"encoding/json"
-	"fmt"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -17,8 +18,6 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-
-	// this line is used by starport scaffolding # 1
 
 	modulev1 "github.com/warden-protocol/wardenprotocol/api/warden/act/module"
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
@@ -79,6 +78,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 	if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
 	}
+
 	return genState.Validate()
 }
 
@@ -93,7 +93,7 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *r
 // AppModule
 // ----------------------------------------------------------------------------
 
-// AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement
+// AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement.
 type AppModule struct {
 	AppModuleBasic
 
@@ -116,13 +116,13 @@ func NewAppModule(
 	}
 }
 
-// RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
+// RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
-// RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value, the InvariantRegistry triggers appropriate logic (most often the chain will be halted)
+// RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value, the InvariantRegistry triggers appropriate logic (most often the chain will be halted).
 func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // InitGenesis performs the module's genesis initialization. It returns no validator updates.

--- a/warden/x/act/module/simulation.go
+++ b/warden/x/act/module/simulation.go
@@ -13,7 +13,7 @@ import (
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
-// avoid unused import issue
+// avoid unused import issue.
 var (
 	_ = actsimulation.FindAccount
 	_ = rand.Rand{}
@@ -32,6 +32,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 	for i, acc := range simState.Accounts {
 		accs[i] = acc.Address.String()
 	}
+
 	actGenesis := types.GenesisState{
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState

--- a/warden/x/act/simulation/helpers.go
+++ b/warden/x/act/simulation/helpers.go
@@ -5,11 +5,12 @@ import (
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 )
 
-// FindAccount find a specific address from an account list
+// FindAccount find a specific address from an account list.
 func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
 	creator, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
 		panic(err)
 	}
+
 	return simtypes.FindAccount(accs, creator)
 }

--- a/warden/x/act/types/v1beta0/action.go
+++ b/warden/x/act/types/v1beta0/action.go
@@ -1,6 +1,7 @@
 package v1beta0
 
 import (
+	"errors"
 	"fmt"
 	time "time"
 
@@ -36,21 +37,23 @@ func (a *Action) SetResult(result proto.Message) error {
 
 	a.Status = ActionStatus_ACTION_STATUS_COMPLETED
 	a.Result = anyV
+
 	return nil
 }
 
 func (a *Action) AddApprover(address string, timestamp time.Time) error {
 	if a.Status != ActionStatus_ACTION_STATUS_PENDING {
-		return fmt.Errorf("action already completed")
+		return errors.New("action already completed")
 	}
 
 	for _, a := range a.Approvers {
 		if a.Address == address {
-			return fmt.Errorf("approver already added")
+			return errors.New("approver already added")
 		}
 	}
 
 	a.Approvers = append(a.Approvers, NewApprover(address, timestamp))
+
 	return nil
 }
 
@@ -59,6 +62,7 @@ func GetActionMessage[Msg sdk.Msg](cdc codectypes.AnyUnpacker, a Action) (Msg, e
 		msg      sdk.Msg
 		emptyMsg Msg
 	)
+
 	if err := cdc.UnpackAny(a.Msg, &msg); err != nil {
 		return emptyMsg, err
 	}

--- a/warden/x/act/types/v1beta0/codec.go
+++ b/warden/x/act/types/v1beta0/codec.go
@@ -4,7 +4,6 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
-	// this line is used by starport scaffolding # 1
 )
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {

--- a/warden/x/act/types/v1beta0/genesis.go
+++ b/warden/x/act/types/v1beta0/genesis.go
@@ -1,13 +1,11 @@
 package v1beta0
 
-import (
 // this line is used by starport scaffolding # genesis/types/import
-)
 
-// DefaultIndex is the default global index
+// DefaultIndex is the default global index.
 const DefaultIndex uint64 = 1
 
-// DefaultGenesis returns the default genesis state
+// DefaultGenesis returns the default genesis state.
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
 		// this line is used by starport scaffolding # genesis/types/default
@@ -19,6 +17,5 @@ func DefaultGenesis() *GenesisState {
 // failure.
 func (gs GenesisState) Validate() error {
 	// this line is used by starport scaffolding # genesis/types/validate
-
 	return gs.Params.Validate()
 }

--- a/warden/x/act/types/v1beta0/genesis_test.go
+++ b/warden/x/act/types/v1beta0/genesis_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta0"
 )
 

--- a/warden/x/act/types/v1beta0/keys.go
+++ b/warden/x/act/types/v1beta0/keys.go
@@ -1,13 +1,13 @@
 package v1beta0
 
 const (
-	// ModuleName defines the module name
+	// ModuleName defines the module name.
 	ModuleName = "intent"
 
-	// StoreKey defines the primary module store key
+	// StoreKey defines the primary module store key.
 	StoreKey = ModuleName
 
-	// MemStoreKey defines the in-memory store key
+	// MemStoreKey defines the in-memory store key.
 	MemStoreKey = "mem_intent"
 
 	ActionCountKey = "action/count"
@@ -17,9 +17,7 @@ const (
 	IntentKey      = "intent/value/"
 )
 
-var (
-	ParamsKey = []byte("p_intent")
-)
+var ParamsKey = []byte("p_intent")
 
 func KeyPrefix(p string) []byte {
 	return []byte(p)

--- a/warden/x/act/types/v1beta0/params.go
+++ b/warden/x/act/types/v1beta0/params.go
@@ -6,27 +6,27 @@ import (
 
 var _ paramtypes.ParamSet = (*Params)(nil)
 
-// ParamKeyTable the param key table for launch module
+// ParamKeyTable the param key table for launch module.
 func ParamKeyTable() paramtypes.KeyTable {
 	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
 }
 
-// NewParams creates a new Params instance
+// NewParams creates a new Params instance.
 func NewParams() Params {
 	return Params{}
 }
 
-// DefaultParams returns a default set of parameters
+// DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
 	return NewParams()
 }
 
-// ParamSetPairs get the params.ParamSet
+// ParamSetPairs get the params.ParamSet.
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{}
 }
 
-// Validate validates the set of params
+// Validate validates the set of params.
 func (p Params) Validate() error {
 	return nil
 }

--- a/warden/x/act/types/v1beta1/action.go
+++ b/warden/x/act/types/v1beta1/action.go
@@ -24,6 +24,7 @@ func (a *Action) SetResult(ctx sdk.Context, result *codectypes.Any) error {
 	}
 
 	a.Result = result
+
 	return nil
 }
 
@@ -31,9 +32,11 @@ func (a *Action) SetStatus(ctx sdk.Context, status ActionStatus) error {
 	if a.Status != ActionStatus_ACTION_STATUS_PENDING {
 		return errors.Wrapf(ErrInvalidActionStatusChange, "from %s to %s", a.Status.String(), status.String())
 	}
+
 	prevStatus := a.Status
 	a.Status = status
 	a.UpdatedAt = ctx.BlockTime()
+
 	return ctx.EventManager().EmitTypedEvent(&EventActionStateChange{
 		Id:             a.Id,
 		PreviousStatus: prevStatus,
@@ -53,6 +56,7 @@ func (a *Action) AddOrUpdateVote(ctx sdk.Context, participant string, voteType A
 			a.Votes[i].VoteType = voteType
 			a.Votes[i].VotedAt = ctx.BlockTime()
 			updated = true
+
 			break
 		}
 	}

--- a/warden/x/act/types/v1beta1/codec.go
+++ b/warden/x/act/types/v1beta1/codec.go
@@ -4,7 +4,6 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
-	// this line is used by starport scaffolding # 1
 )
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {

--- a/warden/x/act/types/v1beta1/errors.go
+++ b/warden/x/act/types/v1beta1/errors.go
@@ -6,7 +6,7 @@ import (
 	sdkerrors "cosmossdk.io/errors"
 )
 
-// x/act module sentinel errors
+// x/act module sentinel errors.
 var (
 	ErrInvalidSigner                = sdkerrors.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
 	ErrInvalidActionMsgSigner       = sdkerrors.Register(ModuleName, 1102, "expected x/act account as only signer for action message")

--- a/warden/x/act/types/v1beta1/expression.go
+++ b/warden/x/act/types/v1beta1/expression.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"cosmossdk.io/errors"
+
 	"github.com/warden-protocol/wardenprotocol/shield"
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
 	"github.com/warden-protocol/wardenprotocol/shield/object"

--- a/warden/x/act/types/v1beta1/genesis.go
+++ b/warden/x/act/types/v1beta1/genesis.go
@@ -1,13 +1,11 @@
 package v1beta1
 
-import (
 // this line is used by starport scaffolding # genesis/types/import
-)
 
-// DefaultIndex is the default global index
+// DefaultIndex is the default global index.
 const DefaultIndex uint64 = 1
 
-// DefaultGenesis returns the default genesis state
+// DefaultGenesis returns the default genesis state.
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
 		// this line is used by starport scaffolding # genesis/types/default
@@ -19,6 +17,5 @@ func DefaultGenesis() *GenesisState {
 // failure.
 func (gs GenesisState) Validate() error {
 	// this line is used by starport scaffolding # genesis/types/validate
-
 	return gs.Params.Validate()
 }

--- a/warden/x/act/types/v1beta1/genesis_test.go
+++ b/warden/x/act/types/v1beta1/genesis_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 

--- a/warden/x/act/types/v1beta1/keys.go
+++ b/warden/x/act/types/v1beta1/keys.go
@@ -1,13 +1,13 @@
 package v1beta1
 
 const (
-	// ModuleName defines the module name
+	// ModuleName defines the module name.
 	ModuleName = "act"
 
-	// StoreKey defines the primary module store key
+	// StoreKey defines the primary module store key.
 	StoreKey = ModuleName
 
-	// MemStoreKey defines the in-memory store key
+	// MemStoreKey defines the in-memory store key.
 	MemStoreKey = "mem_act"
 
 	ActionCountKey = "action/count"
@@ -17,9 +17,7 @@ const (
 	TemplateKey      = "template/value/"
 )
 
-var (
-	ParamsKey = []byte("p_act")
-)
+var ParamsKey = []byte("p_act")
 
 func KeyPrefix(p string) []byte {
 	return []byte(p)

--- a/warden/x/act/types/v1beta1/params.go
+++ b/warden/x/act/types/v1beta1/params.go
@@ -1,22 +1,25 @@
 package v1beta1
 
 import (
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"time"
+
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
 var _ paramtypes.ParamSet = (*Params)(nil)
 
-var DefaultMaxPendingTime time.Duration = time.Hour * 24    // day
-var DefaultMaxCompletedTime time.Duration = time.Hour * 168 // week
-var PruneCheckBlockFrequency int64 = 10000                  // ~17 hours
+var (
+	DefaultMaxPendingTime    time.Duration = time.Hour * 24  // day
+	DefaultMaxCompletedTime  time.Duration = time.Hour * 168 // week
+	PruneCheckBlockFrequency int64         = 10000           // ~17 hours
+)
 
-// NewParams creates a new Params instance
+// NewParams creates a new Params instance.
 func NewParams() Params {
 	return Params{}
 }
 
-// DefaultParams returns a default set of parameters
+// DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
 	return Params{
 		MaxPendingTime:           DefaultMaxPendingTime,
@@ -25,12 +28,12 @@ func DefaultParams() Params {
 	}
 }
 
-// ParamSetPairs get the params.ParamSet
+// ParamSetPairs get the params.ParamSet.
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{}
 }
 
-// Validate validates the set of params
+// Validate validates the set of params.
 func (p Params) Validate() error {
 	return nil
 }

--- a/warden/x/act/types/v1beta1/template.go
+++ b/warden/x/act/types/v1beta1/template.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"cosmossdk.io/errors"
+
 	"github.com/warden-protocol/wardenprotocol/shield"
 	"github.com/warden-protocol/wardenprotocol/shield/object"
 )

--- a/warden/x/async/keeper/abci.go
+++ b/warden/x/async/keeper/abci.go
@@ -7,8 +7,8 @@ import (
 	"cosmossdk.io/collections"
 	cometabci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/skip-mev/slinky/abci/ve"
+
 	"github.com/warden-protocol/wardenprotocol/prophet"
 	"github.com/warden-protocol/wardenprotocol/warden/app/vemanager"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
@@ -72,6 +72,7 @@ func (k Keeper) ExtendVoteHandler() sdk.ExtendVoteHandler {
 		defer done()
 
 		votes := make([]*types.VEVoteItem, len(pVotes))
+
 		for i, v := range pVotes {
 			vote := types.FutureVoteType_VOTE_TYPE_VERIFIED
 			if v.Err != nil {
@@ -85,6 +86,7 @@ func (k Keeper) ExtendVoteHandler() sdk.ExtendVoteHandler {
 		}
 
 		var localHandlers []string
+
 		updateHandlers := false
 		selfConsAddress := k.p.SelfAddress()
 
@@ -94,7 +96,6 @@ func (k Keeper) ExtendVoteHandler() sdk.ExtendVoteHandler {
 			r := collections.NewPrefixedPairRange[sdk.ConsAddress, string](sdk.ConsAddress(selfConsAddress))
 
 			iterator, err := k.handlersByValidator.Iterate(ctx, r)
-
 			if err != nil {
 				return nil, fmt.Errorf("failed to iterate by validator: %w", err)
 			}
@@ -134,6 +135,7 @@ func (k Keeper) ExtendVoteHandler() sdk.ExtendVoteHandler {
 func (k Keeper) VerifyVoteExtensionHandler() sdk.VerifyVoteExtensionHandler {
 	return func(ctx sdk.Context, req *cometabci.RequestVerifyVoteExtension) (*cometabci.ResponseVerifyVoteExtension, error) {
 		var ve types.AsyncVoteExtension
+
 		err := ve.Unmarshal(req.VoteExtension)
 		if err != nil {
 			return &cometabci.ResponseVerifyVoteExtension{
@@ -163,6 +165,7 @@ func (k Keeper) PrepareProposalHandler() sdk.PrepareProposalHandler {
 			log.Error("failed to build async tx", "err", err)
 			return resp, nil
 		}
+
 		resp.Txs = trimExcessBytes(resp.Txs, req.MaxTxBytes-int64(len(asyncTx)))
 		resp.Txs = injectTx(asyncTx, 1, resp.Txs)
 
@@ -181,6 +184,7 @@ func (k Keeper) ProcessProposalHandler() sdk.ProcessProposalHandler {
 		}
 
 		log := ctx.Logger().With("module", "prophet")
+
 		asyncTx := req.Txs[1]
 		if len(asyncTx) == 0 {
 			return resp, nil
@@ -213,6 +217,7 @@ func (k Keeper) PreBlocker() sdk.PreBlocker {
 		}
 
 		log := ctx.Logger().With("module", "x/async")
+
 		asyncTx := req.Txs[1]
 		if len(asyncTx) == 0 {
 			return resp, nil
@@ -320,13 +325,16 @@ func trimExcessBytes(txs [][]byte, maxSizeBytes int64) [][]byte {
 		returnedTxs   [][]byte
 		consumedBytes int64
 	)
+
 	for _, tx := range txs {
 		consumedBytes += int64(len(tx))
 		if consumedBytes > maxSizeBytes {
 			break
 		}
+
 		returnedTxs = append(returnedTxs, tx)
 	}
+
 	return returnedTxs
 }
 

--- a/warden/x/async/keeper/abci_test.go
+++ b/warden/x/async/keeper/abci_test.go
@@ -11,6 +11,7 @@ func TestTrimExcessBytes(t *testing.T) {
 		txs          [][]byte
 		maxSizeBytes int64
 	}
+
 	tests := []struct {
 		name string
 		args args
@@ -78,6 +79,7 @@ func TestInjectTx(t *testing.T) {
 		position int
 		appTxs   [][]byte
 	}
+
 	tests := []struct {
 		name string
 		args args

--- a/warden/x/async/keeper/futures.go
+++ b/warden/x/async/keeper/futures.go
@@ -101,6 +101,7 @@ func (k *FutureKeeper) PendingFutures(ctx context.Context, limit int) ([]types.F
 	defer it.Close()
 
 	futures := make([]types.Future, 0, limit)
+
 	for ; it.Valid(); it.Next() {
 		id, err := it.Key()
 		if err != nil {

--- a/warden/x/async/keeper/genesis.go
+++ b/warden/x/async/keeper/genesis.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
 

--- a/warden/x/async/keeper/keeper.go
+++ b/warden/x/async/keeper/keeper.go
@@ -66,10 +66,10 @@ func NewKeeper(
 	getEvmKeeper func(_placeHolder int16) *evmkeeper.Keeper,
 	asyncModuleAddress sdk.Address,
 	accountKeeper types.AccountKeeper,
-	//selfValAddr sdk.ConsAddress,
+	// selfValAddr sdk.ConsAddress,
 ) Keeper {
 	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
-		panic(fmt.Sprintf("invalid authority address: %s", authority))
+		panic("invalid authority address: " + authority)
 	}
 
 	sb := collections.NewSchemaBuilder(storeService)
@@ -114,7 +114,7 @@ func (k Keeper) GetAuthority() string {
 
 // Logger returns a module-specific logger.
 func (k Keeper) Logger() log.Logger {
-	return k.logger.With("module", fmt.Sprintf("x/%s", types.ModuleName))
+	return k.logger.With("module", "x/"+types.ModuleName)
 }
 
 func (k Keeper) AddFutureResult(ctx context.Context, id uint64, submitter, output []byte) error {
@@ -141,6 +141,7 @@ func (k Keeper) SetFutureVote(ctx context.Context, id uint64, voter []byte, vote
 	if !vote.IsValid() {
 		return fmt.Errorf("invalid vote type: %v", vote)
 	}
+
 	return k.votes.Set(ctx, collections.Join(id, voter), int32(vote))
 }
 
@@ -152,15 +153,18 @@ func (k Keeper) GetFutureVotes(ctx context.Context, futureId uint64) ([]types.Fu
 	defer it.Close()
 
 	var votes []types.FutureVote
+
 	for ; it.Valid(); it.Next() {
 		key, err := it.Key()
 		if err != nil {
 			return nil, err
 		}
+
 		vote, err := it.Value()
 		if err != nil {
 			return nil, err
 		}
+
 		votes = append(votes, types.FutureVote{
 			FutureId: futureId,
 			Voter:    key.K2(),
@@ -177,7 +181,6 @@ func (k Keeper) futureReadyCallback(
 	output []byte,
 ) error {
 	future, err := k.futures.Get(ctx, id)
-
 	if err != nil {
 		return err
 	}
@@ -199,7 +202,6 @@ func (k Keeper) futureReadyCallback(
 	}
 
 	cbAddress, err := precommon.AddressFromBech32Str(future.Callback)
-
 	if err != nil {
 		return err
 	}
@@ -235,6 +237,7 @@ func (k Keeper) callEVMWithData(
 		fromAcc = k.accountKeeper.NewAccountWithAddress(ctx, from.Bytes())
 		k.accountKeeper.SetAccount(ctx, fromAcc)
 	}
+
 	nonce := fromAcc.GetSequence()
 
 	evmKeeper := k.getEvmKeeper(0)
@@ -297,6 +300,7 @@ func (k Keeper) getCompletedFuturesWithoutValidatorVote(ctx context.Context, val
 	defer it.Close()
 
 	futures := make([]prophet.FutureResult, 0, limit)
+
 	for ; it.Valid(); it.Next() {
 		id, err := it.Key()
 		if err != nil {
@@ -312,6 +316,7 @@ func (k Keeper) getCompletedFuturesWithoutValidatorVote(ctx context.Context, val
 		if found {
 			continue
 		}
+
 		if err != nil {
 			return nil, err
 		}

--- a/warden/x/async/keeper/msg_server_add_future.go
+++ b/warden/x/async/keeper/msg_server_add_future.go
@@ -5,6 +5,7 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	precommon "github.com/warden-protocol/wardenprotocol/precompiles/common"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
@@ -30,7 +31,6 @@ func (k msgServer) AddFuture(ctx context.Context, msg *types.MsgAddFuture) (*typ
 
 	if msg.Callback != "" {
 		address, err := precommon.AddressFromBech32Str(msg.Callback)
-
 		if err != nil {
 			return nil, errorsmod.Wrapf(types.ErrInvalidCallback, "invalid callback address: %s", err)
 		}

--- a/warden/x/async/keeper/params.go
+++ b/warden/x/async/keeper/params.go
@@ -8,25 +8,29 @@ import (
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
 
-// GetParams get all parameters as types.Params
+// GetParams get all parameters as types.Params.
 func (k Keeper) GetParams(ctx context.Context) (params types.Params) {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+
 	bz := store.Get(types.ParamsKey)
 	if bz == nil {
 		return params
 	}
 
 	k.cdc.MustUnmarshal(bz, &params)
+
 	return params
 }
 
-// SetParams set the params
+// SetParams set the params.
 func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+
 	bz, err := k.cdc.Marshal(&params)
 	if err != nil {
 		return err
 	}
+
 	store.Set(types.ParamsKey, bz)
 
 	return nil

--- a/warden/x/async/keeper/query_future_by_id.go
+++ b/warden/x/async/keeper/query_future_by_id.go
@@ -22,6 +22,7 @@ func (k Keeper) FutureById(ctx context.Context, req *types.QueryFutureByIdReques
 	}
 
 	var result *types.FutureResult
+
 	r, err := k.futures.GetResult(ctx, req.Id)
 	if err == nil {
 		result = &r

--- a/warden/x/async/keeper/query_futures.go
+++ b/warden/x/async/keeper/query_futures.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 
 	"cosmossdk.io/collections"
+	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/cosmos/cosmos-sdk/types/query"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
 
@@ -20,9 +20,7 @@ func (k Keeper) Futures(ctx context.Context, req *types.QueryFuturesRequest) (*t
 	futures, pageRes, err := query.CollectionFilteredPaginate(ctx, k.futures.Futures(), req.Pagination, func(key uint64, value types.Future) (bool, error) {
 		return req.Creator == "" || req.Creator == value.Creator, nil
 	}, func(key uint64, value types.Future) (types.FutureResponse, error) {
-		var (
-			result *types.FutureResult
-		)
+		var result *types.FutureResult
 
 		r, err := k.futures.GetResult(ctx, value.Id)
 		if err == nil {
@@ -42,7 +40,6 @@ func (k Keeper) Futures(ctx context.Context, req *types.QueryFuturesRequest) (*t
 			Votes:  votes,
 		}, nil
 	})
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/async/keeper/query_handlers_by_validator.go
+++ b/warden/x/async/keeper/query_handlers_by_validator.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"cosmossdk.io/collections"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/query"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
 

--- a/warden/x/async/keeper/query_params.go
+++ b/warden/x/async/keeper/query_params.go
@@ -14,6 +14,7 @@ func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*t
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil

--- a/warden/x/async/keeper/query_pending_futures.go
+++ b/warden/x/async/keeper/query_pending_futures.go
@@ -3,10 +3,10 @@ package keeper
 import (
 	"context"
 
+	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/cosmos/cosmos-sdk/types/query"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
 
@@ -20,11 +20,11 @@ func (k Keeper) PendingFutures(ctx context.Context, req *types.QueryPendingFutur
 		if err != nil {
 			return false, err
 		}
+
 		return !hasResult, nil
 	}, func(key uint64, value types.Future) (types.Future, error) {
 		return value, nil
 	})
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/async/module/genesis_test.go
+++ b/warden/x/async/module/genesis_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	keepertest "github.com/warden-protocol/wardenprotocol/warden/testutil/keeper"
 	"github.com/warden-protocol/wardenprotocol/warden/testutil/nullify"
 	async "github.com/warden-protocol/wardenprotocol/warden/x/async/module"
@@ -24,6 +25,5 @@ func TestGenesis(t *testing.T) {
 
 	nullify.Fill(&genesisState)
 	nullify.Fill(got)
-
 	// this line is used by starport scaffolding # genesis/test/assert
 }

--- a/warden/x/async/module/module.go
+++ b/warden/x/async/module/module.go
@@ -19,8 +19,6 @@ import (
 	evmkeeper "github.com/evmos/evmos/v20/x/evm/keeper"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
-	// this line is used by starport scaffolding # 1
-
 	modulev1 "github.com/warden-protocol/wardenprotocol/api/warden/async/module"
 	"github.com/warden-protocol/wardenprotocol/prophet"
 	"github.com/warden-protocol/wardenprotocol/warden/x/async/keeper"
@@ -79,6 +77,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 	if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
 	}
+
 	return genState.Validate()
 }
 
@@ -93,7 +92,7 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *r
 // AppModule
 // ----------------------------------------------------------------------------
 
-// AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement
+// AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement.
 type AppModule struct {
 	AppModuleBasic
 
@@ -116,13 +115,13 @@ func NewAppModule(
 	}
 }
 
-// RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
+// RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
-// RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value, the InvariantRegistry triggers appropriate logic (most often the chain will be halted)
+// RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value, the InvariantRegistry triggers appropriate logic (most often the chain will be halted).
 func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // InitGenesis performs the module's genesis initialization. It returns no validator updates.

--- a/warden/x/async/module/simulation.go
+++ b/warden/x/async/module/simulation.go
@@ -13,7 +13,7 @@ import (
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
 
-// avoid unused import issue
+// avoid unused import issue.
 var (
 	_ = asyncsimulation.FindAccount
 	_ = rand.Rand{}
@@ -32,6 +32,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 	for i, acc := range simState.Accounts {
 		accs[i] = acc.Address.String()
 	}
+
 	asyncGenesis := types.GenesisState{
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState

--- a/warden/x/async/simulation/helpers.go
+++ b/warden/x/async/simulation/helpers.go
@@ -5,11 +5,12 @@ import (
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 )
 
-// FindAccount find a specific address from an account list
+// FindAccount find a specific address from an account list.
 func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
 	creator, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
 		panic(err)
 	}
+
 	return simtypes.FindAccount(accs, creator)
 }

--- a/warden/x/async/types/v1beta1/errors.go
+++ b/warden/x/async/types/v1beta1/errors.go
@@ -6,7 +6,7 @@ import (
 	sdkerrors "cosmossdk.io/errors"
 )
 
-// x/async module sentinel errors
+// x/async module sentinel errors.
 var (
 	ErrInvalidSigner          = sdkerrors.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
 	ErrInvalidHandler         = sdkerrors.Register(ModuleName, 1102, "invalid handler name")

--- a/warden/x/async/types/v1beta1/genesis.go
+++ b/warden/x/async/types/v1beta1/genesis.go
@@ -2,10 +2,10 @@ package v1beta1
 
 // this line is used by starport scaffolding # genesis/types/import
 
-// DefaultIndex is the default global index
+// DefaultIndex is the default global index.
 const DefaultIndex uint64 = 1
 
-// DefaultGenesis returns the default genesis state
+// DefaultGenesis returns the default genesis state.
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
 		// this line is used by starport scaffolding # genesis/types/default
@@ -17,6 +17,5 @@ func DefaultGenesis() *GenesisState {
 // failure.
 func (gs GenesisState) Validate() error {
 	// this line is used by starport scaffolding # genesis/types/validate
-
 	return gs.Params.Validate()
 }

--- a/warden/x/async/types/v1beta1/keys.go
+++ b/warden/x/async/types/v1beta1/keys.go
@@ -1,10 +1,8 @@
 package v1beta1
 
 const (
-	// ModuleName defines the module name
+	// ModuleName defines the module name.
 	ModuleName = "async"
 )
 
-var (
-	ParamsKey = []byte("p_async")
-)
+var ParamsKey = []byte("p_async")

--- a/warden/x/async/types/v1beta1/params.go
+++ b/warden/x/async/types/v1beta1/params.go
@@ -6,22 +6,22 @@ import (
 
 var _ paramtypes.ParamSet = (*Params)(nil)
 
-// NewParams creates a new Params instance
+// NewParams creates a new Params instance.
 func NewParams() Params {
 	return Params{}
 }
 
-// DefaultParams returns a default set of parameters
+// DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
 	return Params{}
 }
 
-// ParamSetPairs get the params.ParamSet
+// ParamSetPairs get the params.ParamSet.
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{}
 }
 
-// Validate validates the set of params
+// Validate validates the set of params.
 func (p Params) Validate() error {
 	return nil
 }

--- a/warden/x/gmp/cli/query.go
+++ b/warden/x/gmp/cli/query.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
+
 	"github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 )
 
@@ -40,14 +41,15 @@ func GetCmdQueryParams() *cobra.Command {
 			queryClient := types.NewQueryClient(clientCtx)
 
 			res, err := queryClient.Params(cmd.Context(), &types.ParamsRequest{})
-
 			if err != nil {
 				return err
 			}
+
 			return clientCtx.PrintProto(res)
 		},
 	}
 
 	flags.AddQueryFlagsToCmd(cmd)
+
 	return cmd
 }

--- a/warden/x/gmp/cli/tx.go
+++ b/warden/x/gmp/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	"github.com/spf13/cobra"
+
 	"github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 )
 
@@ -43,10 +45,10 @@ func GetCmdBridge() *cobra.Command {
 			}
 
 			if args[0] == "" {
-				return fmt.Errorf("destination-chain cannot be empty")
+				return errors.New("destination-chain cannot be empty")
 			}
 			if args[1] == "" {
-				return fmt.Errorf("warden-contract-address cannot be empty")
+				return errors.New("warden-contract-address cannot be empty")
 			}
 
 			tokens := sdk.Coin{}
@@ -103,16 +105,16 @@ func GetCmdBridgeWithContractCall() *cobra.Command {
 			}
 
 			if args[0] == "" {
-				return fmt.Errorf("destination-chain cannot be empty")
+				return errors.New("destination-chain cannot be empty")
 			}
 			if args[1] == "" {
-				return fmt.Errorf("warden-contract-address cannot be empty")
+				return errors.New("warden-contract-address cannot be empty")
 			}
 			if args[2] == "" {
-				return fmt.Errorf("destination-contract-address cannot be empty")
+				return errors.New("destination-contract-address cannot be empty")
 			}
 			if args[3] == "" {
-				return fmt.Errorf("destination-contract-calldata cannot be empty")
+				return errors.New("destination-contract-calldata cannot be empty")
 			}
 
 			tokens := sdk.Coin{}
@@ -130,7 +132,7 @@ func GetCmdBridgeWithContractCall() *cobra.Command {
 			}
 
 			if len(args[3]) == 0 {
-				return fmt.Errorf("destination-contract-calldata cannot be empty")
+				return errors.New("destination-contract-calldata cannot be empty")
 			}
 
 			destinationContractCalldata, err := base64.StdEncoding.DecodeString(args[3])

--- a/warden/x/gmp/keeper/grpc_query.go
+++ b/warden/x/gmp/keeper/grpc_query.go
@@ -28,5 +28,6 @@ func (q querier) Params(
 ) (*types.ParamsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	params := q.GetParams(ctx)
+
 	return &types.ParamsResponse{Params: params}, nil
 }

--- a/warden/x/gmp/keeper/keeper.go
+++ b/warden/x/gmp/keeper/keeper.go
@@ -7,14 +7,13 @@ import (
 	"time"
 
 	"cosmossdk.io/log"
-	"github.com/ethereum/go-ethereum/common"
-
 	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
-	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types" //nolint:all
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 	"github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/keeper"
 )
@@ -45,7 +44,7 @@ func NewKeeper(
 
 // Logger returns a module-specific logger.
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
-	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
+	return ctx.Logger().With("module", "x/"+types.ModuleName)
 }
 
 // Bridge submits an IBC transfer with a MsgBridge payload.
@@ -73,6 +72,7 @@ func (k Keeper) Bridge(
 		uint64(ctx.BlockTime().Add(time.Duration(params.GmpTimeout)*time.Hour).UnixNano()),
 		string(bz),
 	)
+
 	_, err = k.IBCKeeper.Transfer(ctx, transferMsg)
 	if err != nil {
 		return &types.MsgBridgeResponse{}, err
@@ -92,6 +92,7 @@ func (k Keeper) BuildGmpRequest(
 		common.HexToAddress(msg.DestinationContractAddress),
 		msg.DestinationContractCalldata,
 	)
+
 	payload, err := encoder.GMPEncode()
 	if err != nil {
 		return nil, err
@@ -108,6 +109,7 @@ func (k Keeper) BuildGmpRequest(
 			Recipient: params.FeeRecipient,
 		},
 	}
+
 	bz, err := json.Marshal(&message)
 	if err != nil {
 		k.Logger(ctx).With(err).Error("error marshaling GMP message")
@@ -125,5 +127,6 @@ func (k Keeper) BuildGmpRequest(
 		uint64(ctx.BlockTime().Add(time.Duration(params.GmpTimeout)*time.Hour).UnixNano()),
 		string(bz),
 	)
+
 	return transferMsg, nil
 }

--- a/warden/x/gmp/keeper/msg_server.go
+++ b/warden/x/gmp/keeper/msg_server.go
@@ -5,8 +5,8 @@ import (
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
 	"github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 )
 
@@ -30,6 +30,7 @@ func (ms msgServer) SetParams(goCtx context.Context, msg *types.MsgSetParams) (*
 			ms.keeper.authority,
 			msg.Authority,
 		)
+
 		return nil, err
 	}
 

--- a/warden/x/gmp/keeper/params.go
+++ b/warden/x/gmp/keeper/params.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 )
 
@@ -10,6 +11,7 @@ func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(types.ParamsKey)
 	k.cdc.MustUnmarshal(bz, &params)
+
 	return
 }
 

--- a/warden/x/gmp/module/module.go
+++ b/warden/x/gmp/module/module.go
@@ -92,14 +92,14 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 // AppModule
 // ----------------------------------------------------------------------------
 
-// AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement
+// AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement.
 type AppModule struct {
 	AppModuleBasic
 
 	keeper keeper.Keeper
 }
 
-// NewAppModule creates a new 29-fee module
+// NewAppModule creates a new 29-fee module.
 func NewAppModule(cdc codec.Codec, keeper keeper.Keeper) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(cdc),

--- a/warden/x/gmp/types/abi_decode.go
+++ b/warden/x/gmp/types/abi_decode.go
@@ -24,7 +24,7 @@ var decoderSpec = abi.Arguments{
 	},
 }
 
-// NewGmpDecoder decodes a payload from GMP given a byte array
+// NewGmpDecoder decodes a payload from GMP given a byte array.
 func NewGmpDecoder(payload []byte) (GmpDecoder, error) {
 	args, err := decoderSpec.Unpack(payload)
 	if err != nil {

--- a/warden/x/gmp/types/abi_encode.go
+++ b/warden/x/gmp/types/abi_encode.go
@@ -6,13 +6,13 @@ import (
 )
 
 const (
-	// TypeUnrecognized means coin type is unrecognized
+	// TypeUnrecognized means coin type is unrecognized.
 	TypeUnrecognized = iota
-	// TypeGeneralMessage is a pure message
+	// TypeGeneralMessage is a pure message.
 	TypeGeneralMessage
-	// TypeGeneralMessageWithToken is a general message with token
+	// TypeGeneralMessageWithToken is a general message with token.
 	TypeGeneralMessageWithToken
-	// TypeSendToken is a direct token transfer
+	// TypeSendToken is a direct token transfer.
 	TypeSendToken
 )
 

--- a/warden/x/gmp/types/abi_types.go
+++ b/warden/x/gmp/types/abi_types.go
@@ -12,5 +12,6 @@ func must[T any](t T, err error) T {
 	if err != nil {
 		panic(err)
 	}
+
 	return t
 }

--- a/warden/x/gmp/types/codec.go
+++ b/warden/x/gmp/types/codec.go
@@ -19,7 +19,7 @@ var (
 	ModuleCdc = codec.NewAminoCodec(amino) //nolint:all
 )
 
-// RegisterInterfaces registers the x/gmp interfaces types with the interface registry
+// RegisterInterfaces registers the x/gmp interfaces types with the interface registry.
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgBridge{},

--- a/warden/x/gmp/types/keys.go
+++ b/warden/x/gmp/types/keys.go
@@ -1,20 +1,20 @@
 package types
 
 const (
-	// ModuleName defines the module name
+	// ModuleName defines the module name.
 	ModuleName = "gmp"
 
-	// StoreKey defines the primary module store key
+	// StoreKey defines the primary module store key.
 	StoreKey = ModuleName
 
-	// RouterKey is the message route
+	// RouterKey is the message route.
 	RouterKey = ModuleName
 
-	// QuerierRoute is the query router key for the gmp module
+	// QuerierRoute is the query router key for the gmp module.
 	QuerierRoute = ModuleName
 )
 
-// KVStore key prefixes
+// KVStore key prefixes.
 var (
 	ParamsKey = []byte("p_gmp")
 )

--- a/warden/x/gmp/types/msgs.go
+++ b/warden/x/gmp/types/msgs.go
@@ -1,17 +1,17 @@
 package types
 
 import (
-	fmt "fmt"
+	"errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var _ sdk.Msg = &MsgSetParams{}
 
-// Type implements LegacyMsg interface
+// Type implements LegacyMsg interface.
 func (msg MsgSetParams) Type() string { return sdk.MsgTypeURL(&msg) }
 
-// ValidateBasic Implements sdk.Msg
+// ValidateBasic Implements sdk.Msg.
 func (msg MsgSetParams) ValidateBasic() error {
 	return msg.Params.Validate()
 }
@@ -34,19 +34,21 @@ func NewMsgBridge(
 	}
 }
 
-// Type implements LegacyMsg interface
+// Type implements LegacyMsg interface.
 func (msg MsgBridge) Type() string { return sdk.MsgTypeURL(&msg) }
 
-// ValidateBasic Implements sdk.Msg
+// ValidateBasic Implements sdk.Msg.
 func (msg MsgBridge) ValidateBasic() error {
 	if msg.Relayer == "" {
-		return fmt.Errorf("relayer cannot be empty")
+		return errors.New("relayer cannot be empty")
 	}
+
 	if msg.DestinationChain == "" {
-		return fmt.Errorf("destinationChain cannot be empty")
+		return errors.New("destinationChain cannot be empty")
 	}
+
 	if msg.WardenContractAddress == "" {
-		return fmt.Errorf("wardenContractAddress cannot be empty")
+		return errors.New("wardenContractAddress cannot be empty")
 	}
 
 	return nil

--- a/warden/x/gmp/types/params.go
+++ b/warden/x/gmp/types/params.go
@@ -1,8 +1,6 @@
 package types
 
-import (
-	"fmt"
-)
+import "errors"
 
 func DefaultParams() Params {
 	return Params{}
@@ -10,16 +8,20 @@ func DefaultParams() Params {
 
 func (p Params) Validate() error {
 	if p.GmpTimeout < 1 {
-		return fmt.Errorf("gmp_timeout can not be less than 1")
+		return errors.New("gmp_timeout can not be less than 1")
 	}
+
 	if p.GmpChannel == "" {
-		return fmt.Errorf("gmp_channel can not be empty")
+		return errors.New("gmp_channel can not be empty")
 	}
+
 	if p.GmpAddress == "" {
-		return fmt.Errorf("gmp_address can not be empty")
+		return errors.New("gmp_address can not be empty")
 	}
+
 	if p.FeeRecipient == "" {
-		return fmt.Errorf("gmp_fee recipient can not be empty")
+		return errors.New("gmp_fee recipient can not be empty")
 	}
+
 	return nil
 }

--- a/warden/x/ibctransfer/keeper/ibctransfer.go
+++ b/warden/x/ibctransfer/keeper/ibctransfer.go
@@ -2,8 +2,9 @@ package keeper
 
 import (
 	"context"
+	"errors"
+
 	storetypes "cosmossdk.io/store/types"
-	"fmt"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -11,6 +12,7 @@ import (
 	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types"
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
+
 	gmptypes "github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 	types2 "github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/types"
 )
@@ -41,7 +43,7 @@ func (k Keeper) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	if k.GmpKeeper == nil {
-		return nil, fmt.Errorf("GmpKeeper is not initialized")
+		return nil, errors.New("GmpKeeper is not initialized")
 	}
 
 	gmpKeeper := *k.GmpKeeper
@@ -52,6 +54,7 @@ func (k Keeper) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.
 		// safe byte conversion for invalid UTF-8
 		bz := make([]byte, len(msg.Memo))
 		copy(bz, msg.Memo)
+
 		err := bridgeMsg.Unmarshal(bz)
 		if err != nil {
 			// If the payload is not a bridgeMsg type, then a user is trying to perform GMP
@@ -64,12 +67,14 @@ func (k Keeper) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.
 		if err != nil {
 			return nil, err
 		}
+
 		return k.Keeper.Transfer(goCtx, gmpTransferMsg)
 	}
+
 	return k.Keeper.Transfer(goCtx, msg)
 }
 
-// NewKeeper creates a new IBC transfer Keeper instance
+// NewKeeper creates a new IBC transfer Keeper instance.
 func NewKeeper(
 	cdc codec.BinaryCodec, key storetypes.StoreKey, paramSpace paramtypes.Subspace,
 	ics4Wrapper porttypes.ICS4Wrapper, channelKeeper types.ChannelKeeper, portKeeper types.PortKeeper,

--- a/warden/x/ibctransfer/module/ibc_module.go
+++ b/warden/x/ibctransfer/module/ibc_module.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	ibctransfer "github.com/cosmos/ibc-go/v8/modules/apps/transfer"
+
 	"github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/keeper"
 )
 
@@ -11,7 +12,7 @@ type IBCModule struct {
 	keeper keeper.Keeper
 }
 
-// NewIBCModule creates a new IBCModule given the keeper
+// NewIBCModule creates a new IBCModule given the keeper.
 func NewIBCModule(k keeper.Keeper) IBCModule {
 	return IBCModule{
 		keeper:    k,

--- a/warden/x/ibctransfer/module/module.go
+++ b/warden/x/ibctransfer/module/module.go
@@ -2,11 +2,10 @@ package module
 
 import (
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/keeper"
-
+	ibctransfer "github.com/cosmos/ibc-go/v8/modules/apps/transfer"
 	porttypes "github.com/cosmos/ibc-go/v8/modules/core/05-port/types"
 
-	ibctransfer "github.com/cosmos/ibc-go/v8/modules/apps/transfer"
+	"github.com/warden-protocol/wardenprotocol/warden/x/ibctransfer/keeper"
 )
 
 var (
@@ -15,18 +14,18 @@ var (
 	_ porttypes.IBCModule   = IBCModule{}
 )
 
-// AppModuleBasic is the IBC Transfer AppModuleBasic
+// AppModuleBasic is the IBC Transfer AppModuleBasic.
 type AppModuleBasic struct {
 	ibctransfer.AppModuleBasic
 }
 
-// AppModule represents the AppModule for this module
+// AppModule represents the AppModule for this module.
 type AppModule struct {
 	ibctransfer.AppModule
 	keeper keeper.Keeper
 }
 
-// NewAppModule creates a new 20-transfer module
+// NewAppModule creates a new 20-transfer module.
 func NewAppModule(k keeper.Keeper) AppModule {
 	return AppModule{
 		keeper:    k,

--- a/warden/x/ibctransfer/types/expected_keepers.go
+++ b/warden/x/ibctransfer/types/expected_keepers.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+
 	gmptypes "github.com/warden-protocol/wardenprotocol/warden/x/gmp/types"
 )
 

--- a/warden/x/warden/client/cli/tx.go
+++ b/warden/x/warden/client/cli/tx.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"encoding/base64"
-	"fmt"
 	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -61,7 +60,7 @@ func FulfillKeyRequestTxCmd() *cobra.Command {
 		Long: `Fulfill a key request providing the public key.
 The sender of this transaction must be a writer of the Keychain for the request.
 The public key must be a base64 encoded string.`,
-		Example: fmt.Sprintf("%s tx warden fulfill-key-request 1234 aGV5dGhlcmU=", version.AppName),
+		Example: version.AppName + " tx warden fulfill-key-request 1234 aGV5dGhlcmU=",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
@@ -101,7 +100,7 @@ func RejectKeyRequestTxCmd() *cobra.Command {
 		Short: "Reject a key request providing the reason.",
 		Long: `Reject a key request providing a reason.
 The sender of this transaction must be a writer of the Keychain for the request.`,
-		Example: fmt.Sprintf("%s tx warden reject-key-request 1234 'something happened'", version.AppName),
+		Example: version.AppName + " tx warden reject-key-request 1234 'something happened'",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
@@ -137,7 +136,7 @@ func FulfillSignRequestTxCmd() *cobra.Command {
 		Long: `Fulfill a signature request providing the signature.
 The sender of this transaction must be a writer of the Keychain for the request.
 The sign-data must be a base64 encoded string.`,
-		Example: fmt.Sprintf("%s tx warden fulfill-sign-request 1234 aGV5dGhlcmU=", version.AppName),
+		Example: version.AppName + " tx warden fulfill-sign-request 1234 aGV5dGhlcmU=",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
@@ -181,7 +180,7 @@ func RejectSignRequestTxCmd() *cobra.Command {
 		Short: "Reject a signature request providing a reason.",
 		Long: `Reject a signature request providing a reason.
 The sender of this transaction must be a writer of the Keychain for the request.`,
-		Example: fmt.Sprintf("%s tx warden reject-sign-request 1234 oops", version.AppName),
+		Example: version.AppName + " tx warden reject-sign-request 1234 oops",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)

--- a/warden/x/warden/keeper/genesis.go
+++ b/warden/x/warden/keeper/genesis.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -49,35 +50,42 @@ func (k *Keeper) ExportState(ctx sdk.Context, genState *types.GenesisState) erro
 	if err != nil {
 		return fmt.Errorf("failed to export keychains: %w", err)
 	}
+
 	genState.Keychains = keychains
 
 	spaces, err := k.SpacesKeeper.Coll().Export(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to export spaces: %w", err)
 	}
+
 	genState.Spaces = spaces
 
 	keyRequests, err := k.keyRequests.Export(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to export key requests: %w", err)
 	}
+
 	genState.KeyRequests = keyRequests
 
 	keysIter, err := k.KeysKeeper.Coll().Iterate(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to iterate keys: %w", err)
 	}
+
 	defer keysIter.Close()
+
 	keys, err := keysIter.Values()
 	if err != nil {
 		return fmt.Errorf("failed to export keys: %w", err)
 	}
+
 	genState.Keys = keys
 
 	SignRequests, err := k.signRequests.Export(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to export signature requests: %w", err)
 	}
+
 	genState.SignRequests = SignRequests
 
 	return nil

--- a/warden/x/warden/keeper/keeper.go
+++ b/warden/x/warden/keeper/keeper.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"fmt"
-
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/store"
 	errorsmod "cosmossdk.io/errors"
@@ -73,7 +71,7 @@ func NewKeeper(
 	getWasmKeeper func() wasmkeeper.Keeper,
 ) Keeper {
 	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
-		panic(fmt.Sprintf("invalid authority address: %s", authority))
+		panic("invalid authority address: " + authority)
 	}
 
 	sb := collections.NewSchemaBuilder(storeService)
@@ -137,10 +135,11 @@ func (k Keeper) assertActAuthority(addr string) error {
 	if k.GetActAuthority() != addr {
 		return errorsmod.Wrapf(v1beta3.ErrInvalidActionSigner, "invalid authority; expected %s, got %s", k.GetAuthority(), addr)
 	}
+
 	return nil
 }
 
 // Logger returns a module-specific logger.
 func (k Keeper) Logger() log.Logger {
-	return k.logger.With("module", fmt.Sprintf("x/%s", v1beta3.ModuleName))
+	return k.logger.With("module", "x/"+v1beta3.ModuleName)
 }

--- a/warden/x/warden/keeper/key_requests.go
+++ b/warden/x/warden/keeper/key_requests.go
@@ -52,6 +52,7 @@ func ensureKeyFormatting(req types.KeyRequest, pubKey []byte) error {
 	default:
 		return errors.Wrap(types.ErrUnsupportedKeyType, req.KeyType.String())
 	}
+
 	return nil
 }
 

--- a/warden/x/warden/keeper/keychain.go
+++ b/warden/x/warden/keeper/keychain.go
@@ -2,11 +2,13 @@ package keeper
 
 import (
 	"context"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
-// deductKeychainFees is to deduct fees from creator's address to warden escrow address
+// deductKeychainFees is to deduct fees from creator's address to warden escrow address.
 func (k Keeper) deductKeychainFees(ctx context.Context, creator sdk.AccAddress, fees sdk.Coins) error {
 	if !fees.Empty() {
 		return k.bankKeeper.SendCoins(ctx, creator, k.wardenAuthority, fees)
@@ -15,8 +17,7 @@ func (k Keeper) deductKeychainFees(ctx context.Context, creator sdk.AccAddress, 
 	return nil
 }
 
-// releaseKeychainFees is to release paid keychain fees to keychain, when Keychain operation is
-// completed
+// completed.
 func (k Keeper) releaseKeychainFees(ctx context.Context, kr types.Keychain, fees sdk.Coins) error {
 	if !fees.Empty() {
 		return k.bankKeeper.SendCoins(ctx, k.wardenAuthority, kr.AccAddress(), fees)
@@ -25,8 +26,7 @@ func (k Keeper) releaseKeychainFees(ctx context.Context, kr types.Keychain, fees
 	return nil
 }
 
-// refundKeychainFees is to refund paid keychain fees to action's creator, when Keychain operation is
-// rejected or timed-out
+// rejected or timed-out.
 func (k Keeper) refundKeychainFees(ctx context.Context, creator sdk.AccAddress, fees sdk.Coins) error {
 	if !fees.Empty() {
 		return k.bankKeeper.SendCoins(ctx, k.wardenAuthority, creator, fees)

--- a/warden/x/warden/keeper/keys.go
+++ b/warden/x/warden/keeper/keys.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+
 	"cosmossdk.io/collections"
 	"github.com/cosmos/cosmos-sdk/codec"
 
@@ -20,6 +21,7 @@ func NewKeysKeeper(sb *collections.SchemaBuilder, cdc codec.BinaryCodec) KeysKee
 		sb, KeysSpaceIndexPrefix, "keys_by_space",
 		collections.PairKeyCodec(collections.Uint64Key, collections.Uint64Key),
 	)
+
 	return KeysKeeper{
 		keys:        keys,
 		keysBySpace: keysBySpace,
@@ -39,6 +41,7 @@ func (k KeysKeeper) Set(ctx context.Context, key *types.Key) error {
 	if err := k.keysBySpace.Set(ctx, collections.Join(key.SpaceId, key.Id)); err != nil {
 		return err
 	}
+
 	return k.keys.Set(ctx, key.Id, *key)
 }
 

--- a/warden/x/warden/keeper/msg_server_add_keychain_admin.go
+++ b/warden/x/warden/keeper/msg_server_add_keychain_admin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -18,6 +19,7 @@ func (k msgServer) AddKeychainAdmin(goCtx context.Context, msg *types.MsgAddKeyc
 	if !kr.IsAdmin(msg.Authority) {
 		return nil, types.ErrNotKeychainAdmin
 	}
+
 	if kr.IsAdmin(msg.NewAdmin) {
 		return nil, types.ErrDuplicateKeychainAdmin
 	}

--- a/warden/x/warden/keeper/msg_server_add_keychain_writer.go
+++ b/warden/x/warden/keeper/msg_server_add_keychain_writer.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/warden/x/warden/keeper/msg_server_add_space_owner.go
+++ b/warden/x/warden/keeper/msg_server_add_space_owner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/warden/x/warden/keeper/msg_server_fulfil_sign_request.go
+++ b/warden/x/warden/keeper/msg_server_fulfil_sign_request.go
@@ -2,8 +2,10 @@ package keeper
 
 import (
 	"context"
+
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/warden/x/warden/keeper/msg_server_new_key_request.go
+++ b/warden/x/warden/keeper/msg_server_new_key_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/warden/x/warden/keeper/msg_server_new_keychain.go
+++ b/warden/x/warden/keeper/msg_server_new_keychain.go
@@ -2,7 +2,9 @@ package keeper
 
 import (
 	"context"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/warden/x/warden/keeper/msg_server_new_space.go
+++ b/warden/x/warden/keeper/msg_server_new_space.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -22,6 +23,7 @@ func (k msgServer) NewSpace(goCtx context.Context, msg *types.MsgNewSpace) (*typ
 	if err := space.AddOwner(msg.Creator, space.Nonce); err != nil {
 		return nil, err
 	}
+
 	for _, owner := range msg.AdditionalOwners {
 		if err := space.AddOwner(owner, space.Nonce); err != nil {
 			return nil, err

--- a/warden/x/warden/keeper/msg_server_remove_keychain_admin.go
+++ b/warden/x/warden/keeper/msg_server_remove_keychain_admin.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -19,9 +20,11 @@ func (k msgServer) RemoveKeychainAdmin(goCtx context.Context, msg *types.MsgRemo
 	if !kr.IsAdmin(msg.Authority) {
 		return nil, types.ErrNotKeychainAdmin
 	}
+
 	if !kr.IsAdmin(msg.Admin) {
 		return nil, errors.Wrapf(types.ErrNotKeychainAdmin, "%s can't be removed as it's not an admin of the keychain", msg.Admin)
 	}
+
 	if len(kr.Admins) == 1 {
 		return nil, types.ErrCantRemoveLastKeychainAdmin
 	}

--- a/warden/x/warden/keeper/msg_server_remove_space_owner.go
+++ b/warden/x/warden/keeper/msg_server_remove_space_owner.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/warden/x/warden/keeper/msg_server_update_key.go
+++ b/warden/x/warden/keeper/msg_server_update_key.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -21,6 +22,7 @@ func (k msgServer) UpdateKey(ctx context.Context, msg *types.MsgUpdateKey) (*typ
 		if err = k.actKeeper.IsValidTemplate(ctx, msg.ApproveTemplateId); err != nil {
 			return nil, err
 		}
+
 		key.ApproveTemplateId = msg.ApproveTemplateId
 	}
 
@@ -28,6 +30,7 @@ func (k msgServer) UpdateKey(ctx context.Context, msg *types.MsgUpdateKey) (*typ
 		if err = k.actKeeper.IsValidTemplate(ctx, msg.RejectTemplateId); err != nil {
 			return nil, err
 		}
+
 		key.RejectTemplateId = msg.RejectTemplateId
 	}
 

--- a/warden/x/warden/keeper/msg_server_update_keychain.go
+++ b/warden/x/warden/keeper/msg_server_update_keychain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/warden/x/warden/keeper/msg_server_update_space.go
+++ b/warden/x/warden/keeper/msg_server_update_space.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -21,6 +22,7 @@ func (k msgServer) UpdateSpace(ctx context.Context, msg *types.MsgUpdateSpace) (
 		if err := k.actKeeper.IsValidTemplate(ctx, msg.ApproveAdminTemplateId); err != nil {
 			return nil, err
 		}
+
 		space.ApproveAdminTemplateId = msg.ApproveAdminTemplateId
 	}
 
@@ -28,6 +30,7 @@ func (k msgServer) UpdateSpace(ctx context.Context, msg *types.MsgUpdateSpace) (
 		if err := k.actKeeper.IsValidTemplate(ctx, msg.RejectAdminTemplateId); err != nil {
 			return nil, err
 		}
+
 		space.RejectAdminTemplateId = msg.RejectAdminTemplateId
 	}
 
@@ -35,6 +38,7 @@ func (k msgServer) UpdateSpace(ctx context.Context, msg *types.MsgUpdateSpace) (
 		if err := k.actKeeper.IsValidTemplate(ctx, msg.ApproveSignTemplateId); err != nil {
 			return nil, err
 		}
+
 		space.ApproveSignTemplateId = msg.ApproveSignTemplateId
 	}
 
@@ -42,6 +46,7 @@ func (k msgServer) UpdateSpace(ctx context.Context, msg *types.MsgUpdateSpace) (
 		if err := k.actKeeper.IsValidTemplate(ctx, msg.RejectSignTemplateId); err != nil {
 			return nil, err
 		}
+
 		space.RejectSignTemplateId = msg.RejectSignTemplateId
 	}
 

--- a/warden/x/warden/keeper/params.go
+++ b/warden/x/warden/keeper/params.go
@@ -8,25 +8,29 @@ import (
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
-// GetParams get all parameters as types.Params
+// GetParams get all parameters as types.Params.
 func (k Keeper) GetParams(ctx context.Context) (params types.Params) {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+
 	bz := store.Get(types.ParamsKey)
 	if bz == nil {
 		return params
 	}
 
 	k.cdc.MustUnmarshal(bz, &params)
+
 	return params
 }
 
-// SetParams set the params
+// SetParams set the params.
 func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+
 	bz, err := k.cdc.Marshal(&params)
 	if err != nil {
 		return err
 	}
+
 	store.Set(types.ParamsKey, bz)
 
 	return nil

--- a/warden/x/warden/keeper/query_all_keys.go
+++ b/warden/x/warden/keeper/query_all_keys.go
@@ -23,9 +23,9 @@ func (k Keeper) AllKeys(goCtx context.Context, req *types.QueryAllKeysRequest) (
 			Key:       value,
 			Addresses: value.DeriveAddresses(ctx, req.DeriveAddresses),
 		}
+
 		return response, nil
 	})
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/warden/keeper/query_all_keys_test.go
+++ b/warden/x/warden/keeper/query_all_keys_test.go
@@ -17,7 +17,7 @@ func Benchmark_QueryAllKeys(b *testing.B) {
 	pk, err := base64.StdEncoding.DecodeString("A8Ijpl1mphVgurSqcDfS4mVVSqgXVLubol7+Kgjay1I+")
 	require.NoError(b, err)
 
-	for i := 0; i < 1_000_000; i++ {
+	for i := range 1_000_000 {
 		err = k.KeysKeeper.New(
 			ctx,
 			&types.Key{
@@ -41,8 +41,10 @@ func Benchmark_QueryAllKeys(b *testing.B) {
 			types.AddressType_ADDRESS_TYPE_OSMOSIS,
 		},
 	}
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for range b.N {
 		res, err := k.AllKeys(ctx, req)
 		require.NoError(b, err)
 		require.NotNil(b, res)

--- a/warden/x/warden/keeper/query_key_request_by_id.go
+++ b/warden/x/warden/keeper/query_key_request_by_id.go
@@ -4,13 +4,15 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
-// nolint:stylecheck,st1003
 // revive:disable-next-line var-naming
+//
+//nolint:stylecheck,st1003
 func (k Keeper) KeyRequestById(goCtx context.Context, req *types.QueryKeyRequestByIdRequest) (*types.QueryKeyRequestByIdResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")

--- a/warden/x/warden/keeper/query_key_requests.go
+++ b/warden/x/warden/keeper/query_key_requests.go
@@ -5,9 +5,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
 func (k Keeper) KeyRequests(goCtx context.Context, req *types.QueryKeyRequestsRequest) (*types.QueryKeyRequestsResponse, error) {
@@ -28,7 +29,6 @@ func (k Keeper) KeyRequests(goCtx context.Context, req *types.QueryKeyRequestsRe
 
 		return true, nil
 	}, func(key uint64, v types.KeyRequest) (*types.KeyRequest, error) { return &v, nil })
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/warden/keeper/query_keychain_by_address.go
+++ b/warden/x/warden/keeper/query_keychain_by_address.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
 func (k Keeper) KeychainById(goCtx context.Context, req *types.QueryKeychainByIdRequest) (*types.QueryKeychainByIdResponse, error) {

--- a/warden/x/warden/keeper/query_keychains.go
+++ b/warden/x/warden/keeper/query_keychains.go
@@ -5,9 +5,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
 func (k Keeper) Keychains(goCtx context.Context, req *types.QueryKeychainsRequest) (*types.QueryKeychainsResponse, error) {
@@ -20,7 +21,6 @@ func (k Keeper) Keychains(goCtx context.Context, req *types.QueryKeychainsReques
 	keychains, pageRes, err := query.CollectionPaginate(ctx, k.keychains, req.Pagination, func(id uint64, value types.Keychain) (types.Keychain, error) {
 		return value, nil
 	})
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/warden/keeper/query_keys_by_space_id.go
+++ b/warden/x/warden/keeper/query_keys_by_space_id.go
@@ -36,7 +36,6 @@ func (k Keeper) KeysBySpaceId(goCtx context.Context, req *types.QueryKeysBySpace
 		},
 		query.WithCollectionPaginationPairPrefix[uint64, uint64](req.SpaceId),
 	)
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/warden/keeper/query_keys_by_space_id_test.go
+++ b/warden/x/warden/keeper/query_keys_by_space_id_test.go
@@ -17,7 +17,7 @@ func Benchmark_QueryKeysBySpaceId(b *testing.B) {
 	pk, err := base64.StdEncoding.DecodeString("A8Ijpl1mphVgurSqcDfS4mVVSqgXVLubol7+Kgjay1I+")
 	require.NoError(b, err)
 
-	for i := 0; i < 100_000; i++ {
+	for i := range 100_000 {
 		err = k.KeysKeeper.New(
 			ctx,
 			&types.Key{
@@ -43,8 +43,10 @@ func Benchmark_QueryKeysBySpaceId(b *testing.B) {
 			Limit:      1,
 		},
 	}
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for range b.N {
 		res, err := k.KeysBySpaceId(ctx, req)
 		require.NoError(b, err)
 		require.NotNil(b, res)

--- a/warden/x/warden/keeper/query_params.go
+++ b/warden/x/warden/keeper/query_params.go
@@ -14,6 +14,7 @@ func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*t
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil

--- a/warden/x/warden/keeper/query_sign_request_by_id.go
+++ b/warden/x/warden/keeper/query_sign_request_by_id.go
@@ -4,13 +4,15 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
-// nolint:stylecheck,st1003
 // revive:disable-next-line var-naming
+//
+//nolint:stylecheck,st1003
 func (k Keeper) SignRequestById(goCtx context.Context, req *types.QuerySignRequestByIdRequest) (*types.QuerySignRequestByIdResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")

--- a/warden/x/warden/keeper/query_sign_requests.go
+++ b/warden/x/warden/keeper/query_sign_requests.go
@@ -38,7 +38,6 @@ func (k Keeper) SignRequests(goCtx context.Context, req *types.QuerySignRequests
 
 		return true, nil
 	}, func(key uint64, value types.SignRequest) (*types.SignRequest, error) { return &value, nil })
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/warden/keeper/query_space_by_id.go
+++ b/warden/x/warden/keeper/query_space_by_id.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
 func (k Keeper) SpaceById(goCtx context.Context, req *types.QuerySpaceByIdRequest) (*types.QuerySpaceByIdResponse, error) {

--- a/warden/x/warden/keeper/query_spaces.go
+++ b/warden/x/warden/keeper/query_spaces.go
@@ -5,9 +5,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
 func (k Keeper) Spaces(goCtx context.Context, req *types.QuerySpacesRequest) (*types.QuerySpacesResponse, error) {
@@ -20,7 +21,6 @@ func (k Keeper) Spaces(goCtx context.Context, req *types.QuerySpacesRequest) (*t
 	spaces, pageRes, err := query.CollectionPaginate(ctx, k.SpacesKeeper.Coll(), req.Pagination, func(id uint64, space types.Space) (types.Space, error) {
 		return space, nil
 	})
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/warden/keeper/query_spaces_by_owner.go
+++ b/warden/x/warden/keeper/query_spaces_by_owner.go
@@ -6,9 +6,10 @@ import (
 	"cosmossdk.io/collections"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
 func (k Keeper) SpacesByOwner(goCtx context.Context, req *types.QuerySpacesByOwnerRequest) (*types.QuerySpacesResponse, error) {
@@ -32,7 +33,6 @@ func (k Keeper) SpacesByOwner(goCtx context.Context, req *types.QuerySpacesByOwn
 		},
 		query.WithCollectionPaginationPairPrefix[sdk.AccAddress, uint64](ownerAddr),
 	)
-
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/warden/x/warden/keeper/rules.go
+++ b/warden/x/warden/keeper/rules.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
 	acttypes "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	"github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
@@ -145,6 +146,7 @@ func (k Keeper) updateSpaceTemplate(ctx context.Context, msg *v1beta3.MsgUpdateS
 	if err != nil {
 		return acttypes.Template{}, acttypes.Template{}, err
 	}
+
 	rejectTemplate, err := k.getRejectUpdateSpaceTemplate(ctx, space)
 	if err != nil {
 		return acttypes.Template{}, acttypes.Template{}, err
@@ -247,7 +249,6 @@ func (k Keeper) getApproveUpdateSpaceTemplate(ctx context.Context, space v1beta3
 	} else {
 		return space.TemplateApproveUpdateSpace(), nil
 	}
-
 }
 
 func (k Keeper) getRejectUpdateSpaceTemplate(ctx context.Context, space v1beta3.Space) (acttypes.Template, error) {
@@ -262,23 +263,30 @@ func (k Keeper) executeAnalyzers(ctx context.Context, creator string, contracts 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	creatorAddr := sdk.MustAccAddressFromBech32(creator)
 	analyzerVals := make(map[string]map[string]*ast.Expression)
+
 	var dataForSigning []byte
+
 	for _, contract := range contracts {
 		contractAddr, err := sdk.AccAddressFromBech32(contract)
 		if err != nil {
 			return nil, nil, err
 		}
+
 		dfs, vals, err := k.ExecuteAnalyzer(sdkCtx, contractAddr, creatorAddr, input)
 		if err != nil {
 			return nil, nil, err
 		}
+
 		if dfs != nil && dataForSigning != nil {
 			return nil, nil, v1beta3.ErrDuplicateAnalyzersDataForSigning
 		}
+
 		if dfs != nil {
 			dataForSigning = dfs
 		}
+
 		analyzerVals[contract] = vals
 	}
+
 	return WithAnalyzerValues(ctx, analyzerVals), dataForSigning, nil
 }

--- a/warden/x/warden/keeper/shield.go
+++ b/warden/x/warden/keeper/shield.go
@@ -2,10 +2,12 @@ package keeper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
 	"github.com/warden-protocol/wardenprotocol/warden/x/act/cosmoshield"
 )
@@ -23,7 +25,6 @@ func (w WardenShieldExpander) Expand(ctx context.Context, ident *ast.Identifier)
 
 	if ident.Value == "space.owners" {
 		return w.expandSpaceOwners(ctx)
-
 	}
 
 	return nil, fmt.Errorf("unknown identifier: %s", ident.Value)
@@ -82,10 +83,12 @@ func WithAnalyzerValues(ctx context.Context, vals map[string]map[string]*ast.Exp
 
 func analyzerValues(ctx context.Context) map[string]map[string]*ast.Expression {
 	v := ctx.Value(analyzerValuesKey{})
+
 	vs, ok := v.(map[string]map[string]*ast.Expression)
 	if !ok {
 		return nil
 	}
+
 	return vs
 }
 
@@ -103,13 +106,15 @@ func (w WardenShieldExpander) extractSpaceID(ctx context.Context, msg sdk.Msg) (
 		return msg.GetSpaceId(), nil
 	case getKeyIder:
 		keyID := msg.GetKeyId()
+
 		key, err := w.keeper.KeysKeeper.Get(ctx, keyID)
 		if err != nil {
 			return 0, err
 		}
+
 		return key.SpaceId, nil
 	default:
-		return 0, fmt.Errorf("message does not have a SpaceId or KeyId field")
+		return 0, errors.New("message does not have a SpaceId or KeyId field")
 	}
 }
 

--- a/warden/x/warden/keeper/sign_requests.go
+++ b/warden/x/warden/keeper/sign_requests.go
@@ -1,9 +1,11 @@
 package keeper
 
 import (
-	"cosmossdk.io/errors"
 	"crypto/ed25519"
+
+	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -40,6 +42,7 @@ func ensureSignatureFormatting(key types.Key, sigData []byte) error {
 	default:
 		return errors.Wrap(types.ErrUnsupportedKeyType, key.Type.String())
 	}
+
 	return nil
 }
 
@@ -48,6 +51,7 @@ func (k Keeper) rejectSignRequest(ctx sdk.Context, req types.SignRequest, msg *t
 	req.Result = &types.SignRequest_RejectReason{
 		RejectReason: msg.Result.(*types.MsgFulfilSignRequest_RejectReason).RejectReason,
 	}
+
 	if err := k.signRequests.Set(ctx, req.Id, req); err != nil {
 		return err
 	}

--- a/warden/x/warden/keeper/spaces.go
+++ b/warden/x/warden/keeper/spaces.go
@@ -2,11 +2,12 @@ package keeper
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"cosmossdk.io/collections"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/warden-protocol/wardenprotocol/warden/repo"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
@@ -52,13 +53,14 @@ func (k SpacesKeeper) Set(ctx context.Context, space types.Space) error {
 	if err := k.updateSpaceOwners(ctx, space, oldOwners); err != nil {
 		return err
 	}
+
 	return k.spaces.Set(ctx, space.Id, space)
 }
 
 func (k SpacesKeeper) updateSpaceOwners(ctx context.Context, space types.Space, oldOwners []string) error {
 	id := space.Id
 	if id == 0 {
-		return fmt.Errorf("space id is not set")
+		return errors.New("space id is not set")
 	}
 
 	removedOwners := subtract(oldOwners, space.Owners)
@@ -114,17 +116,20 @@ func (k SpacesKeeper) Import(ctx context.Context, spaces []types.Space) error {
 	return nil
 }
 
-// a - b
+// a - b.
 func subtract(a, b []string) []string {
 	m := make(map[string]struct{}, len(b))
 	for _, x := range b {
 		m[x] = struct{}{}
 	}
+
 	var diff []string
+
 	for _, y := range a {
 		if _, ok := m[y]; !ok {
 			diff = append(diff, y)
 		}
 	}
+
 	return diff
 }

--- a/warden/x/warden/module/genesis_test.go
+++ b/warden/x/warden/module/genesis_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	keepertest "github.com/warden-protocol/wardenprotocol/warden/testutil/keeper"
 	"github.com/warden-protocol/wardenprotocol/warden/testutil/nullify"
-	"github.com/warden-protocol/wardenprotocol/warden/x/warden/module"
+	warden "github.com/warden-protocol/wardenprotocol/warden/x/warden/module"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -24,6 +25,5 @@ func TestGenesis(t *testing.T) {
 
 	nullify.Fill(&genesisState)
 	nullify.Fill(got)
-
 	// this line is used by starport scaffolding # genesis/test/assert
 }

--- a/warden/x/warden/module/module.go
+++ b/warden/x/warden/module/module.go
@@ -20,8 +20,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
-	// this line is used by starport scaffolding # 1
-
 	modulev1 "github.com/warden-protocol/wardenprotocol/api/warden/warden/module"
 	acttypes "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	"github.com/warden-protocol/wardenprotocol/warden/x/warden/client/cli"
@@ -82,6 +80,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 	if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", v1beta3.ModuleName, err)
 	}
+
 	return genState.Validate()
 }
 
@@ -96,7 +95,7 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *r
 // AppModule
 // ----------------------------------------------------------------------------
 
-// AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement
+// AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement.
 type AppModule struct {
 	AppModuleBasic
 
@@ -119,7 +118,7 @@ func NewAppModule(
 	}
 }
 
-// RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
+// RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	v1beta3.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	v1beta3.RegisterQueryServer(cfg.QueryServer(), am.keeper)
@@ -210,6 +209,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 	if in.Config.Authority != "" {
 		authority = authtypes.NewModuleAddressOrBech32Address(in.Config.Authority)
 	}
+
 	actAuthority := authtypes.NewModuleAddress(acttypes.ModuleName)
 	wardenAuthority := authtypes.NewModuleAddress(v1beta3.ModuleName)
 	k := keeper.NewKeeper(

--- a/warden/x/warden/module/simulation.go
+++ b/warden/x/warden/module/simulation.go
@@ -13,7 +13,7 @@ import (
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
-// avoid unused import issue
+// avoid unused import issue.
 var (
 	_ = wardensimulation.FindAccount
 	_ = rand.Rand{}
@@ -32,6 +32,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 	for i, acc := range simState.Accounts {
 		accs[i] = acc.Address.String()
 	}
+
 	wardenGenesis := types.GenesisState{
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState

--- a/warden/x/warden/simulation/helpers.go
+++ b/warden/x/warden/simulation/helpers.go
@@ -5,11 +5,12 @@ import (
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 )
 
-// FindAccount find a specific address from an account list
+// FindAccount find a specific address from an account list.
 func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
 	creator, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
 		panic(err)
 	}
+
 	return simtypes.FindAccount(accs, creator)
 }

--- a/warden/x/warden/types/v1beta2/address.go
+++ b/warden/x/warden/types/v1beta2/address.go
@@ -8,26 +8,31 @@ import (
 
 func (k Key) DeriveAddresses(ctx sdk.Context, types []AddressType) []AddressResponse {
 	responses := make([]AddressResponse, 0, len(types))
+
 	for _, addrType := range types {
 		var (
 			address string
 			err     error
 		)
+
 		switch addrType {
 		case AddressType_ADDRESS_TYPE_ETHEREUM:
 			address, err = EthereumAddress(k)
 		case AddressType_ADDRESS_TYPE_OSMOSIS:
 			address, err = OsmosisAddress(k)
 		}
+
 		if err != nil {
 			ctx.Logger().Warn("failed to derive address for key %d: %w", k.Id, err)
 			continue
 		}
+
 		responses = append(responses, AddressResponse{
 			Address: address,
 			Type:    addrType,
 		})
 	}
+
 	return responses
 }
 
@@ -36,7 +41,9 @@ func EthereumAddress(key Key) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	addr := crypto.PubkeyToAddress(*k)
+
 	return addr.Hex(), nil
 }
 
@@ -49,8 +56,10 @@ func bech32Address(prefix string, key Key) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	var pubkey secp256k1.PubKey
 	pubkey.Key = crypto.CompressPubkey(k)
 	bech32Address := sdk.MustBech32ifyAddressBytes(prefix, pubkey.Address())
+
 	return bech32Address, nil
 }

--- a/warden/x/warden/types/v1beta2/codec.go
+++ b/warden/x/warden/types/v1beta2/codec.go
@@ -4,7 +4,6 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
-	// this line is used by starport scaffolding # 1
 )
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {

--- a/warden/x/warden/types/v1beta2/genesis.go
+++ b/warden/x/warden/types/v1beta2/genesis.go
@@ -1,13 +1,11 @@
 package v1beta2
 
-import (
 // this line is used by starport scaffolding # genesis/types/import
-)
 
-// DefaultIndex is the default global index
+// DefaultIndex is the default global index.
 const DefaultIndex uint64 = 1
 
-// DefaultGenesis returns the default genesis state
+// DefaultGenesis returns the default genesis state.
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
 		// this line is used by starport scaffolding # genesis/types/default
@@ -19,6 +17,5 @@ func DefaultGenesis() *GenesisState {
 // failure.
 func (gs GenesisState) Validate() error {
 	// this line is used by starport scaffolding # genesis/types/validate
-
 	return gs.Params.Validate()
 }

--- a/warden/x/warden/types/v1beta2/genesis_test.go
+++ b/warden/x/warden/types/v1beta2/genesis_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta2"
 )
 

--- a/warden/x/warden/types/v1beta2/key.go
+++ b/warden/x/warden/types/v1beta2/key.go
@@ -38,6 +38,7 @@ func (k *Key) ToECDSASecp256k1() (*ecdsa.PublicKey, error) {
 	if len(k.PublicKey) == 33 {
 		// Compressed form
 		var err error
+
 		pk, err = crypto.DecompressPubkey(k.PublicKey)
 		if err != nil {
 			return nil, err
@@ -45,6 +46,7 @@ func (k *Key) ToECDSASecp256k1() (*ecdsa.PublicKey, error) {
 	} else {
 		// Uncompressed form
 		var err error
+
 		pk, err = crypto.UnmarshalPubkey(k.PublicKey)
 		if err != nil {
 			return nil, err
@@ -68,5 +70,6 @@ func (k *Key) ToEdDSAEd25519() (*ed25519.PublicKey, error) {
 
 	pubKey := ed25519.PublicKey(k.PublicKey)
 	pk = &pubKey
+
 	return pk, nil
 }

--- a/warden/x/warden/types/v1beta2/keychain.go
+++ b/warden/x/warden/types/v1beta2/keychain.go
@@ -10,6 +10,7 @@ func (k *Keychain) AccAddress() sdk.AccAddress {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, k.Id)
 	addr := append([]byte("keychain-"), bz...)
+
 	return sdk.AccAddress(addr)
 }
 
@@ -19,6 +20,7 @@ func (k *Keychain) IsParty(address string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -28,6 +30,7 @@ func (k *Keychain) IsAdmin(address string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/warden/x/warden/types/v1beta2/keys.go
+++ b/warden/x/warden/types/v1beta2/keys.go
@@ -1,19 +1,17 @@
 package v1beta2
 
 const (
-	// ModuleName defines the module name
+	// ModuleName defines the module name.
 	ModuleName = "warden"
 
-	// StoreKey defines the primary module store key
+	// StoreKey defines the primary module store key.
 	StoreKey = ModuleName
 
-	// MemStoreKey defines the in-memory store key
+	// MemStoreKey defines the in-memory store key.
 	MemStoreKey = "mem_warden"
 )
 
-var (
-	ParamsKey = []byte("p_warden")
-)
+var ParamsKey = []byte("p_warden")
 
 func KeyPrefix(p string) []byte {
 	return []byte(p)

--- a/warden/x/warden/types/v1beta2/params.go
+++ b/warden/x/warden/types/v1beta2/params.go
@@ -6,27 +6,27 @@ import (
 
 var _ paramtypes.ParamSet = (*Params)(nil)
 
-// ParamKeyTable the param key table for launch module
+// ParamKeyTable the param key table for launch module.
 func ParamKeyTable() paramtypes.KeyTable {
 	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
 }
 
-// NewParams creates a new Params instance
+// NewParams creates a new Params instance.
 func NewParams() Params {
 	return Params{}
 }
 
-// DefaultParams returns a default set of parameters
+// DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
 	return NewParams()
 }
 
-// ParamSetPairs get the params.ParamSet
+// ParamSetPairs get the params.ParamSet.
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{}
 }
 
-// Validate validates the set of params
+// Validate validates the set of params.
 func (p Params) Validate() error {
 	return nil
 }

--- a/warden/x/warden/types/v1beta2/sign_method_handler.go
+++ b/warden/x/warden/types/v1beta2/sign_method_handler.go
@@ -1,11 +1,11 @@
 package v1beta2
 
 import (
-	"fmt"
+	"errors"
 	"math/big"
 )
 
-var ErrUnknownWalletType = fmt.Errorf("error in NewWallet: unknown wallet type")
+var ErrUnknownWalletType = errors.New("error in NewWallet: unknown wallet type")
 
 func NewSignMethodHandler(k *Key, sm SignMethod) (SignMethodHandler, error) {
 	switch sm {
@@ -16,6 +16,7 @@ func NewSignMethodHandler(k *Key, sm SignMethod) (SignMethodHandler, error) {
 	case SignMethod_SIGN_METHOD_OSMOSIS:
 		return NewOsmosisSignMethodHandler(k)
 	}
+
 	return nil, ErrUnknownWalletType
 }
 

--- a/warden/x/warden/types/v1beta2/sign_method_handler_black_box.go
+++ b/warden/x/warden/types/v1beta2/sign_method_handler_black_box.go
@@ -15,6 +15,7 @@ func NewBlackBoxSignMethodHandler(k *Key) (*BlackBoxSignMethodHandler, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &BlackBoxSignMethodHandler{key: pubkey}, nil
 }
 

--- a/warden/x/warden/types/v1beta2/sign_method_handler_ethereum_test.go
+++ b/warden/x/warden/types/v1beta2/sign_method_handler_ethereum_test.go
@@ -62,9 +62,11 @@ func Test_ParseEthereumTransaction(t *testing.T) {
 				require.Error(t, err)
 				return
 			}
+
 			require.NoError(t, err)
 			require.Equal(t, tt.wantTo, tx.To.Hex())
 			require.Equal(t, tt.wantAmount, tx.Amount)
+
 			if len(tt.wantContract) == 0 {
 				require.Nil(t, tx.Contract)
 			} else {

--- a/warden/x/warden/types/v1beta2/sign_method_handler_osmosis.go
+++ b/warden/x/warden/types/v1beta2/sign_method_handler_osmosis.go
@@ -18,6 +18,7 @@ func NewOsmosisSignMethodHandler(k *Key) (*OsmosisSignMethodHandler, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &OsmosisSignMethodHandler{key: pubkey}, nil
 }
 
@@ -37,5 +38,6 @@ func parseStdSignDoc(bz []byte) []byte {
 func hash(bytes []byte) []byte {
 	hasher := sha256.New()
 	hasher.Write(bytes)
+
 	return hasher.Sum(nil)
 }

--- a/warden/x/warden/types/v1beta3/address.go
+++ b/warden/x/warden/types/v1beta3/address.go
@@ -8,26 +8,31 @@ import (
 
 func (k Key) DeriveAddresses(ctx sdk.Context, types []AddressType) []AddressResponse {
 	responses := make([]AddressResponse, 0, len(types))
+
 	for _, addrType := range types {
 		var (
 			address string
 			err     error
 		)
+
 		switch addrType {
 		case AddressType_ADDRESS_TYPE_ETHEREUM:
 			address, err = EthereumAddress(k)
 		case AddressType_ADDRESS_TYPE_OSMOSIS:
 			address, err = OsmosisAddress(k)
 		}
+
 		if err != nil {
 			ctx.Logger().Warn("failed to derive address for key %d: %w", k.Id, err)
 			continue
 		}
+
 		responses = append(responses, AddressResponse{
 			Address: address,
 			Type:    addrType,
 		})
 	}
+
 	return responses
 }
 
@@ -36,7 +41,9 @@ func EthereumAddress(key Key) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	addr := crypto.PubkeyToAddress(*k)
+
 	return addr.Hex(), nil
 }
 
@@ -49,8 +56,10 @@ func bech32Address(prefix string, key Key) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	var pubkey secp256k1.PubKey
 	pubkey.Key = crypto.CompressPubkey(k)
 	bech32Address := sdk.MustBech32ifyAddressBytes(prefix, pubkey.Address())
+
 	return bech32Address, nil
 }

--- a/warden/x/warden/types/v1beta3/codec.go
+++ b/warden/x/warden/types/v1beta3/codec.go
@@ -4,7 +4,6 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
-	// this line is used by starport scaffolding # 1
 )
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {

--- a/warden/x/warden/types/v1beta3/errors.go
+++ b/warden/x/warden/types/v1beta3/errors.go
@@ -6,7 +6,7 @@ import (
 	sdkerrors "cosmossdk.io/errors"
 )
 
-// x/warden module sentinel errors
+// x/warden module sentinel errors.
 var (
 	ErrInvalidSigner                    = sdkerrors.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
 	ErrInvalidActionSigner              = sdkerrors.Register(ModuleName, 1102, "expected x/act account as only signer for action message")

--- a/warden/x/warden/types/v1beta3/genesis.go
+++ b/warden/x/warden/types/v1beta3/genesis.go
@@ -6,10 +6,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 )
 
-// DefaultIndex is the default global index
+// DefaultIndex is the default global index.
 const DefaultIndex uint64 = 1
 
-// DefaultGenesis returns the default genesis state
+// DefaultGenesis returns the default genesis state.
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
 		// this line is used by starport scaffolding # genesis/types/default
@@ -33,6 +33,5 @@ func GetGenesisStateFromAppState(cdc codec.JSONCodec, appState map[string]json.R
 // failure.
 func (gs GenesisState) Validate() error {
 	// this line is used by starport scaffolding # genesis/types/validate
-
 	return gs.Params.Validate()
 }

--- a/warden/x/warden/types/v1beta3/genesis_test.go
+++ b/warden/x/warden/types/v1beta3/genesis_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/warden/x/warden/types/v1beta3/key.go
+++ b/warden/x/warden/types/v1beta3/key.go
@@ -38,6 +38,7 @@ func (k *Key) ToECDSASecp256k1() (*ecdsa.PublicKey, error) {
 	if len(k.PublicKey) == 33 {
 		// Compressed form
 		var err error
+
 		pk, err = crypto.DecompressPubkey(k.PublicKey)
 		if err != nil {
 			return nil, err
@@ -45,6 +46,7 @@ func (k *Key) ToECDSASecp256k1() (*ecdsa.PublicKey, error) {
 	} else {
 		// Uncompressed form
 		var err error
+
 		pk, err = crypto.UnmarshalPubkey(k.PublicKey)
 		if err != nil {
 			return nil, err
@@ -68,5 +70,6 @@ func (k *Key) ToEdDSAEd25519() (*ed25519.PublicKey, error) {
 
 	pubKey := ed25519.PublicKey(k.PublicKey)
 	pk = &pubKey
+
 	return pk, nil
 }

--- a/warden/x/warden/types/v1beta3/keychain.go
+++ b/warden/x/warden/types/v1beta3/keychain.go
@@ -2,6 +2,7 @@ package v1beta3
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -11,6 +12,7 @@ func (k *Keychain) AccAddress() sdk.AccAddress {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, k.Id)
 	addr := append([]byte("keychain-"), bz...)
+
 	return addr
 }
 
@@ -20,6 +22,7 @@ func (k *Keychain) IsWriter(address string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -29,6 +32,7 @@ func (k *Keychain) IsAdmin(address string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -55,7 +59,7 @@ func (k *Keychain) SetFees(fees KeychainFees) {
 
 func (k *Keychain) SetName(name string) error {
 	if name == "" {
-		return fmt.Errorf("name cannot be empty")
+		return errors.New("name cannot be empty")
 	}
 
 	k.Name = name
@@ -93,7 +97,7 @@ func NewKeybaseId(value string) (*KeybaseId, error) {
 	}
 
 	if len(value) != 16 {
-		return nil, fmt.Errorf("keybase id must be length of 16")
+		return nil, errors.New("keybase id must be length of 16")
 	}
 
 	return &KeybaseId{Value: value}, nil

--- a/warden/x/warden/types/v1beta3/keys.go
+++ b/warden/x/warden/types/v1beta3/keys.go
@@ -1,13 +1,11 @@
 package v1beta3
 
 const (
-	// ModuleName defines the module name
+	// ModuleName defines the module name.
 	ModuleName = "warden"
 
-	// StoreKey defines the primary module store key
+	// StoreKey defines the primary module store key.
 	StoreKey = ModuleName
 )
 
-var (
-	ParamsKey = []byte("p_warden")
-)
+var ParamsKey = []byte("p_warden")

--- a/warden/x/warden/types/v1beta3/params.go
+++ b/warden/x/warden/types/v1beta3/params.go
@@ -6,22 +6,22 @@ import (
 
 var _ paramtypes.ParamSet = (*Params)(nil)
 
-// NewParams creates a new Params instance
+// NewParams creates a new Params instance.
 func NewParams() Params {
 	return Params{}
 }
 
-// DefaultParams returns a default set of parameters
+// DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
 	return NewParams()
 }
 
-// ParamSetPairs get the params.ParamSet
+// ParamSetPairs get the params.ParamSet.
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{}
 }
 
-// Validate validates the set of params
+// Validate validates the set of params.
 func (p Params) Validate() error {
 	return nil
 }

--- a/warden/x/warden/types/v1beta3/space.go
+++ b/warden/x/warden/types/v1beta3/space.go
@@ -13,6 +13,7 @@ func (w *Space) IsOwner(address string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -24,7 +25,9 @@ func (w *Space) AddOwner(address string, nonce uint64) error {
 	if w.IsOwner(address) {
 		return ErrDuplicateSpaceOwner
 	}
+
 	w.Owners = append(w.Owners, address)
+
 	return nil
 }
 


### PR DESCRIPTION
I added a `.golangci-lint.yml` configuration file to enable more linters and configure them accordingly to our needs.

Some linters remain disabled as they require manual intervention. In the future we can start enabling and fixing what's needed, one by one.

The second commit is just the result of `golangci-lint run --fix`, which fixes whatever it can automatically.