### PR TITLE
docs: update link to src/IExecution.sol

### DIFF
--- a/docs/developer-docs/docs/build-an-agent/build-an-onchain-ai-agent/build-the-infrastructure-for-orders/implement-the-execution-interface.md
+++ b/docs/developer-docs/docs/build-an-agent/build-an-onchain-ai-agent/build-the-infrastructure-for-orders/implement-the-execution-interface.md
@@ -13,7 +13,7 @@ Store `IExecution` in the [`src` directory](https://github.com/warden-protocol/w
 :::
 
 :::note Full code
-You can find the full code on GitHub: [`src/IExecution.sol`](https://github.com/warden-protocol/wardenprotocol/blob/main/solidity/orders/src/IExecution.sol)
+You can find the full code on GitHub: [`src/IExecution.sol`](https://github.com/warden-protocol/wardenprotocol/tree/main/solidity/orders/src/types)
 :::
 
 ## Create the `IExecution` contract


### PR DESCRIPTION
there are two versions of this file ([1](https://github.com/warden-protocol/wardenprotocol/blob/main/solidity/orders/src/types/IExecutionV0.sol)) ([2](https://github.com/warden-protocol/wardenprotocol/blob/main/solidity/orders/src/types/IExecutionV1.sol)) so i decided just to add link to directory where links are. let me know if we prefer particular file - i will fix it. 