### PR TITLE
fix(shield): linters

### DIFF
--- a/shield/internal/evaluator/evaluator.go
+++ b/shield/internal/evaluator/evaluator.go
@@ -14,7 +14,7 @@ func Eval(exp *ast.Expression, env env.Environment) object.Object {
 	case *ast.Expression_IntegerLiteral:
 		value, success := new(big.Int).SetString(exp.IntegerLiteral.Value, 10)
 		if !success {
-			return newError("invalid IntegerLiteral value: " + exp.IntegerLiteral.Value)
+			return newError("invalid IntegerLiteral value: %s", exp.IntegerLiteral.Value)
 		}
 		return &object.Integer{Value: value}
 	case *ast.Expression_BooleanLiteral:
@@ -43,7 +43,7 @@ func Eval(exp *ast.Expression, env env.Environment) object.Object {
 			return v
 		}
 
-		return newError("identifier not found: " + exp.Identifier.Value)
+		return newError("identifier not found: %s", exp.Identifier.Value)
 	case *ast.Expression_InfixExpression:
 		return evalInfixExpression(exp.InfixExpression, env)
 	case *ast.Expression_PrefixExpression:
@@ -53,6 +53,7 @@ func Eval(exp *ast.Expression, env env.Environment) object.Object {
 		args := evalExpressions(exp.CallExpression.Arguments, env)
 		return applyFunction(fn, args)
 	}
+
 	return newError("unknown expression: %s (type %T)", exp, exp)
 }
 
@@ -240,5 +241,6 @@ func cmpBigInt(left, right object.Object) (int, *object.Error) {
 	}
 
 	z := new(big.Int)
+
 	return z.Sub(l, r).Sign(), nil
 }

--- a/shield/internal/evaluator/evaluator_test.go
+++ b/shield/internal/evaluator/evaluator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/shield/internal/lexer"
 	"github.com/warden-protocol/wardenprotocol/shield/internal/parser"
 	"github.com/warden-protocol/wardenprotocol/shield/object"

--- a/shield/internal/lexer/lexer.go
+++ b/shield/internal/lexer/lexer.go
@@ -112,6 +112,7 @@ func (l *Lexer) NextToken() token.Token {
 	}
 
 	l.readChar()
+
 	return tok
 }
 

--- a/shield/internal/lexer/lexer_test.go
+++ b/shield/internal/lexer/lexer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/shield/token"
 )
 

--- a/shield/internal/metadata/metadata_test.go
+++ b/shield/internal/metadata/metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
 	"github.com/warden-protocol/wardenprotocol/shield/internal/lexer"
 	"github.com/warden-protocol/wardenprotocol/shield/internal/parser"

--- a/shield/internal/parser/parser_test.go
+++ b/shield/internal/parser/parser_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
 	"github.com/warden-protocol/wardenprotocol/shield/internal/lexer"
 )

--- a/shield/internal/preprocess/preprocess_test.go
+++ b/shield/internal/preprocess/preprocess_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
 	"github.com/warden-protocol/wardenprotocol/shield/internal/lexer"
 	"github.com/warden-protocol/wardenprotocol/shield/internal/parser"
@@ -28,11 +29,12 @@ func parseExpression(t *testing.T, input string) *ast.Expression {
 	}
 
 	require.NotNil(t, expression)
+
 	return expression
 }
 
 func TestPreprocess(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	expression := parseExpression(t, "foo1(foo2(), false || true, [false, [10, 11, 12]])")
 	expander := NoopExpander{}
 	proc, err := Preprocess(ctx, expression, expander)
@@ -67,7 +69,7 @@ func TestPreprocess(t *testing.T) {
 }
 
 func TestPreprocessElements(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	expression := parseExpression(t, "[10, 11, 12]")
 	expander := NoopExpander{}
 
@@ -86,7 +88,7 @@ func TestPreprocessElements(t *testing.T) {
 }
 
 func TestPreprocessInfixExpression(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	expression := parseExpression(t, "false || true && false")
 	expander := NoopExpander{}
 
@@ -111,7 +113,7 @@ func TestPreprocessInfixExpression(t *testing.T) {
 }
 
 func TestPreprocessCallExpression(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	expression := parseExpression(t, "foo1(123, foo2(235))")
 	expander := NoopExpander{}
 

--- a/shield/object/object.go
+++ b/shield/object/object.go
@@ -3,6 +3,7 @@ package object
 import (
 	"fmt"
 	"math/big"
+	"strconv"
 )
 
 type ObjectType string
@@ -37,7 +38,7 @@ type Boolean struct {
 	Value bool
 }
 
-func (b *Boolean) Inspect() string  { return fmt.Sprintf("%t", b.Value) }
+func (b *Boolean) Inspect() string  { return strconv.FormatBool(b.Value) }
 func (b *Boolean) Type() ObjectType { return BOOLEAN_OBJ }
 
 type String struct {

--- a/shield/shield.go
+++ b/shield/shield.go
@@ -2,6 +2,7 @@ package shield
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/warden-protocol/wardenprotocol/shield/ast"
@@ -45,7 +46,7 @@ type Metadata = metadata.Metadata
 // ExtractMetadata extracts metadata from the given expression.
 func ExtractMetadata(root *ast.Expression) (Metadata, error) {
 	if root == nil {
-		return Metadata{}, fmt.Errorf("empty input")
+		return Metadata{}, errors.New("empty input")
 	}
 
 	return metadata.ExtractMetadata(root), nil


### PR DESCRIPTION
golangci-lint is (rightfully) complaining about the fact that we're not using the format arguments properly, and other minor styling things :)