### PR TITLE
ci: upgrade to golangci-lint v2

### DIFF
--- a/.github/workflows/faucet.yml
+++ b/.github/workflows/faucet.yml
@@ -36,9 +36,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
           args: --timeout=10m ${{ env.modules }}
 
   unit-test:

--- a/.github/workflows/go-client.yml
+++ b/.github/workflows/go-client.yml
@@ -22,9 +22,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
           args: --timeout=10m ./go-client/...
 
   unit-test:

--- a/.github/workflows/keychain-sdk.yml
+++ b/.github/workflows/keychain-sdk.yml
@@ -22,9 +22,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
           args: --timeout=10m ./keychain-sdk/...
 
   unit-test:

--- a/.github/workflows/shield.yml
+++ b/.github/workflows/shield.yml
@@ -22,9 +22,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
           args: --timeout=10m ./shield/...
 
   unit-test:

--- a/.github/workflows/soliditygen.yml
+++ b/.github/workflows/soliditygen.yml
@@ -22,9 +22,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
           args: --timeout=10m ./cmd/soliditygen/...
 
   unit-test:

--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -34,9 +34,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
           args: --timeout=10m ${{ env.modules }}
 
   unit-test:

--- a/.github/workflows/wardenkms.yml
+++ b/.github/workflows/wardenkms.yml
@@ -30,9 +30,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.0
           args: --timeout=10m ./cmd/wardenkms/...
 
   unit-test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,98 +1,117 @@
-# yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.jsonschema.json
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
     - cyclop
-    - dupword
-    - err113
-    - exhaustruct
-    - funlen
-    - gochecknoglobals
-    - gochecknoinits
-    - gocyclo
-    - godox
-    - gomoddirectives
-    - ireturn
-    - mnd
-    - musttag
-    - nonamedreturns
-    - paralleltest
-    - protogetter # to be enabled once we start moving towards Opaque API (https://go.dev/blog/protobuf-opaque)
-    - recvcheck
-    - tagalign
-    - tenv
-    - testpackage
-    - varnamelen
-    - wrapcheck
-    
-    # the followings are linters that should be enabled but the codebase
-    # doesn't adhere to and we don't have enough time to fix them all at once
     - depguard
     - dupl
+    - dupword
+    - err113
     - errname
     - errorlint
     - exhaustive
+    - exhaustruct
     - forcetypeassert
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
     - gocognit
     - gocritic
+    - gocyclo
+    - godox
+    - gomoddirectives
     - gosec
     - govet
     - inamedparam
+    - ireturn
     - lll
     - maintidx
+    - mnd
+    - musttag
     - nestif
     - nilerr
     - nilnil
     - nolintlint
+    - nonamedreturns
+    - paralleltest
     - prealloc
     - predeclared
     - promlinter
+    - protogetter
+    - recvcheck
     - revive
-    - stylecheck
+    - tagalign
     - tagliatelle
     - testifylint
+    - testpackage
     - thelper
     - unconvert
     - unparam
+    - varnamelen
+    - wrapcheck
     - wsl
     - zerologlint
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: "math/rand$"
-            desc: use math/rand/v2
-          - pkg: "github.com/sirupsen/logrus"
-            desc: not allowed
-          - pkg: "github.com/pkg/errors"
-            desc: Should be replaced by standard lib errors package
-  exhaustive:
-    check-generated: false
-    default-signifies-exhaustive: true
-  gci:
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/warden-protocol) # Custom section: groups all imports with the specified Prefix.
-      - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
-    custom-order: true
-  nlreturn:
-    block-size: 10
-  revive:
-    rules:
-      - name: unused-parameter
-        disabled: true
-      - name: var-naming
-        severity: warning
-        disabled: false
-        exclude: [""]
-        arguments:
-          - ["ID", "setId"] # AllowList
-          - ["VM"] # DenyList
-  tagliatelle:
-    case:
+  settings:
+    depguard:
       rules:
