### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -7,6 +7,6 @@ jobs:
   go-mod-tidy-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
       - uses: katexochen/go-tidy-check@v2

--- a/warden/.github/workflows/release.yml
+++ b/warden/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
         


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected