### PR TITLE
ci: bump golangci-lint-action to v8

### DIFF
--- a/.github/workflows/faucet.yml
+++ b/.github/workflows/faucet.yml
@@ -36,7 +36,7 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.0
           args: --timeout=10m ${{ env.modules }}

--- a/.github/workflows/go-client.yml
+++ b/.github/workflows/go-client.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.0
           args: --timeout=10m ./go-client/...

--- a/.github/workflows/keychain-sdk.yml
+++ b/.github/workflows/keychain-sdk.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.0
           args: --timeout=10m ./keychain-sdk/...

--- a/.github/workflows/shield.yml
+++ b/.github/workflows/shield.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.0
           args: --timeout=10m ./shield/...

--- a/.github/workflows/soliditygen.yml
+++ b/.github/workflows/soliditygen.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.0
           args: --timeout=10m ./cmd/soliditygen/...

--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -35,7 +35,7 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.0
           args: --timeout=10m ${{ env.modules }}

--- a/.github/workflows/wardenkms.yml
+++ b/.github/workflows/wardenkms.yml
@@ -30,7 +30,7 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.0
           args: --timeout=10m ./cmd/wardenkms/...


### PR DESCRIPTION
Maintenance update to golangci-lint-action@v8 to align with the current best practices; nothing else modified. Refer to [v8.0.0 release notes](https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0) for details.