### PR TITLE
fix(keychain-sdk): pass context explicitly for granular control

### DIFF
--- a/cmd/clichain/main.go
+++ b/cmd/clichain/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"log"
 	"os"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -35,7 +36,7 @@ var generateCmd = &cobra.Command{
 
 		w := os.Stdout
 		if output != "" {
-			f, err := os.OpenFile(output, os.O_CREATE|os.O_WRONLY, 0600)
+			f, err := os.OpenFile(output, os.O_CREATE|os.O_WRONLY, 0o600)
 			if err != nil {
 				return fmt.Errorf("opening output file: %w", err)
 			}
@@ -43,7 +44,7 @@ var generateCmd = &cobra.Command{
 			w = f
 		}
 
-		if _, err := w.Write([]byte(hex.EncodeToString(keybin))); err != nil {
+		if _, err := w.WriteString(hex.EncodeToString(keybin)); err != nil {
 			return fmt.Errorf("writing key to file: %w", err)
 		}
 
@@ -191,7 +192,6 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }

--- a/cmd/wardenkms/wardenkms.go
+++ b/cmd/wardenkms/wardenkms.go
@@ -70,7 +70,7 @@ func main() {
 		TxFees:        sdk.NewCoins(sdk.NewCoin("award", math.NewInt(cfg.TxFee))),
 	})
 
-	app.SetKeyRequestHandler(func(ctx context.Context, w keychain.KeyResponseWriter, req *keychain.KeyRequest) {
+	app.SetKeyRequestHandler(func(ctx context.Context, w keychain.Writer, req *keychain.KeyRequest) {
 		if req.KeyType != types.KeyType_KEY_TYPE_ECDSA_SECP256K1 {
 			_ = w.Reject(ctx, "unsupported key type")
 			return
@@ -96,7 +96,7 @@ func main() {
 		}
 	})
 
-	app.SetSignRequestHandler(func(ctx context.Context, w keychain.SignResponseWriter, req *keychain.SignRequest) {
+	app.SetSignRequestHandler(func(ctx context.Context, w keychain.Writer, req *keychain.SignRequest) {
 		keyID, err := bigEndianBytesFromUint32(req.KeyId)
 		if err != nil {
 			logger.Error("failed to convert Key ID to big endian bytes", "error", err)

--- a/cmd/wardenkms/wardenkms.go
+++ b/cmd/wardenkms/wardenkms.go
@@ -70,48 +70,48 @@ func main() {
 		TxFees:        sdk.NewCoins(sdk.NewCoin("award", math.NewInt(cfg.TxFee))),
 	})
 
-	app.SetKeyRequestHandler(func(w keychain.KeyResponseWriter, req *keychain.KeyRequest) {
+	app.SetKeyRequestHandler(func(ctx context.Context, w keychain.KeyResponseWriter, req *keychain.KeyRequest) {
 		if req.KeyType != types.KeyType_KEY_TYPE_ECDSA_SECP256K1 {
-			_ = w.Reject("unsupported key type")
+			_ = w.Reject(ctx, "unsupported key type")
 			return
 		}
 
 		id, err := bigEndianBytesFromUint32(req.Id)
 		if err != nil {
 			logger.Error("failed to convert key id to big endian bytes", "error", err)
-			_ = w.Reject("request ID is too large")
+			_ = w.Reject(ctx, "request ID is too large")
 			return
 		}
 
 		pubKey, err := bip44.PublicKey(id)
 		if err != nil {
 			logger.Error("failed to get public key", "error", err)
-			_ = w.Reject("failed to get public key")
+			_ = w.Reject(ctx, "failed to get public key")
 			return
 		}
 
-		err = w.Fulfil(pubKey)
+		err = w.Fulfil(ctx, pubKey)
 		if err != nil {
 			logger.Error("failed to fulfil key request", "error", err)
 		}
 	})
 
-	app.SetSignRequestHandler(func(w keychain.SignResponseWriter, req *keychain.SignRequest) {
+	app.SetSignRequestHandler(func(ctx context.Context, w keychain.SignResponseWriter, req *keychain.SignRequest) {
 		keyID, err := bigEndianBytesFromUint32(req.KeyId)
 		if err != nil {
 			logger.Error("failed to convert Key ID to big endian bytes", "error", err)
-			_ = w.Reject("Key ID is too large")
+			_ = w.Reject(ctx, "Key ID is too large")
 			return
 		}
 
 		signature, err := bip44.Sign(keyID, req.DataForSigning)
 		if err != nil {
 			logger.Error("failed to sign message", "error", err)
-			_ = w.Reject("failed to sign message")
+			_ = w.Reject(ctx, "failed to sign message")
 			return
 		}
 
-		err = w.Fulfil(signature)
+		err = w.Fulfil(ctx, signature)
 		if err != nil {
 			logger.Error("failed to fulfil sign request", "error", err)
 		}

--- a/docs/developer-docs/docs/build-a-keychain/build-a-keychain-app.md
+++ b/docs/developer-docs/docs/build-a-keychain/build-a-keychain-app.md
@@ -179,7 +179,7 @@ In this example, the Keychain will generate ECDSA secp256k1 keys using the `gith
     func main() {
         app := ...
     
-        app.SetKeyRequestHandler(func(ctx context.Context, w keychain.KeyResponseWriter, req *keychain.KeyRequest) {
+        app.SetKeyRequestHandler(func(ctx context.Context, w keychain.Writer, req *keychain.KeyRequest) {
             // your custom logic goes here
         })
     }
@@ -187,7 +187,7 @@ In this example, the Keychain will generate ECDSA secp256k1 keys using the `gith
 
     The `SetKeyRequestHandler()` function receives the following:
 
-    - `KeyResponseWriter` that can be used to write the response back to the chain
+    - `Writer` that can be used to write the response back to the chain
     - `KeyRequest` with the details of the request, such as the key type (for example, ECDSA secp256k1)
 
 2. Write a simple in-memory storage:
@@ -234,7 +234,7 @@ In this example, the Keychain will generate ECDSA secp256k1 keys using the `gith
             keys: make(map[uint64]*ecdsa.PrivateKey),
         }
     
-        app.SetKeyRequestHandler(func(ctx context.Context, w keychain.KeyResponseWriter, req *keychain.KeyRequest) {
+        app.SetKeyRequestHandler(func(ctx context.Context, w keychain.Writer, req *keychain.KeyRequest) {
             if req.KeyType != v1beta2.KeyType_KEY_TYPE_ECDSA_SECP256K1 {
                 logger.Error("unsupported key type", "type", req.KeyType)
                 w.Reject(ctx, "unsupported key type")
@@ -273,7 +273,7 @@ Add the following code to your `main.go` file:
 func main() {
     // ...
 
-    app.SetSignRequestHandler(func(ctx context.Context, w keychain.SignResponseWriter, req *keychain.SignRequest) {
+    app.SetSignRequestHandler(func(ctx context.Context, w keychain.Writer, req *keychain.SignRequest) {
         key := store.Get(req.KeyId)
         if key == nil {
             logger.Error("key not found", "id", req.KeyId)

--- a/docs/developer-docs/docs/build-a-keychain/implementations/keychain-sdk.md
+++ b/docs/developer-docs/docs/build-a-keychain/implementations/keychain-sdk.md
@@ -18,11 +18,11 @@ In this section, we will walk you through different modules of the **Keychain SD
 
 **Key components:**
 
-- **SignResponseWriter interface**: Provides methods to fulfill or reject signature requests.
+- **Writer interface**: Provides methods to fulfill or reject signature requests.
   - `Fulfil(signature []byte) error`: Writes a signature to a signature request.
   - `Reject(reason string) error`: Writes a rejection message to a signature request.
 - **SignRequestHandler**: A function type that processes individual signature requests.
-- **signResponseWriter struct**: Implements the `SignResponseWriter` interface, managing encryption and transaction writing.
+- **signResponseWriter struct**: Implements the `Writer` interface, managing encryption and transaction writing.
 
 **Functions:**
 
@@ -51,11 +51,11 @@ In this section, we will walk you through different modules of the **Keychain SD
 
 **Key components:**
 
-- **KeyResponseWriter Interface**: Contains methods to fulfill or reject key requests.
+- **Writer Interface**: Contains methods to fulfill or reject key requests.
   - `Fulfil(publicKey []byte) error`: Sends a public key in response.
   - `Reject(reason string) error`: Sends a rejection reason.
 - **KeyRequestHandler**: A function type for handling key requests.
-- **keyResponseWriter Struct**: Implements the `KeyResponseWriter` interface, processing key requests and writing results.
+- **Writer Struct**: Implements the `Writer` interface, processing key requests and writing results.
 
 **Functions:**
 

--- a/keychain-sdk/example_keychain_test.go
+++ b/keychain-sdk/example_keychain_test.go
@@ -35,16 +35,16 @@ func Main() {
 		BatchSize:     10,
 	})
 
-	app.SetKeyRequestHandler(func(w keychain.KeyResponseWriter, req *keychain.KeyRequest) {
+	app.SetKeyRequestHandler(func(ctx context.Context, w keychain.KeyResponseWriter, req *keychain.KeyRequest) {
 		// handle key request
-		if err := w.Fulfil([]byte("public key data")); err != nil {
+		if err := w.Fulfil(ctx, []byte("public key data")); err != nil {
 			logger.Error("could not fulfill key request", "error", err)
 		}
 	})
 
-	app.SetSignRequestHandler(func(w keychain.SignResponseWriter, req *keychain.SignRequest) {
+	app.SetSignRequestHandler(func(ctx context.Context, w keychain.SignResponseWriter, req *keychain.SignRequest) {
 		// handle sign request
-		if err := w.Fulfil([]byte("signature data")); err != nil {
+		if err := w.Fulfil(ctx, []byte("signature data")); err != nil {
 			logger.Error("could not fulfill sign request", "error", err)
 		}
 	})

--- a/keychain-sdk/example_keychain_test.go
+++ b/keychain-sdk/example_keychain_test.go
@@ -35,14 +35,14 @@ func Main() {
 		BatchSize:     10,
 	})
 
-	app.SetKeyRequestHandler(func(ctx context.Context, w keychain.KeyResponseWriter, req *keychain.KeyRequest) {
+	app.SetKeyRequestHandler(func(ctx context.Context, w keychain.Writer, req *keychain.KeyRequest) {
 		// handle key request
 		if err := w.Fulfil(ctx, []byte("public key data")); err != nil {
 			logger.Error("could not fulfill key request", "error", err)
 		}
 	})
 
-	app.SetSignRequestHandler(func(ctx context.Context, w keychain.SignResponseWriter, req *keychain.SignRequest) {
+	app.SetSignRequestHandler(func(ctx context.Context, w keychain.Writer, req *keychain.SignRequest) {
 		// handle sign request
 		if err := w.Fulfil(ctx, []byte("signature data")); err != nil {
 			logger.Error("could not fulfill sign request", "error", err)

--- a/keychain-sdk/internal/writer/writer.go
+++ b/keychain-sdk/internal/writer/writer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/warden-protocol/wardenprotocol/go-client"
 )
 

--- a/keychain-sdk/key_requests.go
+++ b/keychain-sdk/key_requests.go
@@ -11,20 +11,11 @@ import (
 	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
-// KeyResponseWriter is the interface for writing responses to key requests.
-type KeyResponseWriter interface {
-	// Fulfil writes a public key to the key request.
-	Fulfil(ctx context.Context, publicKey []byte) error
-
-	// Reject writes a human-readable reason for rejecting the key request.
-	Reject(ctx context.Context, reason string) error
-}
-
 // KeyRequest is a key request.
 type KeyRequest wardentypes.KeyRequest
 
 // KeyRequestHandler is a function that handles key requests.
-type KeyRequestHandler func(ctx context.Context, w KeyResponseWriter, req *KeyRequest)
+type KeyRequestHandler func(ctx context.Context, w Writer, req *KeyRequest)
 
 type keyResponseWriter struct {
 	txWriter     *writer.W

--- a/keychain-sdk/key_requests.go
+++ b/keychain-sdk/key_requests.go
@@ -46,9 +46,9 @@ func (w *keyResponseWriter) Reject(ctx context.Context, reason string) error {
 	return err
 }
 
-func (a *App) ingestKeyRequests(keyRequestsCh chan *wardentypes.KeyRequest) {
+func (a *App) ingestKeyRequests(ctx context.Context, keyRequestsCh chan *wardentypes.KeyRequest) {
 	for {
-		reqCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		keyRequests, err := a.keyRequests(reqCtx)
 		cancel()
 		if err != nil {
@@ -70,14 +70,13 @@ func (a *App) ingestKeyRequests(keyRequestsCh chan *wardentypes.KeyRequest) {
 	}
 }
 
-func (a *App) handleKeyRequest(keyRequest *wardentypes.KeyRequest) {
+func (a *App) handleKeyRequest(ctx context.Context, keyRequest *wardentypes.KeyRequest) {
 	if a.keyRequestHandler == nil {
 		a.logger().Error("key request handler not set")
 		return
 	}
 
 	go func() {
-		ctx := context.Background()
 		w := &keyResponseWriter{
 			txWriter:     a.txWriter,
 			keyRequestID: keyRequest.Id,

--- a/keychain-sdk/keychain.go
+++ b/keychain-sdk/keychain.go
@@ -12,11 +12,12 @@ import (
 	"io"
 	"log/slog"
 
+	"google.golang.org/grpc/connectivity"
+
 	"github.com/warden-protocol/wardenprotocol/go-client"
 	"github.com/warden-protocol/wardenprotocol/keychain-sdk/internal/tracker"
 	"github.com/warden-protocol/wardenprotocol/keychain-sdk/internal/writer"
 	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
-	"google.golang.org/grpc/connectivity"
 )
 
 // App is the Keychain application. It is responsible for handling key requests

--- a/keychain-sdk/keychain.go
+++ b/keychain-sdk/keychain.go
@@ -72,11 +72,11 @@ func (a *App) Start(ctx context.Context) error {
 
 	keyRequestsCh := make(chan *wardentypes.KeyRequest)
 	defer close(keyRequestsCh)
-	go a.ingestKeyRequests(keyRequestsCh)
+	go a.ingestKeyRequests(ctx, keyRequestsCh)
 
 	signRequestsCh := make(chan *wardentypes.SignRequest)
 	defer close(signRequestsCh)
-	go a.ingestSignRequests(signRequestsCh)
+	go a.ingestSignRequests(ctx, signRequestsCh)
 
 	flushErrors := make(chan error)
 	defer close(flushErrors)
@@ -93,9 +93,9 @@ func (a *App) Start(ctx context.Context) error {
 		case err := <-flushErrors:
 			a.logger().Error("tx writer flush error", "error", err)
 		case keyRequest := <-keyRequestsCh:
-			go a.handleKeyRequest(keyRequest)
+			go a.handleKeyRequest(ctx, keyRequest)
 		case signRequest := <-signRequestsCh:
-			go a.handleSignRequest(signRequest)
+			go a.handleSignRequest(ctx, signRequest)
 		}
 	}
 }

--- a/keychain-sdk/sign_requests.go
+++ b/keychain-sdk/sign_requests.go
@@ -59,9 +59,9 @@ func (w *signResponseWriter) Reject(ctx context.Context, reason string) error {
 	return err
 }
 
-func (a *App) ingestSignRequests(signRequestsCh chan *wardentypes.SignRequest) {
+func (a *App) ingestSignRequests(ctx context.Context, signRequestsCh chan *wardentypes.SignRequest) {
 	for {
-		reqCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		signRequests, err := a.signRequests(reqCtx)
 		cancel()
 		if err != nil {
@@ -83,7 +83,7 @@ func (a *App) ingestSignRequests(signRequestsCh chan *wardentypes.SignRequest) {
 	}
 }
 
-func (a *App) handleSignRequest(signRequest *wardentypes.SignRequest) {
+func (a *App) handleSignRequest(ctx context.Context, signRequest *wardentypes.SignRequest) {
 	if a.signRequestHandler == nil {
 		a.logger().Error("sign request handler not set")
 		return
@@ -91,7 +91,6 @@ func (a *App) handleSignRequest(signRequest *wardentypes.SignRequest) {
 
 	go func() {
 		a.logger().Debug("handling sign request", "id", signRequest.Id, "data_for_signing", hex.EncodeToString(signRequest.DataForSigning))
-		ctx := context.Background()
 		w := &signResponseWriter{
 			txWriter:      a.txWriter,
 			signRequestID: signRequest.Id,

--- a/keychain-sdk/sign_requests.go
+++ b/keychain-sdk/sign_requests.go
@@ -44,6 +44,7 @@ func (w *signResponseWriter) Fulfil(ctx context.Context, signature []byte) error
 	})
 	w.onComplete()
 	w.logger.Debug("fulfilled sign request", "id", w.signRequestID, "error", err)
+
 	return err
 }
 

--- a/keychain-sdk/sign_requests.go
+++ b/keychain-sdk/sign_requests.go
@@ -12,20 +12,11 @@ import (
 	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
-// SignaResponseWriter is the interface for writing responses to sign requests.
-type SignResponseWriter interface {
-	// Fulfil writes the signature to the sign request.
-	Fulfil(ctx context.Context, signature []byte) error
-
-	// Reject writes a rejection to the sign request.
-	Reject(ctx context.Context, reason string) error
-}
-
 // SignRequest is a sign request.
 type SignRequest wardentypes.SignRequest
 
 // SignRequestHandler is a function that handles sign requests.
-type SignRequestHandler func(ctx context.Context, w SignResponseWriter, req *SignRequest)
+type SignRequestHandler func(ctx context.Context, w Writer, req *SignRequest)
 
 type signResponseWriter struct {
 	txWriter      *writer.W

--- a/keychain-sdk/writer.go
+++ b/keychain-sdk/writer.go
@@ -1,0 +1,13 @@
+package keychain
+
+import "context"
+
+// Writer is the interface for writing responses to key or signature requests.
+type Writer interface {
+	// Fulfil writes the response data (a public key, or a signature) for a
+	// request.
+	Fulfil(ctx context.Context, data []byte) error
+
+	// Reject writes a rejection reason to a request.
+	Reject(ctx context.Context, reason string) error
+}


### PR DESCRIPTION
Instead of embedding the context in the opaque writer, pass it explicitly.

Right now we're not really using this context, but it allows the users to set up custom timeouts and enrich it with any data for more complex use cases.