### PR TITLE
fix(x/async): improve error message when there are no solvers registered for a plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features (non-breaking)
 
 - (go-client) Fix handling of EthAccounts in AuthQueryClient
+- (x/async) Improve error message when there are no solvers registered for a plugin
 
 ### Consensus Breaking Changes
 

--- a/warden/x/async/keeper/msg_server_add_task.go
+++ b/warden/x/async/keeper/msg_server_add_task.go
@@ -35,7 +35,7 @@ func (k msgServer) AddTask(ctx context.Context, msg *types.MsgAddTask) (*types.M
 	}
 
 	if !k.HasPluginValidators(ctx, msg.Plugin) {
-		return nil, errorsmod.Wrapf(types.ErrInvalidPlugin, "plugin doesn't have any registered validators providers")
+		return nil, errorsmod.Wrapf(types.ErrNoSolvers, "no validators can handle requests for this plugin")
 	}
 
 	if len(msg.Input) == 0 {

--- a/warden/x/async/types/v1beta1/errors.go
+++ b/warden/x/async/types/v1beta1/errors.go
@@ -27,4 +27,5 @@ var (
 	ErrTaskAlreadyHasResult = sdkerrors.Register(ModuleName, 1104, "task already has result")
 	ErrInvalidCallback      = sdkerrors.Register(ModuleName, 1105, "invalid callback")
 	ErrInsufficientFees     = sdkerrors.Register(ModuleName, 1106, "insufficient fees for plugin")
+	ErrNoSolvers            = sdkerrors.Register(ModuleName, 1107, "no solvers")
 )


### PR DESCRIPTION
Changed error code and wording.

cc @deiu 