### PR TITLE
fix(ci): missing write permissions on packages

### DIFF
--- a/.github/workflows/release-wardend.yaml
+++ b/.github/workflows/release-wardend.yaml
@@ -12,6 +12,9 @@ jobs:
     strategy:
       matrix:
         release: ["release"]
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -58,6 +58,9 @@ jobs:
     strategy:
       matrix:
         release: ["release"]
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
this should fix the issue where goreleaser fails to publish packages