### PR TITLE
fix: update WardenProtocol RPC to Chiado testnet

### DIFF
--- a/wardenjs/README.md
+++ b/wardenjs/README.md
@@ -223,7 +223,7 @@ import {
 } from 'wardenjs';
 
 const signer: OfflineSigner = /* create your signer (see above)  */
-const rpcEndpint = 'https://rpc.cosmos.directory/wardenprotocol'; // or another URL
+const rpcEndpint = 'https://rpc.chiado.wardenprotocol.org'; // or another URL
 
 const protoRegistry: ReadonlyArray<[string, GeneratedType]> = [
     ...cosmosProtoRegistry,


### PR DESCRIPTION
Hey ! I replace the deprecated endpoint `https://rpc.cosmos.directory/wardenprotocol` for the active Chiado testnet RPC `https://rpc.chiado.wardenprotocol.org` so requests hit a live node and no longer fail.