### PR TITLE
chore(wardenkms): fix linter formatting warnings

### DIFF
--- a/cmd/wardenkms/bip44.go
+++ b/cmd/wardenkms/bip44.go
@@ -41,7 +41,6 @@ func (k *Bip44Keychain) PublicKey(keyID [4]byte) (pubKey []byte, err error) {
 	}
 
 	pubKey, err = generateECDSAPubKey(privKeySeed)
-
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/wardenkms/wardenkms.go
+++ b/cmd/wardenkms/wardenkms.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"log"
 	"log/slog"
 	"net/http"
@@ -137,7 +137,7 @@ func main() {
 
 func bigEndianBytesFromUint32(n uint64) ([4]byte, error) {
 	if n > 0xffffffff {
-		return [4]byte{}, fmt.Errorf("number is too large to fit in 4 bytes")
+		return [4]byte{}, errors.New("number is too large to fit in 4 bytes")
 	}
 
 	b := make([]byte, 4)


### PR DESCRIPTION
A couple minor linter issues in wardenkms (it's been a while since we last ran CI on wardenkms 🤣).