### PR TITLE
fix(ci): fix CI YAML syntax error

### DIFF
--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -100,5 +100,5 @@ jobs:
       - name: ${{ matrix.release }}
         run: just wardend ${{ matrix.release }}
         env:
-          SKIP: "${{ startsWith(github.head_ref, 'dependabot/') ? '--skip=validate,publish' : '--skip=validate' }}"
+          SKIP: ${{ startsWith(github.head_ref, 'dependabot/') && '--skip=validate,publish' || '--skip=validate' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should fix the YAML syntax error on the wardend.yaml workflow