### PR TITLE
ci(buf): disable archive of deleted labels

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -32,3 +32,4 @@ jobs:
           lint: false
           breaking: true
           push: false
+          archive: false


### PR DESCRIPTION
this makes certain CI actions fail when a branch is deleted, e.g. https://github.com/warden-protocol/wardenprotocol/actions/runs/13853355121