### PR TITLE
ci: run go build and test on go.mod changes

### DIFF
--- a/.github/workflows/faucet.yml
+++ b/.github/workflows/faucet.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
     paths:
+      - "go.mod"
       - "cmd/faucet/**"
       - "cmd/wardend/**"
       - "warden/**"
@@ -15,6 +16,7 @@ on:
       - "wardend/v*"
   pull_request:
     paths:
+      - "go.mod"
       - "cmd/faucet/**"
       - "cmd/wardend/**"
       - "warden/**"

--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "go.mod"
       - "cmd/wardend/**"
       - "warden/**"
       - "precompiles/**"
@@ -13,6 +14,7 @@ on:
       - "wardend/v*"
   pull_request:
     paths:
+      - "go.mod"
       - "cmd/wardend/**"
       - "warden/**"
       - "precompiles/**"

--- a/.github/workflows/wardenkms.yml
+++ b/.github/workflows/wardenkms.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
     paths:
+      - "go.mod"
       - "cmd/wardenkms/**"
       - "go-client/**"
       - "keychain-sdk/**"
@@ -13,6 +14,7 @@ on:
       - "wardenkms/v*"
   pull_request:
     paths:
+      - "go.mod"
       - "cmd/wardenkms/**"
       - "go-client/**"
       - "keychain-sdk/**"


### PR DESCRIPTION
Sometimes we bump some dependencies in the go.mod, it would be great to immediately have a check for ensuring our binaries (wardend, faucet, wardenkms) keep compiling correctly.