### PR TITLE
Fix typos in protocol definitions and code comments

### DIFF
--- a/wardenjs/proto/ethermint/evm/v1/genesis.proto
+++ b/wardenjs/proto/ethermint/evm/v1/genesis.proto
@@ -21,7 +21,7 @@ message GenesisState {
 // Its main difference between with Geth's GenesisAccount is that it uses a
 // custom storage type and that it doesn't contain the private key field.
 message GenesisAccount {
-  // address defines an ethereum hex formated address of an account
+  // address defines an ethereum hex formatted address of an account
   string address = 1;
   // code defines the hex bytes of the account code.
   string code = 2;

--- a/wardenjs/proto/tendermint/crypto/proof.proto
+++ b/wardenjs/proto/tendermint/crypto/proof.proto
@@ -27,7 +27,7 @@ message DominoOp {
 }
 
 // ProofOp defines an operation used for calculating Merkle root
-// The data could be arbitrary format, providing nessecary data
+// The data could be arbitrary format, providing necessary data
 // for example neighbouring node hash
 message ProofOp {
   string type = 1;

--- a/wardenjs/proto/tendermint/types/types.proto
+++ b/wardenjs/proto/tendermint/types/types.proto
@@ -9,7 +9,7 @@ import "tendermint/crypto/proof.proto";
 import "tendermint/version/types.proto";
 import "tendermint/types/validator.proto";
 
-// BlockIdFlag indicates which BlcokID the signature is for
+// BlockIdFlag indicates which BlockID the signature is for
 enum BlockIDFlag {
   option (gogoproto.goproto_enum_stringer) = true;
   option (gogoproto.goproto_enum_prefix)   = false;

--- a/wardenjs/src/codegen/warden/act/v1beta1/action.ts
+++ b/wardenjs/src/codegen/warden/act/v1beta1/action.ts
@@ -12,7 +12,7 @@ export enum ActionStatus {
   ACTION_STATUS_UNSPECIFIED = 0,
   /** ACTION_STATUS_PENDING - Action is pending approval. This is the initial status. */
   ACTION_STATUS_PENDING = 1,
-  /** ACTION_STATUS_COMPLETED - Template has been satified, action has been executed. */
+  /** ACTION_STATUS_COMPLETED - Template has been satisfied, action has been executed. */
   ACTION_STATUS_COMPLETED = 2,
   /** ACTION_STATUS_REVOKED - Action has been revoked by its creator. */
   ACTION_STATUS_REVOKED = 3,


### PR DESCRIPTION
This pull request fixes several typos found in the codebase:

1. Fixed typo in ethereum address comment: "formatted" was misspelled
2. Fixed typo in ProofOp comment: "necessary" was misspelled
3. Fixed casing in BlockIdFlag comment: "BlockID" was incorrectly written
4. Fixed typo in action status comment: "satisfied" was misspelled

These changes are purely cosmetic and do not affect functionality.