### PR TITLE
fix(ci): dependabot skip publishing the images

### DIFF
--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -59,6 +59,7 @@ jobs:
       matrix:
         release: ["release"]
     permissions:
+      actions: read
       contents: read
       packages: write
 
@@ -99,5 +100,5 @@ jobs:
       - name: ${{ matrix.release }}
         run: just wardend ${{ matrix.release }}
         env:
-          SKIP: "--skip=validate"
+          SKIP: "${{ startsWith(github.head_ref, 'dependabot/') ? '--skip=validate,publish' : '--skip=validate' }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should fix when dependabot opens a PR and tries to publish new container images. By default dependabot is not trusted to publish any images/artifacts etc.
It should be enough to see that builds succeed and there is no need to publish them.