-        json: snake
-        yaml: snake
+        main:
+          deny:
+            - pkg: math/rand$
+              desc: use math/rand/v2
+            - pkg: github.com/sirupsen/logrus
+              desc: not allowed
+            - pkg: github.com/pkg/errors
+              desc: Should be replaced by standard lib errors package
+    exhaustive:
+      default-signifies-exhaustive: true
+    nlreturn:
+      block-size: 10
+    revive:
+      rules:
+        - name: unused-parameter
+          disabled: true
+        - name: var-naming
+          arguments:
+            - - ID
+              - setId
+            - - VM
+          severity: warning
+          disabled: false
+          exclude:
+            - ""
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+          yaml: snake
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/warden-protocol)
+        - localmodule
+      custom-order: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/shield_repl/main.go
+++ b/cmd/shield_repl/main.go
@@ -15,7 +15,7 @@ func main() {
 	env := object.NewEnvironment()
 
 	for {
-		fmt.Print("> ")
+		fmt.Print("> ") //nolint:forbidigo
 		sn := scanner.Scan()
 		if !sn {
 			return
@@ -27,7 +27,6 @@ func main() {
 		}
 
 		exp, err := shield.Parse(line)
-
 		if err != nil {
 			io.WriteString(os.Stderr, err.Error()) //nolint:all
 			continue

--- a/go-client/tx_raw_client.go
+++ b/go-client/tx_raw_client.go
@@ -8,7 +8,6 @@ import (
 
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/cosmos/cosmos-sdk/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
@@ -20,14 +19,14 @@ import (
 
 var (
 	DefaultGasLimit = uint64(300000000000000000)
-	DefaultFees     = types.NewCoins(types.NewCoin("award", math.NewInt(1000000000000000)))
+	DefaultFees     = sdk.NewCoins(sdk.NewCoin("award", math.NewInt(1000000000000000)))
 
 	queryTimeout = 250 * time.Millisecond
 	txConfig     = app.NewTxConfig()
 )
 
 type AccountFetcher interface {
-	Account(ctx context.Context, addr string) (types.AccountI, error)
+	Account(ctx context.Context, addr string) (sdk.AccountI, error)
 }
 
 var _ AccountFetcher = (*QueryClient)(nil)
@@ -70,7 +69,7 @@ type Msger interface {
 
 // Build a transaction with the given messages and sign it.
 // Sequence and account numbers will be fetched automatically from the chain.
-func (c *RawTxClient) BuildTx(ctx context.Context, gasLimit uint64, fees types.Coins, msgers ...Msger) ([]byte, error) {
+func (c *RawTxClient) BuildTx(ctx context.Context, gasLimit uint64, fees sdk.Coins, msgers ...Msger) ([]byte, error) {
 	account, err := c.accountFetcher.Account(ctx, c.Identity.Address.String())
 	if err != nil {
 		return nil, fmt.Errorf("fetch account: %w", err)

--- a/precompiles/act/events.go
+++ b/precompiles/act/events.go
@@ -39,7 +39,7 @@ func (p *Precompile) GetCreateTemplateEvent(ctx sdk.Context, writerAddress *ethc
 	}
 
 	topics := make([]ethcmn.Hash, 2)
-	event := p.ABI.Events[EventCreateTemplate]
+	event := p.Events[EventCreateTemplate]
 	// The first topic is always the signature of the event.
 	topics[0] = event.ID
 
@@ -85,7 +85,7 @@ func (p *Precompile) GetUpdateTemplateEvent(ctx sdk.Context, writerAddress *ethc
 	}
 
 	topics := make([]ethcmn.Hash, 2)
-	event := p.ABI.Events[EventUpdateTemplate]
+	event := p.Events[EventUpdateTemplate]
 	// The first topic is always the signature of the event.
 	topics[0] = event.ID
 
@@ -131,7 +131,7 @@ func (p *Precompile) GetCreateActionEvent(ctx sdk.Context, writerAddress *ethcmn
 	}
 
 	topics := make([]ethcmn.Hash, 2)
-	event := p.ABI.Events[EventCreateAction]
+	event := p.Events[EventCreateAction]
 	// The first topic is always the signature of the event.
 	topics[0] = event.ID
 
@@ -177,7 +177,7 @@ func (p *Precompile) GetActionVotedEvent(ctx sdk.Context, writerAddress *ethcmn.
 	}
 
 	topics := make([]ethcmn.Hash, 2)
-	event := p.ABI.Events[EventActionVoted]
+	event := p.Events[EventActionVoted]
 	// The first topic is always the signature of the event.
 	topics[0] = event.ID
 
@@ -224,7 +224,7 @@ func (p *Precompile) GetActionStateChangeEvent(ctx sdk.Context, writerAddress *e
 	}
 
 	topics := make([]ethcmn.Hash, 2)
-	event := p.ABI.Events[EventActionStateChange]
+	event := p.Events[EventActionStateChange]
 	// The first topic is always the signature of the event.
 	topics[0] = event.ID
 

--- a/precompiles/act/tx.go
+++ b/precompiles/act/tx.go
@@ -10,7 +10,6 @@ import (
 
 	precommon "github.com/warden-protocol/wardenprotocol/precompiles/common"
 	actmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/act/keeper"
-	"github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	acttypes "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 )
 
@@ -314,11 +313,11 @@ func newMsgVoteForAction(args []interface{}, origin common.Address) (*acttypes.M
 // nil. If the vote fails, this function returns the error.
 func (p Precompile) tryVoteAsSender(
 	ctx sdk.Context,
-	msgServer v1beta1.MsgServer,
+	msgServer acttypes.MsgServer,
 	actionId uint64,
 	caller common.Address,
 ) error {
-	actionResponse, err := p.queryServer.ActionById(ctx, &v1beta1.QueryActionByIdRequest{
+	actionResponse, err := p.queryServer.ActionById(ctx, &acttypes.QueryActionByIdRequest{
 		Id: actionId,
 	})
 	if err != nil {
@@ -327,16 +326,16 @@ func (p Precompile) tryVoteAsSender(
 
 	action := actionResponse.Action
 
-	if action.GetStatus() != v1beta1.ActionStatus_ACTION_STATUS_PENDING {
+	if action.GetStatus() != acttypes.ActionStatus_ACTION_STATUS_PENDING {
 		return nil
 	}
 
 	participant := precommon.Bech32StrFromAddress(caller)
 
-	_, err = msgServer.VoteForAction(ctx, &v1beta1.MsgVoteForAction{
+	_, err = msgServer.VoteForAction(ctx, &acttypes.MsgVoteForAction{
 		Participant: participant,
 		ActionId:    action.GetId(),
-		VoteType:    v1beta1.ActionVoteType_VOTE_TYPE_APPROVED,
+		VoteType:    acttypes.ActionVoteType_VOTE_TYPE_APPROVED,
 	})
 	if err != nil {
 		return err

--- a/precompiles/async/events.go
+++ b/precompiles/async/events.go
@@ -19,7 +19,7 @@ const (
 func (p *Precompile) GetCreateFutureEvent(ctx sdk.Context, writerAddress *ethcmn.Address, sdkEvent sdk.Event) (*ethtypes.Log, error) {
 	var err error
 
-	event := p.ABI.Events[EventCreateFuture]
+	event := p.Events[EventCreateFuture]
 
 	topics := make([]ethcmn.Hash, 3)
 	topics[0] = event.ID

--- a/precompiles/warden/events.go
+++ b/precompiles/warden/events.go
@@ -53,7 +53,7 @@ const (
 // GetAddKeychainAdminEvent maps EventAddKeychainAdmin to eth AddKeychainAdmin event and write to eth log.
 func (p Precompile) GetAddKeychainAdminEvent(ctx sdk.Context, adminAddress *common.Address, eventAddKeychainAdmin sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
-	event := p.ABI.Events[EventTypeAddKeychainAdmin]
+	event := p.Events[EventTypeAddKeychainAdmin]
 
 	if adminAddress == nil {
 		return nil, errors.New("adminAddress is nil")
@@ -96,7 +96,7 @@ func (p Precompile) GetAddKeychainAdminEvent(ctx sdk.Context, adminAddress *comm
 // GetAddKeychainWriterEvent maps EventAddKeychainWriter to eth AddKeychainWriter event and write to eth log.
 func (p Precompile) GetAddKeychainWriterEvent(ctx sdk.Context, writerAddress *common.Address, eventAddKeychainWriter sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
-	event := p.ABI.Events[EventTypeAddKeychainWriter]
+	event := p.Events[EventTypeAddKeychainWriter]
 
 	if writerAddress == nil {
 		return nil, errors.New("writerAddress is nil")
@@ -139,7 +139,7 @@ func (p Precompile) GetAddKeychainWriterEvent(ctx sdk.Context, writerAddress *co
 // GetNewKeyEvent maps EventNewKey to eth NewKey event and write to eth log.
 func (p Precompile) GetNewKeyEvent(ctx sdk.Context, _ *common.Address, eventNewKey sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
-	event := p.ABI.Events[EventTypeNewKey]
+	event := p.Events[EventTypeNewKey]
 
 	topics := make([]common.Hash, 2)
 	// The first topic is always the signature of the event.
@@ -179,7 +179,7 @@ func (p Precompile) GetNewKeyEvent(ctx sdk.Context, _ *common.Address, eventNewK
 // GetRejectKeyRequestEvent maps EventRejectKeyRequest to eth RejectKeyRequest event and write to eth log.
 func (p Precompile) GetRejectKeyRequestEvent(ctx sdk.Context, _ *common.Address, eventRejectKeyRequest sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
-	event := p.ABI.Events[EventRejectKeyRequest]
+	event := p.Events[EventRejectKeyRequest]
 
 	topics := make([]common.Hash, 2)
 	// The first topic is always the signature of the event.
@@ -209,7 +209,7 @@ func (p Precompile) GetRejectKeyRequestEvent(ctx sdk.Context, _ *common.Address,
 // GetFulfilSignRequestEvent maps EventFulfilSignRequest to eth FulfilSignRequest event and write to eth log.
 func (p Precompile) GetFulfilSignRequestEvent(ctx sdk.Context, _ *common.Address, eventFulfilSignRequest sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
-	event := p.ABI.Events[EventFulfilSignRequest]
+	event := p.Events[EventFulfilSignRequest]
 
 	topics := make([]common.Hash, 2)
 	// The first topic is always the signature of the event.
@@ -239,7 +239,7 @@ func (p Precompile) GetFulfilSignRequestEvent(ctx sdk.Context, _ *common.Address
 // GetRejectSignRequestEvent maps EventRejectSignRequest to eth RejectSignRequest event and write to eth log.
 func (p Precompile) GetRejectSignRequestEvent(ctx sdk.Context, _ *common.Address, eventRejectSignRequest sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
-	event := p.ABI.Events[EventRejectSignRequest]
+	event := p.Events[EventRejectSignRequest]
 
 	topics := make([]common.Hash, 2)
 	// The first topic is always the signature of the event.
@@ -270,7 +270,7 @@ func (p Precompile) GetRejectSignRequestEvent(ctx sdk.Context, _ *common.Address
 func (p Precompile) GetNewKeychainEvent(ctx sdk.Context, creator *common.Address, eventNewKeychain sdk.Event) (*ethtypes.Log, error) {
 	var err error
 	// Prepare the event topics
-	event := p.ABI.Events[EventNewKeychain]
+	event := p.Events[EventNewKeychain]
 
 	if creator == nil {
 		return nil, errors.New("creator is nil")
@@ -308,7 +308,7 @@ func (p Precompile) GetNewKeychainEvent(ctx sdk.Context, creator *common.Address
 func (p Precompile) GetNewSpaceEvent(ctx sdk.Context, creator *common.Address, eventNewSpace sdk.Event) (*ethtypes.Log, error) {
 	var err error
 	// Prepare the event topics
-	event := p.ABI.Events[EventNewSpace]
+	event := p.Events[EventNewSpace]
 
 	if creator == nil {
 		return nil, errors.New("creator is nil")
@@ -351,7 +351,7 @@ func (p Precompile) GetNewSpaceEvent(ctx sdk.Context, creator *common.Address, e
 func (p Precompile) GetRemoveKeychainAdminEvent(ctx sdk.Context, admin *common.Address, eventRemoveKeychainAdmin sdk.Event) (*ethtypes.Log, error) {
 	var err error
 	// Prepare the event topics
-	event := p.ABI.Events[EventRemoveKeychainAdmin]
+	event := p.Events[EventRemoveKeychainAdmin]
 
 	if admin == nil {
 		return nil, errors.New("admin is nil")
@@ -394,7 +394,7 @@ func (p Precompile) GetRemoveKeychainAdminEvent(ctx sdk.Context, admin *common.A
 // GetUpdateKeychainEvent maps EventUpdateKeychain to eth UpdateKeychain event and write to eth log.
 func (p Precompile) GetUpdateKeychainEvent(ctx sdk.Context, _ *common.Address, eventUpdateKeychain sdk.Event) (*ethtypes.Log, error) {
 	// Prepare the event topics
-	event := p.ABI.Events[EventUpdateKeychain]
+	event := p.Events[EventUpdateKeychain]
 
 	topics := make([]common.Hash, 2)
 	// The first topic is always the signature of the event.
@@ -442,7 +442,7 @@ func (p Precompile) GetUpdateKeychainEvent(ctx sdk.Context, _ *common.Address, e
 
 // GetAddSpaceOwnerEvent maps EventAddSpaceOwner to eth AddSpaceOwner event and write to eth log.
 func (p Precompile) GetAddSpaceOwnerEvent(ctx sdk.Context, _ *common.Address, addSpaceOwnerEvent sdk.Event) (*ethtypes.Log, error) {
-	event := p.ABI.Events[EventAddSpaceOwner]
+	event := p.Events[EventAddSpaceOwner]
 
 	topics := make([]common.Hash, 2)
 	topics[0] = event.ID
@@ -478,7 +478,7 @@ func (p Precompile) GetAddSpaceOwnerEvent(ctx sdk.Context, _ *common.Address, ad
 
 // GetRemoveSpaceOwnerEvent maps EventRemoveSpaceOwner to eth RemoveSpaceOwner event and write to eth log.
 func (p Precompile) GetRemoveSpaceOwnerEvent(ctx sdk.Context, _ *common.Address, removeSpaceOwnerEvent sdk.Event) (*ethtypes.Log, error) {
-	event := p.ABI.Events[EventRemoveSpaceOwner]
+	event := p.Events[EventRemoveSpaceOwner]
 
 	topics := make([]common.Hash, 2)
 	topics[0] = event.ID
@@ -514,7 +514,7 @@ func (p Precompile) GetRemoveSpaceOwnerEvent(ctx sdk.Context, _ *common.Address,
 
 // GetNewKeyRequestEvent maps EventNewKeyRequest to eth NewKeyRequest event and write to eth log.
 func (p Precompile) GetNewKeyRequestEvent(ctx sdk.Context, _ *common.Address, newKeyRequestEvent sdk.Event) (*ethtypes.Log, error) {
-	event := p.ABI.Events[EventNewKeyRequest]
+	event := p.Events[EventNewKeyRequest]
 
 	topics := make([]common.Hash, 2)
 	topics[0] = event.ID
@@ -555,7 +555,7 @@ func (p Precompile) GetNewKeyRequestEvent(ctx sdk.Context, _ *common.Address, ne
 
 // GetNewSignRequestEvent maps EventNewSignRequest to eth NewSignRequest event and write to eth log.
 func (p Precompile) GetNewSignRequestEvent(ctx sdk.Context, _ *common.Address, newSignRequestEvent sdk.Event) (*ethtypes.Log, error) {
-	event := p.ABI.Events[EventNewSignRequest]
+	event := p.Events[EventNewSignRequest]
 
 	topics := make([]common.Hash, 2)
 	topics[0] = event.ID
@@ -592,7 +592,7 @@ func (p Precompile) GetNewSignRequestEvent(ctx sdk.Context, _ *common.Address, n
 
 // GetUpdateKeyEvent maps EventUpdateKey to eth UpdateKey event and write to eth log.
 func (p Precompile) GetUpdateKeyEvent(ctx sdk.Context, _ *common.Address, updateKeyEvent sdk.Event) (*ethtypes.Log, error) {
-	event := p.ABI.Events[EventUpdateKey]
+	event := p.Events[EventUpdateKey]
 
 	topics := make([]common.Hash, 2)
 	topics[0] = event.ID
@@ -627,7 +627,7 @@ func (p Precompile) GetUpdateKeyEvent(ctx sdk.Context, _ *common.Address, update
 
 // GetUpdateSpaceEvent maps EventUpdateSpace to eth UpdateSpace event and write to eth log.
 func (p Precompile) GetUpdateSpaceEvent(ctx sdk.Context, _ *common.Address, updateSpaceEvent sdk.Event) (*ethtypes.Log, error) {
-	event := p.ABI.Events[EventUpdateSpace]
+	event := p.Events[EventUpdateSpace]
 
 	topics := make([]common.Hash, 2)
 	topics[0] = event.ID

--- a/precompiles/warden/query_types.go
+++ b/precompiles/warden/query_types.go
@@ -363,13 +363,14 @@ func (o *SignRequest) mapSignRequest(signRequest *types.SignRequest) (*SignReque
 	o.Status = uint8(signRequest.Status)
 
 	result := signRequest.Result
-	if signRequest.Status == types.SignRequestStatus_SIGN_REQUEST_STATUS_FULFILLED {
+	switch signRequest.Status {
+	case types.SignRequestStatus_SIGN_REQUEST_STATUS_FULFILLED:
 		if signedData, ok := result.(*types.SignRequest_SignedData); ok {
 			o.Result = signedData.SignedData
 		} else {
 			return nil, errors.New("unexpected result type for fulfilled sign request")
 		}
-	} else if signRequest.Status == types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED {
+	case types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED:
 		if rejectReason, ok := result.(*types.SignRequest_RejectReason); ok {
 			o.Result = []byte(rejectReason.RejectReason)
 		} else {

--- a/precompiles/warden/warden.go
+++ b/precompiles/warden/warden.go
@@ -16,7 +16,6 @@ import (
 	actmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/act/keeper"
 	acttypes "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
 	wardenmodulekeeper "github.com/warden-protocol/wardenprotocol/warden/x/warden/keeper"
-	"github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -116,13 +115,13 @@ func (p *Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz 
 	case AddKeychainWriterMethod:
 		bz, err = p.AddKeychainWriterMethod(ctx, evm.Origin, stateDB, method, args)
 	case FulfilKeyRequestMethod:
-		bz, err = p.FulfilKeyRequestMethod(ctx, evm.Origin, v1beta3.KeyRequestStatus_KEY_REQUEST_STATUS_FULFILLED, stateDB, method, args)
+		bz, err = p.FulfilKeyRequestMethod(ctx, evm.Origin, types.KeyRequestStatus_KEY_REQUEST_STATUS_FULFILLED, stateDB, method, args)
 	case RejectKeyRequestMethod:
-		bz, err = p.FulfilKeyRequestMethod(ctx, evm.Origin, v1beta3.KeyRequestStatus_KEY_REQUEST_STATUS_REJECTED, stateDB, method, args)
+		bz, err = p.FulfilKeyRequestMethod(ctx, evm.Origin, types.KeyRequestStatus_KEY_REQUEST_STATUS_REJECTED, stateDB, method, args)
 	case FulfilSignRequestMethod:
-		bz, err = p.FulfilSignRequestMethod(ctx, evm.Origin, v1beta3.SignRequestStatus_SIGN_REQUEST_STATUS_FULFILLED, stateDB, method, args)
+		bz, err = p.FulfilSignRequestMethod(ctx, evm.Origin, types.SignRequestStatus_SIGN_REQUEST_STATUS_FULFILLED, stateDB, method, args)
 	case RejectSignRequestMethod:
-		bz, err = p.FulfilSignRequestMethod(ctx, evm.Origin, v1beta3.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED, stateDB, method, args)
+		bz, err = p.FulfilSignRequestMethod(ctx, evm.Origin, types.SignRequestStatus_SIGN_REQUEST_STATUS_REJECTED, stateDB, method, args)
 	case NewKeychainMethod:
 		bz, err = p.NewKeychainMethod(ctx, evm.Origin, stateDB, method, args)
 	case NewSpaceMethod:

--- a/tests/cases/add_remove_owner.go
+++ b/tests/cases/add_remove_owner.go
@@ -1,10 +1,10 @@
 package cases
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/tests/framework"
 	"github.com/warden-protocol/wardenprotocol/tests/framework/checks"
 	"github.com/warden-protocol/wardenprotocol/tests/framework/exec"
@@ -19,14 +19,14 @@ type Test_AddRemoveOwner struct {
 	w *exec.WardenNode
 }
 
-func (c *Test_AddRemoveOwner) Setup(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_AddRemoveOwner) Setup(t *testing.T, build framework.BuildResult) {
 	c.w = exec.NewWardenNode(t, build.Wardend)
 
-	go c.w.Start(t, ctx, "./testdata/snapshot-base")
+	go c.w.Start(t, "./testdata/snapshot-base")
 	c.w.WaitRunning(t)
 }
 
-func (c *Test_AddRemoveOwner) Run(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_AddRemoveOwner) Run(t *testing.T, build framework.BuildResult) {
 	alice := exec.NewWardend(c.w, "alice")
 	res := alice.Tx(t, "warden new-space")
 	checks.SuccessTx(t, res)
@@ -35,7 +35,7 @@ func (c *Test_AddRemoveOwner) Run(t *testing.T, ctx context.Context, build frame
 	checks.SuccessTx(t, resAddOwner)
 
 	client := c.w.GRPCClient(t)
-	spacesByOwnerRes, err := client.Warden.SpacesByOwner(ctx, &types.QuerySpacesByOwnerRequest{
+	spacesByOwnerRes, err := client.Warden.SpacesByOwner(t.Context(), &types.QuerySpacesByOwnerRequest{
 		Owner: "warden10zm6farjqffkadjx8v0znx67x6a26f36p020td",
 	})
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func (c *Test_AddRemoveOwner) Run(t *testing.T, ctx context.Context, build frame
 	resRemoveOwner := alice.Tx(t, "warden new-action remove-space-owner --space-id 1 --owner warden10zm6farjqffkadjx8v0znx67x6a26f36p020td --nonce 1")
 	checks.SuccessTx(t, resRemoveOwner)
 
-	spacesByOwnerRes2, err := client.Warden.SpacesByOwner(ctx, &types.QuerySpacesByOwnerRequest{
+	spacesByOwnerRes2, err := client.Warden.SpacesByOwner(t.Context(), &types.QuerySpacesByOwnerRequest{
 		Owner: "warden10zm6farjqffkadjx8v0znx67x6a26f36p020td",
 	})
 	require.NoError(t, err)

--- a/tests/cases/approve_any_3_action.go
+++ b/tests/cases/approve_any_3_action.go
@@ -1,16 +1,15 @@
 package cases
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 
 	"github.com/warden-protocol/wardenprotocol/tests/framework"
 	"github.com/warden-protocol/wardenprotocol/tests/framework/checks"
 	"github.com/warden-protocol/wardenprotocol/tests/framework/exec"
+	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
 func init() {
@@ -21,14 +20,14 @@ type Test_ApproveAny3Action struct {
 	w *exec.WardenNode
 }
 
-func (c *Test_ApproveAny3Action) Setup(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_ApproveAny3Action) Setup(t *testing.T, build framework.BuildResult) {
 	c.w = exec.NewWardenNode(t, build.Wardend)
 
-	go c.w.Start(t, ctx, "./testdata/snapshot-many-users")
+	go c.w.Start(t, "./testdata/snapshot-many-users")
 	c.w.WaitRunning(t)
 }
 
-func (c *Test_ApproveAny3Action) Run(t *testing.T, ctx context.Context, _ framework.BuildResult) {
+func (c *Test_ApproveAny3Action) Run(t *testing.T, _ framework.BuildResult) {
 	client := TestGRPCClient(*c.w.GRPCClient(t))
 
 	alice := exec.NewWardend(c.w, "alice")
@@ -36,28 +35,29 @@ func (c *Test_ApproveAny3Action) Run(t *testing.T, ctx context.Context, _ framew
 	charlie := exec.NewWardend(c.w, "charlie")
 	dave := exec.NewWardend(c.w, "dave")
 
+	//nolint:goconst
 	addNewOwnerCommandTemplate := "warden new-action add-space-owner --space-id %d --new-owner %s --nonce %d"
 
-	resAddOwner := bob.Tx(t, fmt.Sprintf(addNewOwnerCommandTemplate, 1, bob.Address(t), 0)) //1
+	resAddOwner := bob.Tx(t, fmt.Sprintf(addNewOwnerCommandTemplate, 1, bob.Address(t), 0)) // 1
 	checks.SuccessTx(t, resAddOwner)
-	client.EnsureSpaceAmount(t, ctx, bob.Address(t), 0)
+	client.EnsureSpaceAmount(t, bob.Address(t), 0)
 
 	resApproveBob := alice.Tx(t, "act vote-for-action --vote-type vote-type-approved --action-id 1")
 	checks.SuccessTx(t, resApproveBob)
-	client.EnsureSpaceAmount(t, ctx, bob.Address(t), 1)
+	client.EnsureSpaceAmount(t, bob.Address(t), 1)
 
-	resAddOwner2 := alice.Tx(t, fmt.Sprintf(addNewOwnerCommandTemplate, 1, charlie.Address(t), 1)) //2
+	resAddOwner2 := alice.Tx(t, fmt.Sprintf(addNewOwnerCommandTemplate, 1, charlie.Address(t), 1)) // 2
 	checks.SuccessTx(t, resAddOwner2)
-	client.EnsureSpaceAmount(t, ctx, charlie.Address(t), 1)
+	client.EnsureSpaceAmount(t, charlie.Address(t), 1)
 
 	newApproveTemplateDefinition := "\"any(3, warden.space.owners)\""
 	resNewTemplate := alice.Tx(t, "act new-template --name approve_requires_three --definition "+newApproveTemplateDefinition)
 	checks.SuccessTx(t, resNewTemplate)
 
-	resUpdateSpaceAdminTemplateByAlice := alice.Tx(t, "warden new-action update-space --space-id 1 --approve-admin-template-id 1 --nonce 2") //3
+	resUpdateSpaceAdminTemplateByAlice := alice.Tx(t, "warden new-action update-space --space-id 1 --approve-admin-template-id 1 --nonce 2") // 3
 	checks.SuccessTx(t, resUpdateSpaceAdminTemplateByAlice)
 
-	spaceAfterValidApprove, err := client.Warden.SpaceById(ctx, &types.QuerySpaceByIdRequest{
+	spaceAfterValidApprove, err := client.Warden.SpaceById(t.Context(), &types.QuerySpaceByIdRequest{
 		Id: 1,
 	})
 	require.NoError(t, err)
@@ -65,16 +65,15 @@ func (c *Test_ApproveAny3Action) Run(t *testing.T, ctx context.Context, _ framew
 
 	addNewOwnerCommandTemplate = "warden new-action add-space-owner --space-id %d --new-owner %s --nonce %d --expected-approve-expression %s"
 
-	resAliceAddOwnerDave := alice.Tx(t, fmt.Sprintf(addNewOwnerCommandTemplate, 1, dave.Address(t), 3, newApproveTemplateDefinition)) //4
+	resAliceAddOwnerDave := alice.Tx(t, fmt.Sprintf(addNewOwnerCommandTemplate, 1, dave.Address(t), 3, newApproveTemplateDefinition)) // 4
 	checks.SuccessTx(t, resAliceAddOwnerDave)
-	client.EnsureSpaceAmount(t, ctx, dave.Address(t), 0)
+	client.EnsureSpaceAmount(t, dave.Address(t), 0)
 
 	resApproveDaveByBob := bob.Tx(t, "act vote-for-action --vote-type vote-type-approved --action-id 4")
 	checks.SuccessTx(t, resApproveDaveByBob)
-	client.EnsureSpaceAmount(t, ctx, dave.Address(t), 0)
+	client.EnsureSpaceAmount(t, dave.Address(t), 0)
 
 	resApproveDaveByCharlie := charlie.Tx(t, "act vote-for-action --vote-type vote-type-approved --action-id 4")
 	checks.SuccessTx(t, resApproveDaveByCharlie)
-	client.EnsureSpaceAmount(t, ctx, dave.Address(t), 1)
-
+	client.EnsureSpaceAmount(t, dave.Address(t), 1)
 }

--- a/tests/cases/async_precompile.go
+++ b/tests/cases/async_precompile.go
@@ -1,7 +1,6 @@
 package cases
 
 import (
-	"context"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -22,15 +21,15 @@ type Test_AsyncPrecompile struct {
 	w *exec.WardenNode
 }
 
-func (c *Test_AsyncPrecompile) Setup(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_AsyncPrecompile) Setup(t *testing.T, build framework.BuildResult) {
 	c.w = exec.NewWardenNode(t, build.Wardend)
 
-	go c.w.Start(t, ctx, "./testdata/snapshot-many-users")
+	go c.w.Start(t, "./testdata/snapshot-many-users")
 	c.w.WaitRunning(t)
 }
 
-// TODO(backsapc): Implement positive test cases with async sidecar integration
-func (c *Test_AsyncPrecompile) Run(t *testing.T, ctx context.Context, _ framework.BuildResult) {
+// TODO(backsapc): Implement positive test cases with async sidecar integration.
+func (c *Test_AsyncPrecompile) Run(t *testing.T, _ framework.BuildResult) {
 	alice := exec.NewWardend(c.w, "alice")
 
 	evmClient := c.w.EthClient(t)
@@ -41,10 +40,10 @@ func (c *Test_AsyncPrecompile) Run(t *testing.T, ctx context.Context, _ framewor
 	require.NoError(t, err)
 	require.Len(t, futuresQuery.Futures, 0)
 
-	addFutureTx, err := iAsyncClient.AddFuture(alice.TransactOps(t, ctx, evmClient), "echo", []byte("USDT"), common.HexToAddress("0x0000000000000000000000000000000000000000"))
+	addFutureTx, err := iAsyncClient.AddFuture(alice.TransactOps(t, evmClient), "echo", []byte("USDT"), common.HexToAddress("0x0000000000000000000000000000000000000000"))
 	require.NoError(t, err)
 
-	addFutureReceipt, err := bind.WaitMined(ctx, evmClient, addFutureTx)
+	addFutureReceipt, err := bind.WaitMined(t.Context(), evmClient, addFutureTx)
 	require.NoError(t, err)
 
 	createFutureEvents, err := checks.GetParsedEventsOnly(addFutureReceipt, iAsyncClient.ParseCreateFuture)

--- a/tests/cases/cases.go
+++ b/tests/cases/cases.go
@@ -1,12 +1,12 @@
 package cases
 
 import (
-	"context"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/tests/framework"
 	"github.com/warden-protocol/wardenprotocol/tests/framework/exec"
 	"github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
@@ -14,8 +14,8 @@ import (
 )
 
 type TestCase interface {
-	Setup(t *testing.T, ctx context.Context, build framework.BuildResult)
-	Run(t *testing.T, ctx context.Context, build framework.BuildResult)
+	Setup(t *testing.T, build framework.BuildResult)
+	Run(t *testing.T, build framework.BuildResult)
 }
 
 var list []TestCase
@@ -28,22 +28,22 @@ func List() []TestCase { return list }
 
 type TestGRPCClient exec.GRPCClient
 
-func (client *TestGRPCClient) EnsureSpaceAmount(t *testing.T, ctx context.Context, ownerKey string, amount int) {
-	resSpacesByDaveAfterBobApprove, err := client.Warden.SpacesByOwner(ctx, &types.QuerySpacesByOwnerRequest{
+func (client *TestGRPCClient) EnsureSpaceAmount(t *testing.T, ownerKey string, amount int) {
+	resSpacesByDaveAfterBobApprove, err := client.Warden.SpacesByOwner(t.Context(), &types.QuerySpacesByOwnerRequest{
 		Owner: ownerKey,
 	})
 	require.NoError(t, err)
 	require.Equal(t, amount, len(resSpacesByDaveAfterBobApprove.Spaces))
 }
 
-func (client *TestGRPCClient) EnsureActionStatus(t *testing.T, ctx context.Context, actionId uint64, expectedStatus v1beta1.ActionStatus) {
-	res, err := client.Act.ActionById(ctx, &v1beta1.QueryActionByIdRequest{Id: actionId})
+func (client *TestGRPCClient) EnsureActionStatus(t *testing.T, actionId uint64, expectedStatus v1beta1.ActionStatus) {
+	res, err := client.Act.ActionById(t.Context(), &v1beta1.QueryActionByIdRequest{Id: actionId})
 	require.NoError(t, err)
 	require.Equal(t, expectedStatus, res.Action.Status)
 }
 
-func (client *TestGRPCClient) EnsureBalanceAmount(t *testing.T, ctx context.Context, ownerKey string, balance sdk.Coin) {
-	balanceResponse, err := client.Bank.Balance(ctx, &banktypes.QueryBalanceRequest{
+func (client *TestGRPCClient) EnsureBalanceAmount(t *testing.T, ownerKey string, balance sdk.Coin) {
+	balanceResponse, err := client.Bank.Balance(t.Context(), &banktypes.QueryBalanceRequest{
 		Address: ownerKey,
 		Denom:   balance.Denom,
 	})
@@ -51,8 +51,8 @@ func (client *TestGRPCClient) EnsureBalanceAmount(t *testing.T, ctx context.Cont
 	require.True(t, balance.Equal(balanceResponse.Balance))
 }
 
-func (client *TestGRPCClient) GetBalanceAmount(t *testing.T, ctx context.Context, ownerKey string, denom string) sdk.Coin {
-	balanceResponse, err := client.Bank.Balance(ctx, &banktypes.QueryBalanceRequest{
+func (client *TestGRPCClient) GetBalanceAmount(t *testing.T, ownerKey string, denom string) sdk.Coin {
+	balanceResponse, err := client.Bank.Balance(t.Context(), &banktypes.QueryBalanceRequest{
 		Address: ownerKey,
 		Denom:   denom,
 	})

--- a/tests/cases/create_space.go
+++ b/tests/cases/create_space.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/tests/framework"
 	"github.com/warden-protocol/wardenprotocol/tests/framework/checks"
 	"github.com/warden-protocol/wardenprotocol/tests/framework/exec"
@@ -20,14 +21,14 @@ type Test_CreateSpace struct {
 	w *exec.WardenNode
 }
 
-func (c *Test_CreateSpace) Setup(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_CreateSpace) Setup(t *testing.T, build framework.BuildResult) {
 	c.w = exec.NewWardenNode(t, build.Wardend)
 
-	go c.w.Start(t, ctx, "./testdata/snapshot-base")
+	go c.w.Start(t, "./testdata/snapshot-base")
 	c.w.WaitRunning(t)
 }
 
-func (c *Test_CreateSpace) Run(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_CreateSpace) Run(t *testing.T, build framework.BuildResult) {
 	alice := exec.NewWardend(c.w, "alice")
 	res := alice.Tx(t, "warden new-space")
 	checks.SuccessTx(t, res)
@@ -35,7 +36,7 @@ func (c *Test_CreateSpace) Run(t *testing.T, ctx context.Context, build framewor
 	client := c.w.GRPCClient(t)
 
 	require.Eventually(t, func() bool {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 		defer cancel()
 
 		res, err := client.Warden.Spaces(ctx, &types.QuerySpacesRequest{})

--- a/tests/cases/keychain_writers.go
+++ b/tests/cases/keychain_writers.go
@@ -1,14 +1,13 @@
 package cases
 
 import (
-	"context"
 	"encoding/base64"
 	"testing"
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/tests/framework"
 	"github.com/warden-protocol/wardenprotocol/tests/framework/checks"
 	"github.com/warden-protocol/wardenprotocol/tests/framework/exec"
@@ -24,80 +23,80 @@ type Test_KeychainWriters struct {
 	w *exec.WardenNode
 }
 
-func (c *Test_KeychainWriters) Setup(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_KeychainWriters) Setup(t *testing.T, build framework.BuildResult) {
 	c.w = exec.NewWardenNode(t, build.Wardend)
 
-	go c.w.Start(t, ctx, "./testdata/snapshot-keychain")
+	go c.w.Start(t, "./testdata/snapshot-keychain")
 	c.w.WaitRunning(t)
 }
 
-func (c *Test_KeychainWriters) Run(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_KeychainWriters) Run(t *testing.T, build framework.BuildResult) {
 	bob := exec.NewWardend(c.w, "bob")
 	writer := exec.NewWardend(c.w, "writer")
 	client := TestGRPCClient(*c.w.GRPCClient(t))
 	wardenAddress := "warden130djg732wmskv3gwryl3shcdam8wmmn9p704s5"
-	balance := client.GetBalanceAmount(t, ctx, wardenAddress, "award")
+	balance := client.GetBalanceAmount(t, wardenAddress, "award")
 
 	t.Run("create key request", func(t *testing.T) {
 		// create a KeyRequest
 		newReqTx := bob.Tx(t, "warden new-action new-key-request --space-id 1 --keychain-id 1 --key-type 1 --max-keychain-fees \"1award\" --nonce 0")
 		checks.SuccessTx(t, newReqTx)
-		client.EnsureActionStatus(t, ctx, 1, v1beta1.ActionStatus_ACTION_STATUS_REVOKED)
-		client.EnsureBalanceAmount(t, ctx, wardenAddress, balance)
+		client.EnsureActionStatus(t, 1, v1beta1.ActionStatus_ACTION_STATUS_REVOKED)
+		client.EnsureBalanceAmount(t, wardenAddress, balance)
 
 		newReqTx = bob.Tx(t, "warden new-action new-key-request --space-id 1 --keychain-id 1 --key-type 1 --max-keychain-fees \"3award\" --nonce 0")
 		checks.SuccessTx(t, newReqTx)
-		client.EnsureActionStatus(t, ctx, 2, v1beta1.ActionStatus_ACTION_STATUS_COMPLETED)
-		client.EnsureBalanceAmount(t, ctx, wardenAddress, balance.Add(sdk.NewCoin("award", math.NewInt(2))))
+		client.EnsureActionStatus(t, 2, v1beta1.ActionStatus_ACTION_STATUS_COMPLETED)
+		client.EnsureBalanceAmount(t, wardenAddress, balance.Add(sdk.NewCoin("award", math.NewInt(2))))
 
 		// try to fulfill it from an address that's not one of the Keychain's writers
 		bobFulfilTx := bob.Tx(t, "warden fulfill-key-request 1 'A93VNAt/SYLw61VYTAhYO0pMJUqjnKKT2owP7HjGNRoK'")
 		checks.FailTx(t, bobFulfilTx)
-		client.EnsureBalanceAmount(t, ctx, wardenAddress, balance.Add(sdk.NewCoin("award", math.NewInt(2))))
+		client.EnsureBalanceAmount(t, wardenAddress, balance.Add(sdk.NewCoin("award", math.NewInt(2))))
 
 		// try to fulfill it from one of the Keychain's writers
 		writerFulfilTx := writer.Tx(t, "warden fulfill-key-request 1 'A93VNAt/SYLw61VYTAhYO0pMJUqjnKKT2owP7HjGNRoK'")
 		checks.SuccessTx(t, writerFulfilTx)
-		client.EnsureBalanceAmount(t, ctx, wardenAddress, balance)
+		client.EnsureBalanceAmount(t, wardenAddress, balance)
 
 		// check KeyRequest was updated and Key created
 		client := c.w.GRPCClient(t)
-		res, err := client.Warden.KeyRequestById(ctx, &v1beta3.QueryKeyRequestByIdRequest{Id: 1})
+		res, err := client.Warden.KeyRequestById(t.Context(), &v1beta3.QueryKeyRequestByIdRequest{Id: 1})
 		require.NoError(t, err)
 		require.Equal(t, v1beta3.KeyRequestStatus_KEY_REQUEST_STATUS_FULFILLED, res.KeyRequest.Status)
 
-		//SKIP: a bug in the go-protobuf pkg causes this query to panic - not sure why.
-		//keyRes, err := client.Warden.KeyById(ctx, &v1beta3.QueryKeyByIdRequest{Id: res.KeyRequest.Id})
-		//require.NoError(t, err)
-		//require.Equal(t, "A93VNAt/SYLw61VYTAhYO0pMJUqjnKKT2owP7HjGNRoK", base64.StdEncoding.EncodeToString(keyRes.Key.PublicKey))
+		// SKIP: a bug in the go-protobuf pkg causes this query to panic - not sure why.
+		// keyRes, err := client.Warden.KeyById(ctx, &v1beta3.QueryKeyByIdRequest{Id: res.KeyRequest.Id})
+		// require.NoError(t, err)
+		// require.Equal(t, "A93VNAt/SYLw61VYTAhYO0pMJUqjnKKT2owP7HjGNRoK", base64.StdEncoding.EncodeToString(keyRes.Key.PublicKey))
 	})
 
 	t.Run("create signature request", func(t *testing.T) {
 		// create a SignRequest with not enough fee
 		newReqTx := bob.Tx(t, "warden new-action new-sign-request --key-id 1 --input 'HoZ4Z+ZU7Zd08kUR5NcbtFZrmGKF18mSBJ29dg0qI44=' --max-keychain-fees \"1award\" --nonce 0")
 		checks.SuccessTx(t, newReqTx)
-		client.EnsureActionStatus(t, ctx, 3, v1beta1.ActionStatus_ACTION_STATUS_REVOKED)
-		client.EnsureBalanceAmount(t, ctx, wardenAddress, balance)
+		client.EnsureActionStatus(t, 3, v1beta1.ActionStatus_ACTION_STATUS_REVOKED)
+		client.EnsureBalanceAmount(t, wardenAddress, balance)
 
 		// create a SignRequest with enough fee
 		newReqTx = bob.Tx(t, "warden new-action new-sign-request --key-id 1 --input 'HoZ4Z+ZU7Zd08kUR5NcbtFZrmGKF18mSBJ29dg0qI44=' --max-keychain-fees \"3award\" --nonce 0")
 		checks.SuccessTx(t, newReqTx)
-		client.EnsureActionStatus(t, ctx, 4, v1beta1.ActionStatus_ACTION_STATUS_COMPLETED)
-		client.EnsureBalanceAmount(t, ctx, wardenAddress, balance.Add(sdk.NewCoin("award", math.NewInt(2))))
+		client.EnsureActionStatus(t, 4, v1beta1.ActionStatus_ACTION_STATUS_COMPLETED)
+		client.EnsureBalanceAmount(t, wardenAddress, balance.Add(sdk.NewCoin("award", math.NewInt(2))))
 
 		// try to fulfill it from an address that's not one of the Keychain's writers
 		bobFulfilTx := bob.Tx(t, "warden fulfill-sign-request 1 'LKu131U23Q5Ke7jJscb57zdSmuZD27a4VeZ+/hwf7ShOLo4ozUc36pvNT14+a1s09k1PbPihrFbK29J00Jh3tgA='")
 		checks.FailTx(t, bobFulfilTx)
-		client.EnsureBalanceAmount(t, ctx, wardenAddress, balance.Add(sdk.NewCoin("award", math.NewInt(2))))
+		client.EnsureBalanceAmount(t, wardenAddress, balance.Add(sdk.NewCoin("award", math.NewInt(2))))
 
 		// try to fulfill it from one of the Keychain's writers
 		writerFulfilTx := writer.Tx(t, "warden fulfill-sign-request 1 'LKu131U23Q5Ke7jJscb57zdSmuZD27a4VeZ+/hwf7ShOLo4ozUc36pvNT14+a1s09k1PbPihrFbK29J00Jh3tgA='")
 		checks.SuccessTx(t, writerFulfilTx)
-		client.EnsureBalanceAmount(t, ctx, wardenAddress, balance)
+		client.EnsureBalanceAmount(t, wardenAddress, balance)
 
 		// check SignRequest was updated and Signature created
 		client := c.w.GRPCClient(t)
-		res, err := client.Warden.SignRequestById(ctx, &v1beta3.QuerySignRequestByIdRequest{Id: 1})
+		res, err := client.Warden.SignRequestById(t.Context(), &v1beta3.QuerySignRequestByIdRequest{Id: 1})
 		require.NoError(t, err)
 		require.Equal(t, v1beta3.SignRequestStatus_SIGN_REQUEST_STATUS_FULFILLED, res.SignRequest.Status)
 		require.Equal(t, "LKu131U23Q5Ke7jJscb57zdSmuZD27a4VeZ+/hwf7ShOLo4ozUc36pvNT14+a1s09k1PbPihrFbK29J00Jh3tgA=", base64.StdEncoding.EncodeToString(res.SignRequest.Result.(*v1beta3.SignRequest_SignedData).SignedData))

--- a/tests/cases/owner_approve_action.go
+++ b/tests/cases/owner_approve_action.go
@@ -1,7 +1,6 @@
 package cases
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -21,14 +20,14 @@ type Test_OwnerApproveAction struct {
 	w *exec.WardenNode
 }
 
-func (c *Test_OwnerApproveAction) Setup(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_OwnerApproveAction) Setup(t *testing.T, build framework.BuildResult) {
 	c.w = exec.NewWardenNode(t, build.Wardend)
 
-	go c.w.Start(t, ctx, "./testdata/snapshot-many-users")
+	go c.w.Start(t, "./testdata/snapshot-many-users")
 	c.w.WaitRunning(t)
 }
 
-func (c *Test_OwnerApproveAction) Run(t *testing.T, ctx context.Context, _ framework.BuildResult) {
+func (c *Test_OwnerApproveAction) Run(t *testing.T, _ framework.BuildResult) {
 	client := TestGRPCClient(*c.w.GRPCClient(t))
 
 	alice := exec.NewWardend(c.w, "alice")
@@ -36,16 +35,18 @@ func (c *Test_OwnerApproveAction) Run(t *testing.T, ctx context.Context, _ frame
 	charlie := exec.NewWardend(c.w, "charlie")
 	dave := exec.NewWardend(c.w, "dave")
 
+	//nolint:goconst
 	addNewOwnerCommandTemplate := "warden new-action add-space-owner --space-id %d --new-owner %s --nonce %d"
 
 	resAddOwner := bob.Tx(t, fmt.Sprintf(addNewOwnerCommandTemplate, 1, bob.Address(t), 0))
 	checks.SuccessTx(t, resAddOwner)
-	client.EnsureSpaceAmount(t, ctx, bob.Address(t), 0)
+	client.EnsureSpaceAmount(t, bob.Address(t), 0)
 
 	resApproveBob := alice.Tx(t, "act vote-for-action --vote-type vote-type-approved --action-id 1")
 	checks.SuccessTx(t, resApproveBob)
-	client.EnsureSpaceAmount(t, ctx, bob.Address(t), 1)
+	client.EnsureSpaceAmount(t, bob.Address(t), 1)
 
+	//nolint:goconst
 	newApproveTemplateDefinition := "\"any(2, warden.space.owners)\""
 	resNewTemplate := alice.Tx(t, "act new-template --name approve_requires_two --definition "+newApproveTemplateDefinition)
 	checks.SuccessTx(t, resNewTemplate)
@@ -55,7 +56,7 @@ func (c *Test_OwnerApproveAction) Run(t *testing.T, ctx context.Context, _ frame
 	resUpdateSpaceAdminTemplateByCharlie := charlie.Tx(t, updateSpaceApproveAdminTemplateIdCommand)
 	checks.SuccessTx(t, resUpdateSpaceAdminTemplateByCharlie)
 
-	spaceAfterInvalidApprove, err := client.Warden.SpaceById(ctx, &types.QuerySpaceByIdRequest{
+	spaceAfterInvalidApprove, err := client.Warden.SpaceById(t.Context(), &types.QuerySpaceByIdRequest{
 		Id: 1,
 	})
 	require.NoError(t, err)
@@ -64,7 +65,7 @@ func (c *Test_OwnerApproveAction) Run(t *testing.T, ctx context.Context, _ frame
 	resUpdateSpaceAdminTemplateByAlice := alice.Tx(t, updateSpaceApproveAdminTemplateIdCommand)
 	checks.SuccessTx(t, resUpdateSpaceAdminTemplateByAlice)
 
-	spaceAfterValidApprove, err := client.Warden.SpaceById(ctx, &types.QuerySpaceByIdRequest{
+	spaceAfterValidApprove, err := client.Warden.SpaceById(t.Context(), &types.QuerySpaceByIdRequest{
 		Id: 1,
 	})
 	require.NoError(t, err)
@@ -74,17 +75,17 @@ func (c *Test_OwnerApproveAction) Run(t *testing.T, ctx context.Context, _ frame
 
 	resAliceAddOwnerCharlie := alice.Tx(t, fmt.Sprintf(addNewOwnerCommandTemplate, 1, charlie.Address(t), 2, newApproveTemplateDefinition))
 	checks.SuccessTx(t, resAliceAddOwnerCharlie)
-	client.EnsureSpaceAmount(t, ctx, charlie.Address(t), 0)
+	client.EnsureSpaceAmount(t, charlie.Address(t), 0)
 
 	resApproveCharlie := bob.Tx(t, "act vote-for-action --vote-type vote-type-approved --action-id 4")
 	checks.SuccessTx(t, resApproveCharlie)
-	client.EnsureSpaceAmount(t, ctx, charlie.Address(t), 1)
+	client.EnsureSpaceAmount(t, charlie.Address(t), 1)
 
 	resCharlieAddOwnerDave := charlie.Tx(t, fmt.Sprintf(addNewOwnerCommandTemplate, 1, dave.Address(t), 3, newApproveTemplateDefinition))
 	checks.SuccessTx(t, resCharlieAddOwnerDave)
-	client.EnsureSpaceAmount(t, ctx, dave.Address(t), 0)
+	client.EnsureSpaceAmount(t, dave.Address(t), 0)
 
 	resApproveDaveByBob := bob.Tx(t, "act vote-for-action --vote-type vote-type-approved --action-id 5")
 	checks.SuccessTx(t, resApproveDaveByBob)
-	client.EnsureSpaceAmount(t, ctx, dave.Address(t), 1)
+	client.EnsureSpaceAmount(t, dave.Address(t), 1)
 }

--- a/tests/cases/slinky_precompile.go
+++ b/tests/cases/slinky_precompile.go
@@ -1,7 +1,6 @@
 package cases
 
 import (
-	"context"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -20,10 +19,10 @@ type Test_SlinkyPrecompile struct {
 	w *exec.WardenNode
 }
 
-func (c *Test_SlinkyPrecompile) Setup(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_SlinkyPrecompile) Setup(t *testing.T, build framework.BuildResult) {
 	c.w = exec.NewWardenNode(t, build.Wardend)
 
-	go c.w.Start(t, ctx, "./testdata/snapshot-many-users")
+	go c.w.Start(t, "./testdata/snapshot-many-users")
 	c.w.WaitRunning(t)
 }
 
@@ -32,8 +31,8 @@ const (
 	testPairUSDTETH = "USDT/ETH"
 )
 
-// TODO(backsapc): Implement positive test cases with slinky sidecar integration
-func (c *Test_SlinkyPrecompile) Run(t *testing.T, ctx context.Context, _ framework.BuildResult) {
+// TODO(backsapc): Implement positive test cases with slinky sidecar integration.
+func (c *Test_SlinkyPrecompile) Run(t *testing.T, _ framework.BuildResult) {
 	alice := exec.NewWardend(c.w, "alice")
 
 	evmClient := c.w.EthClient(t)

--- a/tests/cases/warden_precompile.go
+++ b/tests/cases/warden_precompile.go
@@ -1,7 +1,6 @@
 package cases
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"math/big"
@@ -25,16 +24,16 @@ type Test_WardenPrecompile struct {
 	w *exec.WardenNode
 }
 
-func (c *Test_WardenPrecompile) Setup(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_WardenPrecompile) Setup(t *testing.T, build framework.BuildResult) {
 	c.w = exec.NewWardenNode(t, build.Wardend)
 
-	go c.w.Start(t, ctx, "./testdata/snapshot-many-users")
+	go c.w.Start(t, "./testdata/snapshot-many-users")
 	c.w.WaitRunning(t)
 
-	c.w.PrintLogsAtTheEnd(t, ctx, []string{"TEST_DEBUG"})
+	c.w.PrintLogsAtTheEnd(t, []string{"TEST_DEBUG"})
 }
 
-func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_WardenPrecompile) Run(t *testing.T, build framework.BuildResult) {
 	alice := exec.NewWardend(c.w, "alice")
 	bob := exec.NewWardend(c.w, "bob")
 	dave := exec.NewWardend(c.w, "dave")
@@ -57,10 +56,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 		keychainUrl := "test.url"
 		keychainKeybaseId := "1234567890ABCDEF"
 
-		newKeychainTx, err := iWardenClient.NewKeychain(alice.TransactOps(t, ctx, evmClient), keychainName, keychainFees, keychainDescription, keychainUrl, keychainKeybaseId)
+		newKeychainTx, err := iWardenClient.NewKeychain(alice.TransactOps(t, evmClient), keychainName, keychainFees, keychainDescription, keychainUrl, keychainKeybaseId)
 		require.NoError(t, err)
 
-		newKeychainReceipt, err := bind.WaitMined(ctx, evmClient, newKeychainTx)
+		newKeychainReceipt, err := bind.WaitMined(t.Context(), evmClient, newKeychainTx)
 		require.NoError(t, err)
 
 		createTemplateEvents, err := checks.GetParsedEventsOnly(newKeychainReceipt, iWardenClient.ParseNewKeychain)
@@ -88,10 +87,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 			KeybaseId:   keychainKeybaseId,
 		}, keychain)
 		// add keychain writer
-		addKeychainWriterTx, err := iWardenClient.AddKeychainWriter(alice.TransactOps(t, ctx, evmClient), 1, alice.EthAddress(t))
+		addKeychainWriterTx, err := iWardenClient.AddKeychainWriter(alice.TransactOps(t, evmClient), 1, alice.EthAddress(t))
 		require.NoError(t, err)
 
-		addKeychainWriterReceipt, err := bind.WaitMined(ctx, evmClient, addKeychainWriterTx)
+		addKeychainWriterReceipt, err := bind.WaitMined(t.Context(), evmClient, addKeychainWriterTx)
 		require.NoError(t, err)
 
 		addKeychainWriterEvents, err := checks.GetParsedEventsOnly(addKeychainWriterReceipt, iWardenClient.ParseAddKeychainWriter)
@@ -118,10 +117,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 			KeybaseId:   keychainKeybaseId,
 		}, keychain)
 		// add keychain admin
-		addKeychainAdminTx, err := iWardenClient.AddKeychainAdmin(alice.TransactOps(t, ctx, evmClient), 1, bob.EthAddress(t))
+		addKeychainAdminTx, err := iWardenClient.AddKeychainAdmin(alice.TransactOps(t, evmClient), 1, bob.EthAddress(t))
 		require.NoError(t, err)
 
-		addKeychainAdminReceipt, err := bind.WaitMined(ctx, evmClient, addKeychainAdminTx)
+		addKeychainAdminReceipt, err := bind.WaitMined(t.Context(), evmClient, addKeychainAdminTx)
 		require.NoError(t, err)
 
 		addKeychainAdminEvents, err := checks.GetParsedEventsOnly(addKeychainAdminReceipt, iWardenClient.ParseAddKeychainAdmin)
@@ -148,10 +147,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 			KeybaseId:   keychainKeybaseId,
 		}, keychain)
 		// remove keychain admin
-		removeKeychainAdminTx, err := iWardenClient.RemoveKeychainAdmin(alice.TransactOps(t, ctx, evmClient), 1, alice.EthAddress(t))
+		removeKeychainAdminTx, err := iWardenClient.RemoveKeychainAdmin(alice.TransactOps(t, evmClient), 1, alice.EthAddress(t))
 		require.NoError(t, err)
 
-		removeKeychainAdminReceipt, err := bind.WaitMined(ctx, evmClient, removeKeychainAdminTx)
+		removeKeychainAdminReceipt, err := bind.WaitMined(t.Context(), evmClient, removeKeychainAdminTx)
 		require.NoError(t, err)
 
 		removeKeychainAdminEvents, err := checks.GetParsedEventsOnly(removeKeychainAdminReceipt, iWardenClient.ParseRemoveKeychainAdmin)
@@ -194,10 +193,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 			KeyReq: keyReq,
 			SigReq: sigReq,
 		}
-		updateKeychainTx, err := iWardenClient.UpdateKeychain(bob.TransactOps(t, ctx, evmClient), 1, keychainName, keychainFees, keychainDescription, keychainUrl, keychainKeybaseId)
+		updateKeychainTx, err := iWardenClient.UpdateKeychain(bob.TransactOps(t, evmClient), 1, keychainName, keychainFees, keychainDescription, keychainUrl, keychainKeybaseId)
 		require.NoError(t, err)
 
-		updateKeychainReceipt, err := bind.WaitMined(ctx, evmClient, updateKeychainTx)
+		updateKeychainReceipt, err := bind.WaitMined(t.Context(), evmClient, updateKeychainTx)
 		require.NoError(t, err)
 
 		updateKeychainEvents, err := checks.GetParsedEventsOnly(updateKeychainReceipt, iWardenClient.ParseUpdateKeychain)
@@ -230,10 +229,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 		require.Equal(t, []warden.Space{}, spaces.Spaces)
 
 		additionalOwners := []common.Address{}
-		newSpaceTx, err := iWardenClient.NewSpace(alice.TransactOps(t, ctx, evmClient), 0, 0, 0, 0, additionalOwners)
+		newSpaceTx, err := iWardenClient.NewSpace(alice.TransactOps(t, evmClient), 0, 0, 0, 0, additionalOwners)
 		require.NoError(t, err)
 
-		newSpaceReceipt, err := bind.WaitMined(ctx, evmClient, newSpaceTx)
+		newSpaceReceipt, err := bind.WaitMined(t.Context(), evmClient, newSpaceTx)
 		require.NoError(t, err)
 
 		newSpaceEvents, err := checks.GetParsedEventsOnly(newSpaceReceipt, iWardenClient.ParseNewSpace)
@@ -283,10 +282,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 		pubKey, err := hex.DecodeString("04698b4299b6d5a097dadfa74f7b36413422102308160840d5c07b6124aa95d6972dd03c5db4fd57c01fc2152bc01362c298351a9e6c8876f5e533037fe11b82bf")
 		require.NoError(t, err)
 
-		fulfilKeyRequestTx, err := iWardenClient.FulfilKeyRequest(alice.TransactOps(t, ctx, evmClient), 1, pubKey)
+		fulfilKeyRequestTx, err := iWardenClient.FulfilKeyRequest(alice.TransactOps(t, evmClient), 1, pubKey)
 		require.NoError(t, err)
 
-		fulfilKeyRequestReceipt, err := bind.WaitMined(ctx, evmClient, fulfilKeyRequestTx)
+		fulfilKeyRequestReceipt, err := bind.WaitMined(t.Context(), evmClient, fulfilKeyRequestTx)
 		require.NoError(t, err)
 
 		newKeyEvents, err := checks.GetParsedEventsOnly(fulfilKeyRequestReceipt, iWardenClient.ParseNewKey)
@@ -353,10 +352,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 		newKeyReqTx = alice.Tx(t, "warden new-action new-key-request --space-id 1 --keychain-id 1 --key-type 1 --max-keychain-fees \"1award\" --nonce 0")
 		checks.SuccessTx(t, newKeyReqTx)
 
-		rejectKeyRequestTx, err := iWardenClient.RejectKeyRequest(alice.TransactOps(t, ctx, evmClient), 2, "test reject reason")
+		rejectKeyRequestTx, err := iWardenClient.RejectKeyRequest(alice.TransactOps(t, evmClient), 2, "test reject reason")
 		require.NoError(t, err)
 
-		rejectKeyRequestReceipt, err := bind.WaitMined(ctx, evmClient, rejectKeyRequestTx)
+		rejectKeyRequestReceipt, err := bind.WaitMined(t.Context(), evmClient, rejectKeyRequestTx)
 		require.NoError(t, err)
 
 		rejectKeyRequestEvents, err := checks.GetParsedEventsOnly(rejectKeyRequestReceipt, iWardenClient.ParseRejectKeyRequest)
@@ -386,10 +385,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 		signedData, err := base64.StdEncoding.DecodeString("LKu131U23Q5Ke7jJscb57zdSmuZD27a4VeZ+/hwf7ShOLo4ozUc36pvNT14+a1s09k1PbPihrFbK29J00Jh3tgA=")
 		require.NoError(t, err)
 
-		fulfilSignRequestTx, err := iWardenClient.FulfilSignRequest(alice.TransactOps(t, ctx, evmClient), 1, signedData)
+		fulfilSignRequestTx, err := iWardenClient.FulfilSignRequest(alice.TransactOps(t, evmClient), 1, signedData)
 		require.NoError(t, err)
 
-		fulfilSignRequestReceipt, err := bind.WaitMined(ctx, evmClient, fulfilSignRequestTx)
+		fulfilSignRequestReceipt, err := bind.WaitMined(t.Context(), evmClient, fulfilSignRequestTx)
 		require.NoError(t, err)
 
 		fulfilSignRequestEvents, err := checks.GetParsedEventsOnly(fulfilSignRequestReceipt, iWardenClient.ParseFulfilSignRequest)
@@ -419,10 +418,10 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, ctx context.Context, build fra
 		newSignReqTx = alice.Tx(t, "warden new-action new-sign-request --key-id 1 --input 'HoZ4Z+ZU7Zd08kUR5NcbtFZrmGKF18mSBJ29dg0qI44=' --max-keychain-fees \"1award\" --nonce 0")
 		checks.SuccessTx(t, newSignReqTx)
 		signRequestRejectReason := "test reject reason"
-		rejectSignRequestTx, err := iWardenClient.RejectSignRequest(alice.TransactOps(t, ctx, evmClient), 2, signRequestRejectReason)
+		rejectSignRequestTx, err := iWardenClient.RejectSignRequest(alice.TransactOps(t, evmClient), 2, signRequestRejectReason)
 		require.NoError(t, err)
 
-		rejectSignRequestReceipt, err := bind.WaitMined(ctx, evmClient, rejectSignRequestTx)
+		rejectSignRequestReceipt, err := bind.WaitMined(t.Context(), evmClient, rejectSignRequestTx)
 		require.NoError(t, err)
 
 		rejectSignRequestEvents, err := checks.GetParsedEventsOnly(rejectSignRequestReceipt, iWardenClient.ParseRejectSignRequest)

--- a/tests/cases/warden_precompile_action.go
+++ b/tests/cases/warden_precompile_action.go
@@ -1,7 +1,6 @@
 package cases
 
 import (
-	"context"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -24,15 +23,15 @@ type Test_WardenPrecompileAction struct {
 	w *exec.WardenNode
 }
 
-func (c *Test_WardenPrecompileAction) Setup(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_WardenPrecompileAction) Setup(t *testing.T, build framework.BuildResult) {
 	c.w = exec.NewWardenNode(t, build.Wardend)
 
-	go c.w.Start(t, ctx, "./testdata/snapshot-many-users")
+	go c.w.Start(t, "./testdata/snapshot-many-users")
 	c.w.WaitRunning(t)
-	c.w.PrintLogsAtTheEnd(t, ctx, []string{"TEST_DEBUG"})
+	c.w.PrintLogsAtTheEnd(t, []string{"TEST_DEBUG"})
 }
 
-func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, build framework.BuildResult) {
+func (c *Test_WardenPrecompileAction) Run(t *testing.T, build framework.BuildResult) {
 	alice := exec.NewWardend(c.w, "alice")
 	bob := exec.NewWardend(c.w, "bob")
 
@@ -47,7 +46,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 	t.Run("work with new action", func(t *testing.T) {
 		// addSpaceOwner
 		addSpaceOwnerTx, err := iWardenClient.AddSpaceOwner(
-			alice.TransactOps(t, context.Background(), evmClient),
+			alice.TransactOps(t, evmClient),
 			1,
 			bob.EthAddress(t),
 			0,
@@ -56,7 +55,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 			"any(1, warden.space.owners)")
 		require.NoError(t, err)
 
-		addSpaceOwnerTxReceipt, err := bind.WaitMined(ctx, evmClient, addSpaceOwnerTx)
+		addSpaceOwnerTxReceipt, err := bind.WaitMined(t.Context(), evmClient, addSpaceOwnerTx)
 		require.NoError(t, err)
 
 		addSpaceOwnerEvents, err := checks.GetParsedEventsOnly(addSpaceOwnerTxReceipt, iWardenClient.ParseAddSpaceOwner)
@@ -86,7 +85,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 
 		// removeSpaceOwner
 		removeSpaceOwnerTx, err := iWardenClient.RemoveSpaceOwner(
-			alice.TransactOps(t, context.Background(), evmClient),
+			alice.TransactOps(t, evmClient),
 			1,
 			bob.EthAddress(t),
 			1,
@@ -95,7 +94,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 			"any(1, warden.space.owners)")
 		require.NoError(t, err)
 
-		removeSpaceOwnerTxReceipt, err := bind.WaitMined(ctx, evmClient, removeSpaceOwnerTx)
+		removeSpaceOwnerTxReceipt, err := bind.WaitMined(t.Context(), evmClient, removeSpaceOwnerTx)
 		require.NoError(t, err)
 
 		removeSpaceOwnerEvents, err := checks.GetParsedEventsOnly(removeSpaceOwnerTxReceipt, iWardenClient.ParseRemoveSpaceOwner)
@@ -123,10 +122,10 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 			Owners:                 []common.Address{alice.EthAddress(t)},
 		}, spaceById2)
 
-		newKeychainTx, err := iWardenClient.NewKeychain(alice.TransactOps(t, context.Background(), evmClient), "test keychain", warden.KeychainFees{}, "", "", "")
+		newKeychainTx, err := iWardenClient.NewKeychain(alice.TransactOps(t, evmClient), "test keychain", warden.KeychainFees{}, "", "", "")
 		require.NoError(t, err)
 
-		_, err = bind.WaitMined(ctx, evmClient, newKeychainTx)
+		_, err = bind.WaitMined(t.Context(), evmClient, newKeychainTx)
 		require.NoError(t, err)
 
 		keychains1, err := iWardenClient.Keychains(alice.CallOps(t), warden.TypesPageRequest{})
@@ -135,12 +134,12 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 		require.Len(t, keychains1.Keychains, 1)
 
 		addKeychainWriterTx, err := iWardenClient.AddKeychainWriter(
-			alice.TransactOps(t, context.Background(), evmClient),
+			alice.TransactOps(t, evmClient),
 			1,
 			alice.EthAddress(t))
 		require.NoError(t, err)
 
-		_, err = bind.WaitMined(ctx, evmClient, addKeychainWriterTx)
+		_, err = bind.WaitMined(t.Context(), evmClient, addKeychainWriterTx)
 		require.NoError(t, err)
 
 		keychains2, err := iWardenClient.Keychains(alice.CallOps(t), warden.TypesPageRequest{})
@@ -150,7 +149,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 
 		// newKeyRequest
 		newKeyRequestTx, err := iWardenClient.NewKeyRequest(
-			alice.TransactOps(t, context.Background(), evmClient),
+			alice.TransactOps(t, evmClient),
 			1,
 			1,
 			uint8(types.KeyType_KEY_TYPE_ECDSA_SECP256K1),
@@ -163,7 +162,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 			"any(1, warden.space.owners)")
 		require.NoError(t, err)
 
-		newKeyRequestTxReceipt, err := bind.WaitMined(ctx, evmClient, newKeyRequestTx)
+		newKeyRequestTxReceipt, err := bind.WaitMined(t.Context(), evmClient, newKeyRequestTx)
 		require.NoError(t, err)
 
 		newKeyRequestEvents, err := checks.GetParsedEventsOnly(newKeyRequestTxReceipt, iWardenClient.ParseNewKeyRequest)
@@ -201,13 +200,13 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 		}, keyRequests1.KeyRequests[0])
 
 		fulfilKeyRequestTx, err := iWardenClient.FulfilKeyRequest(
-			alice.TransactOps(t, context.Background(), evmClient),
+			alice.TransactOps(t, evmClient),
 			1,
 			[]byte{3, 127, 233, 231, 7, 1, 37, 58, 229, 52, 192, 74, 160, 180, 120, 109, 158, 81, 170, 197, 189, 110, 90, 124, 50, 198, 188, 78, 49, 207, 247, 159, 237},
 		)
 		require.NoError(t, err)
 
-		_, err = bind.WaitMined(ctx, evmClient, fulfilKeyRequestTx)
+		_, err = bind.WaitMined(t.Context(), evmClient, fulfilKeyRequestTx)
 		require.NoError(t, err)
 
 		keyRequests2, err := iWardenClient.KeyRequests(alice.CallOps(t), warden.TypesPageRequest{}, 1, uint8(types.KeyRequestStatus_KEY_REQUEST_STATUS_FULFILLED), 1)
@@ -217,7 +216,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 
 		// newSignRequest automatic
 		signRequestAutomatic, err := iWardenClient.NewSignRequest(
-			alice.TransactOps(t, context.Background(), evmClient),
+			alice.TransactOps(t, evmClient),
 			1,
 			[]byte{30, 134, 120, 103, 230, 84, 237, 151, 116, 242, 69, 17, 228, 215, 27, 180, 86, 107, 152, 98, 133, 215, 201, 146, 4, 157, 189, 118, 13, 42, 35, 142},
 			[][]byte{},
@@ -230,7 +229,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 			uint8(types.BroadcastType_BROADCAST_TYPE_AUTOMATIC))
 		require.NoError(t, err)
 
-		newSignRequestAutomaticTxReceipt, err := bind.WaitMined(ctx, evmClient, signRequestAutomatic)
+		newSignRequestAutomaticTxReceipt, err := bind.WaitMined(t.Context(), evmClient, signRequestAutomatic)
 		require.NoError(t, err)
 
 		newSignRequestAutomaticEvents, err := checks.GetParsedEventsOnly(newSignRequestAutomaticTxReceipt, iWardenClient.ParseNewSignRequest)
@@ -274,7 +273,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 
 		// newSignRequest disabled
 		newSignRequestDisabledTx, err := iWardenClient.NewSignRequest(
-			alice.TransactOps(t, context.Background(), evmClient),
+			alice.TransactOps(t, evmClient),
 			1,
 			[]byte{30, 134, 120, 103, 230, 84, 237, 151, 116, 242, 69, 17, 228, 215, 27, 180, 86, 107, 152, 98, 133, 215, 201, 146, 4, 157, 189, 118, 13, 42, 35, 142},
 			[][]byte{},
@@ -287,7 +286,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 			uint8(types.BroadcastType_BROADCAST_TYPE_DISABLED))
 		require.NoError(t, err)
 
-		newSignRequestDisabledTxReceipt, err := bind.WaitMined(ctx, evmClient, newSignRequestDisabledTx)
+		newSignRequestDisabledTxReceipt, err := bind.WaitMined(t.Context(), evmClient, newSignRequestDisabledTx)
 		require.NoError(t, err)
 
 		newSignRequestDisabledEvents, err := checks.GetParsedEventsOnly(newSignRequestDisabledTxReceipt, iWardenClient.ParseNewSignRequest)
@@ -340,16 +339,16 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 
 		// updateKey
 		newTemplateTx, err := iActClient.NewTemplate(
-			alice.TransactOps(t, context.Background(), evmClient),
+			alice.TransactOps(t, evmClient),
 			"test template",
 			"any(2, warden.space.owners)")
 		require.NoError(t, err)
 
-		_, err = bind.WaitMined(ctx, evmClient, newTemplateTx)
+		_, err = bind.WaitMined(t.Context(), evmClient, newTemplateTx)
 		require.NoError(t, err)
 
 		updateKeyTx, err := iWardenClient.UpdateKey(
-			alice.TransactOps(t, context.Background(), evmClient),
+			alice.TransactOps(t, evmClient),
 			1,
 			1,
 			1,
@@ -358,7 +357,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 			"any(1, warden.space.owners)")
 		require.NoError(t, err)
 
-		updateKeyTxReceipt, err := bind.WaitMined(ctx, evmClient, updateKeyTx)
+		updateKeyTxReceipt, err := bind.WaitMined(t.Context(), evmClient, updateKeyTx)
 		require.NoError(t, err)
 
 		updateKeyEvents, err := checks.GetParsedEventsOnly(updateKeyTxReceipt, iWardenClient.ParseUpdateKey)
@@ -393,7 +392,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 
 		// updateSpace
 		updateSpaceTx, err := iWardenClient.UpdateSpace(
-			alice.TransactOps(t, context.Background(), evmClient),
+			alice.TransactOps(t, evmClient),
 			1,
 			2,
 			1,
@@ -405,7 +404,7 @@ func (c *Test_WardenPrecompileAction) Run(t *testing.T, ctx context.Context, bui
 			"any(1, warden.space.owners)")
 		require.NoError(t, err)
 
-		updateSpaceTxReceipt, err := bind.WaitMined(ctx, evmClient, updateSpaceTx)
+		updateSpaceTxReceipt, err := bind.WaitMined(t.Context(), evmClient, updateSpaceTx)
 		require.NoError(t, err)
 
 		updateSpaceEvents, err := checks.GetParsedEventsOnly(updateSpaceTxReceipt, iWardenClient.ParseUpdateSpace)

--- a/tests/framework/checks/checks.go
+++ b/tests/framework/checks/checks.go
@@ -12,7 +12,7 @@ import (
 func Eventually[T any](t *testing.T, f func(ctx context.Context) (T, bool)) T {
 	var result T
 	require.Eventually(t, func() bool {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 		defer cancel()
 		r, ok := f(ctx)
 		result = r

--- a/tests/framework/checks/eth_checks.go
+++ b/tests/framework/checks/eth_checks.go
@@ -1,13 +1,14 @@
 package checks
 
 import (
-	"fmt"
+	"errors"
+
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
 func GetParsedEventsOnly[T any](txReceipt *types.Receipt, eventParser func(types.Log) (T, error)) ([]T, error) {
 	if txReceipt == nil {
-		return nil, fmt.Errorf("no transaction receipt")
+		return nil, errors.New("no transaction receipt")
 	}
 
 	result := make([]T, 0)
@@ -25,7 +26,7 @@ func GetParsedEventsOnly[T any](txReceipt *types.Receipt, eventParser func(types
 	}
 
 	if len(result) == 0 {
-		return nil, fmt.Errorf("no parsed events")
+		return nil, errors.New("no parsed events")
 	}
 
 	return result, nil

--- a/tests/framework/exec/warden_cli.go
+++ b/tests/framework/exec/warden_cli.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/tests/framework/iowriter"
 )
 
@@ -35,7 +36,7 @@ func NewWardend(node *WardenNode, name string) *Wardend {
 }
 
 func (cli *Wardend) Tx(t *testing.T, command string) sdk.TxResponse {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	cmd := &Exec{
@@ -60,7 +61,7 @@ func (cli *Wardend) Address(t *testing.T) string {
 		return cli.address
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 	defer cancel()
 
 	cmd := &Exec{
@@ -83,7 +84,7 @@ func (cli *Wardend) PrivateKey(t *testing.T) string {
 		return cli.privateKey
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 	defer cancel()
 
 	cmd := &Exec{

--- a/tests/framework/exec/warden_eth.go
+++ b/tests/framework/exec/warden_eth.go
@@ -1,7 +1,6 @@
 package exec
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"math/big"
 	"testing"
@@ -35,17 +34,17 @@ func (cli *Wardend) EthAddress(t *testing.T) common.Address {
 
 func (cli *Wardend) TransactOps(
 	t *testing.T,
-	ctx context.Context,
-	client *ethclient.Client) *bind.TransactOpts {
+	client *ethclient.Client,
+) *bind.TransactOpts {
 	privateKey, err := crypto.HexToECDSA(cli.PrivateKey(t))
 	require.NoError(t, err)
 
 	fromAddress := cli.EthAddress(t)
 
-	nonce, err := client.PendingNonceAt(ctx, fromAddress)
+	nonce, err := client.PendingNonceAt(t.Context(), fromAddress)
 	require.NoError(t, err)
 
-	gasPrice, err := client.SuggestGasPrice(ctx)
+	gasPrice, err := client.SuggestGasPrice(t.Context())
 	require.NoError(t, err)
 
 	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1337))

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -1,10 +1,10 @@
 package framework
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/warden-protocol/wardenprotocol/tests/framework/exec"
 )
 
@@ -23,7 +23,7 @@ func Build(t *testing.T) BuildResult {
 		Args: []string{"build", "-o", wardend, "./cmd/wardend"},
 		Pwd:  "../",
 	}
-	err := cmd.Run(context.Background())
+	err := cmd.Run(t.Context())
 	require.NoError(t, err)
 
 	return BuildResult{

--- a/tests/framework/ports/ports.go
+++ b/tests/framework/ports/ports.go
@@ -17,7 +17,7 @@ func ReservePorts(t *testing.T, count int) *FreePort {
 	var ports []int
 	var lsns []net.Listener
 
-	for i := 0; i < count; i++ {
+	for range count {
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 		ports = append(ports, ln.Addr().(*net.TCPAddr).Port)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -22,8 +21,9 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+//nolint:forbidigo
 func TestIntegration(t *testing.T) {
-	var casesToRun = cases.List()
+	casesToRun := cases.List()
 	if list {
 		fmt.Println("Available test cases:")
 		for _, c := range casesToRun {
@@ -37,13 +37,10 @@ func TestIntegration(t *testing.T) {
 
 	for _, c := range casesToRun {
 		t.Run(getName(c), func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			fmt.Println("setup test:", getName(c))
-			c.Setup(t, ctx, build)
+			c.Setup(t, build)
 			fmt.Println("run test:", getName(c))
-			c.Run(t, ctx, build)
+			c.Run(t, build)
 		})
 	}
 

--- a/warden/app/ante.go
+++ b/warden/app/ante.go
@@ -11,7 +11,6 @@ import (
 	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
 	"github.com/cosmos/ibc-go/v8/modules/core/keeper"
@@ -24,7 +23,7 @@ import (
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC
 // channel keeper, wasm keeper and EvmOS keepers.
 type HandlerOptions struct {
-	ante.HandlerOptions
+	authante.HandlerOptions
 
 	IBCKeeper             *keeper.Keeper
 	WasmConfig            *wasmTypes.WasmConfig
@@ -35,7 +34,7 @@ type HandlerOptions struct {
 	// evmos
 	FeeMarketKeeper    evmante.FeeMarketKeeper
 	EvmKeeper          evmante.EVMKeeper
-	TxFeeChecker       ante.TxFeeChecker
+	TxFeeChecker       authante.TxFeeChecker
 	AccountKeeper      evmtypes.AccountKeeper
 	BankKeeper         evmtypes.BankKeeper
 	DistributionKeeper anteutils.DistributionKeeper
@@ -49,23 +48,23 @@ func newCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		cosmosante.NewAuthzLimiterDecorator( // disable the Msg types that cannot be included on an authz.MsgExec msgs field
 			sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}),
 		),
-		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		authante.NewSetUpContextDecorator(),                                              // outermost AnteDecorator. SetUpContext must be called first
 		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit), // after setup context to enforce limits early
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreService),
 		wasmkeeper.NewGasRegisterDecorator(options.WasmKeeper.GetGasRegister()),
 		circuitante.NewCircuitBreakerDecorator(options.CircuitKeeper),
-		ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
-		ante.NewValidateBasicDecorator(),
-		ante.NewTxTimeoutHeightDecorator(),
-		ante.NewValidateMemoDecorator(options.AccountKeeper),
+		authante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
+		authante.NewValidateBasicDecorator(),
+		authante.NewTxTimeoutHeightDecorator(),
+		authante.NewValidateMemoDecorator(options.AccountKeeper),
 		cosmosante.NewMinGasPriceDecorator(options.FeeMarketKeeper, options.EvmKeeper),
-		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
-		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.HandlerOptions.TxFeeChecker),
-		ante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
-		ante.NewValidateSigCountDecorator(options.AccountKeeper),
-		ante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
-		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
-		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
+		authante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
+		authante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.HandlerOptions.TxFeeChecker),
+		authante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
+		authante.NewValidateSigCountDecorator(options.AccountKeeper),
+		authante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
+		authante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		authante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
 	}
 

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -514,7 +514,7 @@ func New(
 			return nil, err
 		}
 
-		return app.App.InitChainer(ctx, req)
+		return app.InitChainer(ctx, req)
 	})
 
 	maxGasWanted := cast.ToUint64(appOpts.Get(srvflags.EVMMaxTxGasWanted))
@@ -565,7 +565,7 @@ func New(
 	}
 
 	if loadLatest {
-		ctx := app.BaseApp.NewUncachedContext(true, tmproto.Header{})
+		ctx := app.NewUncachedContext(true, tmproto.Header{})
 
 		// Initialize pinned codes in wasmvm as they are not persisted there
 		if err := app.WasmKeeper.InitializePinnedCodes(ctx); err != nil {

--- a/warden/app/export.go
+++ b/warden/app/export.go
@@ -45,7 +45,7 @@ func (app *App) ExportAppStateAndValidators(forZeroHeight bool, jailAllowedAddrs
 		AppState:        appState,
 		Validators:      validators,
 		Height:          height,
-		ConsensusParams: app.BaseApp.GetConsensusParams(ctx),
+		ConsensusParams: app.GetConsensusParams(ctx),
 	}, err
 }
 
@@ -54,12 +54,9 @@ func (app *App) ExportAppStateAndValidators(forZeroHeight bool, jailAllowedAddrs
 //
 //	in favor of export at a block height
 func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
-	applyAllowedAddrs := false
+	applyAllowedAddrs := len(jailAllowedAddrs) > 0
 
 	// check if there is a allowed address list
-	if len(jailAllowedAddrs) > 0 {
-		applyAllowedAddrs = true
-	}
 
 	allowedAddrsMap := make(map[string]bool)
 

--- a/warden/app/oracle.go
+++ b/warden/app/oracle.go
@@ -15,7 +15,6 @@ import (
 	oraclepreblock "github.com/skip-mev/slinky/abci/preblock/oracle"
 	"github.com/skip-mev/slinky/abci/proposals"
 	"github.com/skip-mev/slinky/abci/strategies/aggregator"
-	"github.com/skip-mev/slinky/abci/strategies/codec"
 	compression "github.com/skip-mev/slinky/abci/strategies/codec"
 	"github.com/skip-mev/slinky/abci/strategies/currencypair"
 	"github.com/skip-mev/slinky/abci/ve"
@@ -281,7 +280,7 @@ func combinePreBlocker(a, b sdk.PreBlocker) sdk.PreBlocker {
 // WardenSlinkyCodec wraps slinky's codec.VoteExtensionCodec to support our
 // custom vote extension format (vemanager.VE).
 type WardenSlinkyCodec struct {
-	slinkyCodec codec.VoteExtensionCodec
+	slinkyCodec compression.VoteExtensionCodec
 }
 
 var _ compression.VoteExtensionCodec = (*WardenSlinkyCodec)(nil)

--- a/warden/repo/seqcollection.go
+++ b/warden/repo/seqcollection.go
@@ -69,7 +69,7 @@ func (c SeqCollection[V]) Import(ctx context.Context, values []V, getIDFn func(V
 		id := getIDFn(v)
 		actualID, err := c.Append(ctx, &v)
 		if err != nil {
-			return fmt.Errorf("ID mismatch: expected %d, got %d. Cannot import this list of values.", id, actualID)
+			return fmt.Errorf("ID mismatch: expected %d, got %d: cannot import this list of values", id, actualID)
 		}
 	}
 

--- a/warden/x/act/keeper/msg_server_vote_for_action.go
+++ b/warden/x/act/keeper/msg_server_vote_for_action.go
@@ -39,15 +39,16 @@ func (k msgServer) VoteForAction(goCtx context.Context, msg *types.MsgVoteForAct
 		return nil, err
 	}
 
-	if msg.VoteType == types.ActionVoteType_VOTE_TYPE_APPROVED {
+	switch msg.VoteType {
+	case types.ActionVoteType_VOTE_TYPE_APPROVED:
 		if err := k.TryExecuteVotedAction(goCtx, &act); err != nil {
 			return nil, err
 		}
-	} else if msg.VoteType == types.ActionVoteType_VOTE_TYPE_REJECTED {
+	case types.ActionVoteType_VOTE_TYPE_REJECTED:
 		if err := k.TryRejectVotedAction(goCtx, &act); err != nil {
 			return nil, err
 		}
-	} else {
+	default:
 		return nil, fmt.Errorf("unhandled VoteType value: %v", msg.VoteType)
 	}
 

--- a/warden/x/async/keeper/futures.go
+++ b/warden/x/async/keeper/futures.go
@@ -9,7 +9,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/warden-protocol/wardenprotocol/warden/repo"
-	"github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
 )
 
@@ -71,7 +70,7 @@ func (k *FutureKeeper) Set(ctx context.Context, f types.Future) error {
 
 func (k *FutureKeeper) SetResult(ctx context.Context, result types.FutureResult) error {
 	if exists, _ := k.results.Has(ctx, result.Id); exists {
-		return v1beta1.ErrFutureAlreadyHasResult
+		return types.ErrFutureAlreadyHasResult
 	}
 
 	if err := k.pendingFutures.Remove(ctx, result.Id); err != nil {

--- a/warden/x/warden/keeper/keys.go
+++ b/warden/x/warden/keeper/keys.go
@@ -6,7 +6,6 @@ import (
 	"cosmossdk.io/collections"
 	"github.com/cosmos/cosmos-sdk/codec"
 
-	"github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -16,7 +15,7 @@ type KeysKeeper struct {
 }
 
 func NewKeysKeeper(sb *collections.SchemaBuilder, cdc codec.BinaryCodec) KeysKeeper {
-	keys := collections.NewMap(sb, KeyPrefix, "keys", collections.Uint64Key, codec.CollValue[v1beta3.Key](cdc))
+	keys := collections.NewMap(sb, KeyPrefix, "keys", collections.Uint64Key, codec.CollValue[types.Key](cdc))
 	keysBySpace := collections.NewKeySet(
 		sb, KeysSpaceIndexPrefix, "keys_by_space",
 		collections.PairKeyCodec(collections.Uint64Key, collections.Uint64Key),
@@ -45,7 +44,7 @@ func (k KeysKeeper) Set(ctx context.Context, key *types.Key) error {
 	return k.keys.Set(ctx, key.Id, *key)
 }
 
-func (k KeysKeeper) Coll() collections.Map[uint64, v1beta3.Key] {
+func (k KeysKeeper) Coll() collections.Map[uint64, types.Key] {
 	return k.keys
 }
 


### PR DESCRIPTION
I used `golangci-lint migrate` to migrate the configuration file, updated the version in the github actions, and then used `golangci-lint run --fix ./...` to fix most of the new issues combined with some manual work (especially regarding the use of the new t.Context()).