### PR TITLE
fix(go-client): handling of EthAccounts in AuthQueryClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features (non-breaking)
 
+- (go-client) Fix handling of EthAccounts in AuthQueryClient
+
 ### Consensus Breaking Changes
 
 ### Bug Fixes

--- a/go-client/query_client_auth.go
+++ b/go-client/query_client_auth.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	ethtypes "github.com/evmos/evmos/v20/types"
 	"google.golang.org/grpc"
 )
 
@@ -30,10 +31,18 @@ func (c *AuthQueryClient) Account(ctx context.Context, addr string) (types.Accou
 		return nil, err
 	}
 
-	var account authtypes.BaseAccount
-	if err := account.Unmarshal(res.Account.Value); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal account: %w", err)
+	switch res.Account.TypeUrl {
+	case "/ethermint.types.v1.EthAccount":
+		var account ethtypes.EthAccount
+		if err := account.Unmarshal(res.Account.Value); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal EthAccount: %w", err)
+		}
+		return &account, nil
+	default:
+		var account authtypes.BaseAccount
+		if err := account.Unmarshal(res.Account.Value); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal BaseAccount: %w", err)
+		}
+		return &account, nil
 	}
-
-	return &account, nil
 }


### PR DESCRIPTION
The current implementation returns an error, while we should handle EthAccounts correctly (it's easy as they implement the base types.AccountI interface).