### PR TITLE
build(solidity): move from yarn to pnpm

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -22,11 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: foundry-rs/foundry-toolchain@v1
-      - name: Clear Yarn Cache
-        run: yarn cache clean
+      - uses: pnpm/action-setup@v3
+        name: Install pnpm
+        with:
+          version: 10.11.0
+          run_install: false
       - name: Install dependencies
-        run: yarn install
+        run: pnpm install
       - name: Run lint
-        run: yarn run lint
+        run: pnpm run lint
       - name: Run test
-        run: yarn run test
+        run: pnpm run test

--- a/solidity/justfile
+++ b/solidity/justfile
@@ -6,16 +6,16 @@ local_chain_id := "1337"
 orders: build-orders lint-orders test-orders
 
 build-orders:
-    cd orders && yarn && yarn build
+    cd orders && pnpm install && pnpm build
 
 lint-orders:
-    cd orders && yarn lint
+    cd orders && pnpm lint
 
 test-orders:
-    cd orders && yarn test
+    cd orders && pnpm test
 
 localnet-orders $RPC_URL=local_rpc_url $CHAIN_ID=local_chain_id $MNEMONIC=shulgin_mnemonic $SCHEDULER_ADDRESS=shulgin $FACTORY_OWNER_ADDRESS=shulgin:
-    cd orders && CHAIN_ID=$CHAIN_ID RPC_URL=$RPC_URL yarn deploy
+    cd orders && CHAIN_ID=$CHAIN_ID RPC_URL=$RPC_URL pnpm deploy
 
 # Example:
 # just solidity create-basic-order \

--- a/solidity/orders/README.md
+++ b/solidity/orders/README.md
@@ -2,18 +2,18 @@
 
 ### Commands
 
-Before using commands install dependencies with `yarn install`.
+Before using commands install dependencies with `pnpm install`.
 
 #### Build
 
 ```sh
-yarn build
+pnpm build
 ```
 
 #### Tests
 
 ```sh
-yarn test
+pnpm test
 ```
 
 ### Order

--- a/solidity/orders/package.json
+++ b/solidity/orders/package.json
@@ -14,14 +14,13 @@
   "scripts": {
     "clean": "rm -rf cache out",
     "build": "forge build src --via-ir",
-    "lint": "yarn run lint:sol && yarn run prettier:check",
-    "lint:sol": "forge fmt --check && yarn solhint \"{script,src,test}/**/*.sol\"",
+    "lint": "pnpm run lint:sol && pnpm run prettier:check",
+    "lint:sol": "forge fmt --check && pnpm solhint \"{script,src,test}/**/*.sol\"",
     "prettier:check": "prettier --check \"**/*.{json,md,yml}\" --ignore-path \".prettierignore\"",
     "prettier:write": "prettier --write \"**/*.{json,md,yml}\" --ignore-path \".prettierignore\"",
     "test": "forge test --via-ir",
     "test:coverage": "forge coverage",
     "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage",
     "deploy": "forge script script/Deploy.s.sol:Deploy --chain $CHAIN_ID --rpc-url $RPC_URL --broadcast -vvvv --via-ir --slow"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }


### PR DESCRIPTION
Building this package is flaky in CI, one reason is that we're using an ancient version of yarn.

I migrated the solidity/orders package to pnpm.

Ideally we can do the same for the packages under automated-orders but it requires a bit more work for setting up their workspace properly.

(if you encounter problems locally, try `rm -rf node_modules` and reinstall the dependencies using pnpm)