### PR TITLE
ci(buf): disable failing breaking change check on main

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -30,5 +30,5 @@ jobs:
         with:
           format: true
           lint: false
-          breaking: true
+          breaking: ${{ contains(fromJSON('["pull_request"]'), github.event_name) }}
           push: false


### PR DESCRIPTION
This "buf breaking" check fails on new commits on main, because the buf build action doesn't understand what to check it against.

Disable the failing check for now, keep it on PRs where it seems to be working.