### PR TITLE
fix spelling issues 

### DIFF
--- a/cmd/wardend/cmd/wait.go
+++ b/cmd/wardend/cmd/wait.go
@@ -90,7 +90,7 @@ func newResponseFormatBroadcastTxCommit(res *coretypes.ResultBroadcastTxCommit) 
 	return newTxResponseDeliverTx(res)
 }
 
-// WaitTx returns a CLI command thatwaits for a transaction with the given hash to be included in a block.
+// WaitTx returns a CLI command that waits for a transaction with the given hash to be included in a block.
 func WaitTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wait-tx [hash]",

--- a/cmd/wardenkms/bip44.go
+++ b/cmd/wardenkms/bip44.go
@@ -107,7 +107,7 @@ func generateECDSAPubKey(seed []byte) (pubKeyBytes []byte, err error) {
 	}
 	prv, err := crypto.ToECDSA(prvD)
 	if err != nil {
-		return nil, fmt.Errorf("error genertaing ecdsa private/public key pair: Error %v. Priv key bitlength: %v", err, 8*len(seed))
+		return nil, fmt.Errorf("error generating ecdsa private/public key pair: Error %v. Priv key bitlength: %v", err, 8*len(seed))
 	}
 	pubKeyBytes = crypto.CompressPubkey(&prv.PublicKey)
 


### PR DESCRIPTION
thatwaits - that waits `added missing space`
genertaing - generating `fix error`