### PR TITLE
ci: fix wardend release permissions

### DIFF
--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -60,7 +60,7 @@ jobs:
         release: ["release"]
     permissions:
       actions: read
-      contents: read
+      contents: write
       packages: write
 
     steps:


### PR DESCRIPTION
this is an attempt to close #1415 but i'm not sure if it's enough