### PR TITLE
feat(ci): tune trivy image scanning

### DIFF
--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -13,13 +13,26 @@ jobs:
       matrix:
         image: ${{ fromJSON(vars.SCAN_IMAGES_LIST) }}
     steps:
+      - name: Get latest image tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ENCODED_NAME=$(echo "${{ matrix.image }}" | sed 's/\//%2F/g')
+          LATEST_TAG=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/$ENCODED_NAME/versions?per_page=1" \
+            | jq -r '.[0].metadata.container.tags[0]')
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.30.0
         with:
-          image-ref: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest"
+          image-ref: "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ env.latest_tag }}"
           format: "sarif"
           output: "trivy.sarif"
           severity: "CRITICAL,HIGH"
+          ignore-unfixed: true
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
           TRIVY_USERNAME: ${{ github.actor }}


### PR DESCRIPTION
- Now we're scanning true latest image version in the registry instead of using `latest` tag
- Reducing the noise from the trivy scanner by ignoring issues that we can't fix
- Updating the scanner action to the latest version