### PR TITLE
Remove unsupported formatters from golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters:
     - protogetter # to be enabled once we start moving towards Opaque API (https://go.dev/blog/protobuf-opaque)
     - recvcheck
     - tagalign
-    - tenv
     - testpackage
     - varnamelen
     - wrapcheck


### PR DESCRIPTION
Removed `tenv` from ` .golangci.yml `because they are now considered formatters, not linters. Without these changes, golangci-lint fails with errors. Locally tested per the [official migration guide](https://golangci-lint.run/product/migration-guide/).
