### PR TITLE
ci: revert linter change that broke templates strings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   enable-all: true
   disable:
     - cyclop
+    - dupword
     - err113
     - exhaustruct
     - funlen

--- a/cmd/wardend/cmd/config.go
+++ b/cmd/wardend/cmd/config.go
@@ -109,8 +109,8 @@ func initAppConfig() (string, interface{}) {
 		oracleconfig.DefaultConfigTemplate +
 		evmservercfg.DefaultEVMConfigTemplate +
 		evmservercfg.DefaultRosettaConfigTemplate +
-		pricepredconfig.DefaultEVMConfigTemplate +
-		httpconfig.DefaultEVMConfigTemplate
+		pricepredconfig.DefaultConfigTemplate +
+		httpconfig.DefaultConfigTemplate
 
 	// Edit the default template file
 	//

--- a/prophet/handlers/http/config/config.go
+++ b/prophet/handlers/http/config/config.go
@@ -4,8 +4,8 @@ package config
 // be set in the app.toml file.
 
 type Config struct {
-	Enabled    bool     `mapstructure:"enabled" toml:"enabled"`
-	URLs       []string `mapstructure:"urls" toml:"urls"`
+	Enabled    bool     `mapstructure:"enabled"     toml:"enabled"`
+	URLs       []string `mapstructure:"urls"        toml:"urls"`
 	TimeoutSec int      `mapstructure:"timeout_sec" toml:"timeout_sec"`
 }
 
@@ -18,4 +18,18 @@ func DefaultConfig() *Config {
 	}
 }
 
-const DefaultEVMConfigTemplate = "\n###############################################################################\n###                      HTTP configuration                     ###\n###############################################################################\n[http]\n\n# Is HTTP handler enabled\n= \"{{ .Http.Enabled }}\"\n\n# URLs used for HTTP handler\nurls = [\"{{ range $i, $url := .Http.URLs }}{{if $i}},{{end}}{{$url}}{{end}}\"]\n\n# Timeout in seconds for the HTTP client\ntimeout_sec = {{ .Http.TimeoutSec"
+const DefaultConfigTemplate = `
+###############################################################################
+###                      HTTP configuration                                 ###
+###############################################################################
+[http]
+
+# Is HTTP handler enabled
+enabled = "{{ .Http.Enabled }}"
+
+# URLs used for HTTP handler
+urls = ["{{ range $i, $url := .Http.URLs }}{{if $i}},{{end}}{{$url}}{{end}}"]
+
+# Timeout in seconds for the HTTP client
+timeout_sec = {{ .Http.TimeoutSec }}
+`

--- a/prophet/handlers/pricepred/config/config.go
+++ b/prophet/handlers/pricepred/config/config.go
@@ -16,4 +16,15 @@ func DefaultConfig() *Config {
 	}
 }
 
-const DefaultEVMConfigTemplate = "\n###############################################################################\n###                      Price prediction configuration                     ###\n###############################################################################\n[pricepred]\n\n# Is price prediction enabled\n= \"{{ .PricePred.Enabled }}\"\n\n# URL used for price prediction handler\nurl = \"{{ .PricePred.URL"
+const DefaultConfigTemplate = `
+###############################################################################
+###                      Price prediction configuration                     ###
+###############################################################################
+[pricepred]
+
+# Is price prediction enabled
+enabled = "{{ .PricePred.Enabled }}"
+
+# URL used for price prediction handler
+url = "{{ .PricePred.URL }}"
+`


### PR DESCRIPTION
The dupword linter broke the templating strings we use for configuring the prophet handlers. I disabled the linter.

Revert the change and fix the variable name (remove EVM from it, which was a copy/paste mistake).