### PR TITLE
ci: run solidity contracts tests on precompile changes

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -7,9 +7,11 @@ on:
       - main
     paths:
       - "solidity/orders/**"
+      - "precompiles/**"
   pull_request:
     paths:
       - "solidity/orders/**"
+      - "precompiles/**"
 
 jobs:
   test:


### PR DESCRIPTION
This change makes solidity tests run when precompiles are changed, to ensure that changes in the precompiles are not breaking our existing contracts.