### PR TITLE
fix(go-client): avoid calling NewApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* (go-client) Fix additional goroutine being created for every signed transaction
+
 ## [v0.6.2](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.6.2) - 2025-03-05
 
 ### Bug Fixes

--- a/go-client/query_client_auth.go
+++ b/go-client/query_client_auth.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-// AuthQueryClient stores a query client for the warden auth module
+// AuthQueryClient stores a query client for the warden auth module.
 type AuthQueryClient struct {
 	client authtypes.QueryClient
 }

--- a/go-client/query_client_warden.go
+++ b/go-client/query_client_warden.go
@@ -4,8 +4,9 @@ import (
 	"context"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	"google.golang.org/grpc"
+
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
 type PageRequest = query.PageRequest
@@ -15,7 +16,7 @@ type WardenQueryClient struct {
 	client types.QueryClient
 }
 
-// NewWardenQueryClient returns a WardenQueryClient
+// NewWardenQueryClient returns a WardenQueryClient.
 func NewWardenQueryClient(c *grpc.ClientConn) *WardenQueryClient {
 	return &WardenQueryClient{
 		client: types.NewQueryClient(c),

--- a/go-client/tx_identity_test.go
+++ b/go-client/tx_identity_test.go
@@ -2,9 +2,9 @@ package client
 
 import (
 	"encoding/base64"
-	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewIdentityFromSeed(t *testing.T) {
@@ -13,8 +13,8 @@ func TestNewIdentityFromSeed(t *testing.T) {
 	id, err := NewIdentityFromSeed(seed)
 	require.NoError(t, err)
 
-	fmt.Printf("address: %s\n", id.Address.String())
-	fmt.Printf("private key: %s\n", base64.StdEncoding.EncodeToString(id.PrivKey.Bytes()))
+	t.Logf("address: %s\n", id.Address.String())
+	t.Logf("private key: %s\n", base64.StdEncoding.EncodeToString(id.PrivKey.Bytes()))
 
 	if id.Address.String() != "warden1d652c9nngq5cneak2whyaqa4g9ehr8pstxj0r5" {
 		t.Fatalf("unexpected address: %s", id.Address.String())

--- a/go-client/tx_raw_client.go
+++ b/go-client/tx_raw_client.go
@@ -13,8 +13,9 @@ import (
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
-	"github.com/warden-protocol/wardenprotocol/warden/app"
 	"google.golang.org/grpc"
+
+	"github.com/warden-protocol/wardenprotocol/warden/app"
 )
 
 var (

--- a/go-client/tx_raw_client.go
+++ b/go-client/tx_raw_client.go
@@ -3,21 +3,16 @@ package client
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
-	"cosmossdk.io/log"
 	"cosmossdk.io/math"
-	db "github.com/cosmos/cosmos-db"
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
-	"github.com/spf13/viper"
 	"github.com/warden-protocol/wardenprotocol/warden/app"
 	"google.golang.org/grpc"
 )
@@ -27,6 +22,7 @@ var (
 	DefaultFees     = types.NewCoins(types.NewCoin("award", math.NewInt(1000000000000000)))
 
 	queryTimeout = 250 * time.Millisecond
+	txConfig     = app.NewTxConfig()
 )
 
 type AccountFetcher interface {
@@ -81,27 +77,8 @@ func (c *RawTxClient) BuildTx(ctx context.Context, gasLimit uint64, fees types.C
 	accSeq := account.GetSequence()
 	accNum := account.GetAccountNumber()
 
-	appConfig := viper.New()
-	dname, err := os.MkdirTemp("", "warden-go-client")
-	if err != nil {
-		return nil, fmt.Errorf("create temp dir: %w", err)
-	}
-	defer os.RemoveAll(dname)
-	appConfig.Set(flags.FlagHome, dname)
-	app, err := app.New(
-		log.NewNopLogger(),
-		db.NewMemDB(),
-		nil,
-		false,
-		appConfig,
-		nil,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create app: %w", err)
-	}
-
-	txBuilder := app.TxConfig().NewTxBuilder()
-	signMode := app.TxConfig().SignModeHandler().DefaultMode()
+	txBuilder := txConfig.NewTxBuilder()
+	signMode := txConfig.SignModeHandler().DefaultMode()
 
 	// build unsigned tx
 	txBuilder.SetGasLimit(gasLimit)
@@ -145,7 +122,7 @@ func (c *RawTxClient) BuildTx(ctx context.Context, gasLimit uint64, fees types.C
 		signerData,
 		txBuilder,
 		c.Identity.PrivKey,
-		app.TxConfig(),
+		txConfig,
 		accSeq,
 	)
 	if err != nil {
@@ -157,7 +134,7 @@ func (c *RawTxClient) BuildTx(ctx context.Context, gasLimit uint64, fees types.C
 		return nil, fmt.Errorf("set signature: %w", err)
 	}
 
-	txBytes, err := app.TxConfig().TxEncoder()(txBuilder.GetTx())
+	txBytes, err := txConfig.TxEncoder()(txBuilder.GetTx())
 	if err != nil {
 		return nil, fmt.Errorf("encode tx: %w", err)
 	}

--- a/go-client/tx_warden.go
+++ b/go-client/tx_warden.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -271,6 +271,26 @@ func AppConfig() depinject.Config {
 	)
 }
 
+// NewTxConfig initializes a new TxConfig, equivalent to the one used by [App].
+func NewTxConfig() client.TxConfig {
+	var txConfig client.TxConfig
+
+	appConfig := depinject.Configs(
+		AppConfig(),
+		depinject.Supply(
+			log.NewNopLogger(),
+		),
+	)
+
+	if err := depinject.Inject(appConfig,
+		&txConfig,
+	); err != nil {
+		panic(err)
+	}
+
+	return txConfig
+}
+
 // New returns a reference to an initialized App.
 func New(
 	logger log.Logger,


### PR DESCRIPTION
The `app.New` call inside go-client spawned several goroutines (e.g. slinky client, prophet) that were not explicitly stopped.

We can simplify a lot the txConfig initialization logic by implementing the new `app.NewTxConfig` function.