### PR TITLE
fix(ci): skip publishing the images  in the dev workflow

### DIFF
--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -100,5 +100,5 @@ jobs:
       - name: ${{ matrix.release }}
         run: just wardend ${{ matrix.release }}
         env:
-          SKIP: ${{ startsWith(github.head_ref, 'dependabot/') && '--skip=validate,publish' || '--skip=validate' }}
+          SKIP: ${{ github.event_name == 'pull_request' && '--skip=validate,publish' || '--skip=validate' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -53,6 +53,7 @@ jobs:
         run: go test -race -v ${{ env.modules }}
 
   release-dev:
+    if: ${{ github.event_name != 'pull_request' }}
     name: ${{ matrix.release }}
     runs-on: ubuntu-latest
     strategy:
@@ -100,5 +101,5 @@ jobs:
       - name: ${{ matrix.release }}
         run: just wardend ${{ matrix.release }}
         env:
-          SKIP: ${{ github.event_name == 'pull_request' && '--skip=validate,publish' || '--skip=validate' }}
+          SKIP: "--skip=validate"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It should be enough to see that the builds succeed, and there's no need to publish them while working on a PR