### PR TITLE
fix: bump wasmvm and fix binaries checksums

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt update && \
     useradd -M -u 1000 -U -s /bin/sh -d /data warden && \
     install -o 1000 -g 1000 -d /data
 COPY --from=wardend-build --chown=warden:warden /build/wardend /usr/bin/wardend
-ADD --chmod=444 --checksum=sha256:015bdae5e70304f1e487981f90e3956754718fe7bdac4446aab0838fcb8b33e0 --chown=warden:warden https://github.com/CosmWasm/wasmvm/releases/download/v2.1.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
+ADD --chmod=444 --checksum=sha256:a7f6f5a79f41c756f87e4e3de86439a18fec07238c2521ac21ac2e5655751460 --chown=warden:warden https://github.com/CosmWasm/wasmvm/releases/download/v2.2.4/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
 
 USER warden
 CMD ["wardend", "start"]
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=wardend-build --chown=warden:warden /build/wardend /usr/bin/wardend
 COPY --from=wardend-build --chown=warden:warden /build/faucet /usr/bin/faucet
-ADD --chmod=444 --checksum=sha256:015bdae5e70304f1e487981f90e3956754718fe7bdac4446aab0838fcb8b33e0 https://github.com/CosmWasm/wasmvm/releases/download/v2.1.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
+ADD --chmod=444 --checksum=sha256:a7f6f5a79f41c756f87e4e3de86439a18fec07238c2521ac21ac2e5655751460 https://github.com/CosmWasm/wasmvm/releases/download/v2.2.4/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
 
 USER warden
 
@@ -74,7 +74,7 @@ RUN --mount=type=bind,source=.,target=.,readonly\
 
 FROM debian:bookworm-slim AS wardenkms
 COPY --chown=nobody:nogroup --from=wardenkms-build /build/wardenkms /
-ADD --chmod=444 --chown=nobody:nogroup --checksum=sha256:015bdae5e70304f1e487981f90e3956754718fe7bdac4446aab0838fcb8b33e0 https://github.com/CosmWasm/wasmvm/releases/download/v2.1.2/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
+ADD --chmod=444 --chown=nobody:nogroup --checksum=sha256:a7f6f5a79f41c756f87e4e3de86439a18fec07238c2521ac21ac2e5655751460 https://github.com/CosmWasm/wasmvm/releases/download/v2.2.4/libwasmvm.x86_64.so /lib/libwasmvm.x86_64.so
 
 USER nobody
 ENTRYPOINT ["/wardenkms"]

--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/CosmWasm/wasmvm/v2 v2.2.1 // indirect
+	github.com/CosmWasm/wasmvm/v2 v2.2.4 // indirect
 	github.com/DataDog/datadog-go v4.8.3+incompatible // indirect
 	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CosmWasm/wasmd v0.55.0 h1:NJgTxvdqh4WunjQ/djL0hnnq3LUU58rW7CiUkeCBu/8=
 github.com/CosmWasm/wasmd v0.55.0/go.mod h1:67K2PzoSF9+NjImaALEYMaAHd3zwaSuWLsQ7iSznUik=
-github.com/CosmWasm/wasmvm/v2 v2.2.1 h1:cmOnM+TDfUl2VRugeo1eJBw4U/Lw0WLviuQHKSo9DVQ=
-github.com/CosmWasm/wasmvm/v2 v2.2.1/go.mod h1:bMhLQL4Yp9CzJi9A83aR7VO9wockOsSlZbT4ztOl6bg=
+github.com/CosmWasm/wasmvm/v2 v2.2.4 h1:V3UwXJMA8TNOuQETppDQkaXAevF7gOWLYpKvrThPv7o=
+github.com/CosmWasm/wasmvm/v2 v2.2.4/go.mod h1:Aj/rB2KMRM8nAdbWxkO23rnQYb5KsoPuH9ZizSi0sVg=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=

--- a/justfile
+++ b/justfile
@@ -30,11 +30,11 @@ deploy-contract contract from="shulgin" label="":
 
 # variables for building and releasing
 wasmvm_version := `go list -m -f '{{ .Version }}' github.com/CosmWasm/wasmvm/v2`
-wasmvm_amd64_checksum := '015bdae5e70304f1e487981f90e3956754718fe7bdac4446aab0838fcb8b33e0'
-wasmvm_arm64_checksum := 'aaca92c6a114c34128b9c8e826f49841229d33d914fab0369007591b2d6b782d'
-wasmvm_muslc_amd64_checksum := '58e1f6bfa89ee390cb9abc69a5bc126029a497fe09dd399f38a82d0d86fe95ef'
-wasmvm_muslc_arm64_checksum := '0881c5b463e89e229b06370e9e2961aec0a5c636772d5142c68d351564464a66'
-wasmvm_static_darwin_checksum := '28527dcc9fde23292ed096a22eaf9577d12a8e772fe64c0700170514f976a5f2'
+wasmvm_amd64_checksum := 'a7f6f5a79f41c756f87e4e3de86439a18fec07238c2521ac21ac2e5655751460'
+wasmvm_arm64_checksum := '3a6f1a2448cb88c6a00faf9a2c72262d8b2d6b65a3a1dd3c969e5df42534bb0d'
+wasmvm_muslc_amd64_checksum := '70c989684d2b48ca17bbd55bb694bbb136d75c393c067ef3bdbca31d2b23b578'
+wasmvm_muslc_arm64_checksum := '27fb13821dbc519119f4f98c30a42cb32429b111b0fdc883686c34a41777488f'
+wasmvm_static_darwin_checksum := '43f1341015143c626b634a709872efe848e45ad24444c091496f9c648fd71a67'
 goreleaser_cross_version := 'v1.24.1'
 release := env("RELEASE", "false")
 github_token := env("GITHUB_TOKEN", "")


### PR DESCRIPTION
took the chance to bump wasmvm to latest (v2.2.4) and fix all the checksums