### PR TITLE
fix(wardend): app initialization with different chain IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (x/async) Improve error message when there are no solvers registered for a plugin
 - (x/async) Add a list of plugins to register onchain to the genesis file
 - (x/async) Initial version of a Venice.ai plugin for LLM completions
+- (wardend) Fixed EVM initialization on chain id different than "warden-1337_1"
 
 ### Consensus Breaking Changes
 

--- a/cmd/wardend/cmd/commands.go
+++ b/cmd/wardend/cmd/commands.go
@@ -196,7 +196,6 @@ func newApp(
 	app, err := app.New(
 		logger, db, traceStore, true,
 		appOpts,
-		app.EVMAppOptions,
 		wasmOpts,
 		baseappOptions...,
 	)
@@ -242,7 +241,7 @@ func appExport(
 	var emptyWasmOpts []wasmkeeper.Option
 
 	if height != -1 {
-		bApp, err = app.New(logger, db, traceStore, false, appOpts, app.EVMAppOptions, emptyWasmOpts)
+		bApp, err = app.New(logger, db, traceStore, false, appOpts, emptyWasmOpts)
 		if err != nil {
 			return servertypes.ExportedApp{}, err
 		}
@@ -251,7 +250,7 @@ func appExport(
 			return servertypes.ExportedApp{}, err
 		}
 	} else {
-		bApp, err = app.New(logger, db, traceStore, true, appOpts, app.EVMAppOptions, emptyWasmOpts)
+		bApp, err = app.New(logger, db, traceStore, true, appOpts, emptyWasmOpts)
 		if err != nil {
 			return servertypes.ExportedApp{}, err
 		}

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -97,10 +97,10 @@ import (
 )
 
 const (
-	Name         = "warden"
-	ChainID      = "warden_1337-1"
-	ChainDenom   = "award"
-	DisplayDenom = "ward"
+	Name          = "warden"
+	ChainDenom    = "award"
+	DenomDecimals = evmtypes.EighteenDecimals
+	DisplayDenom  = "ward"
 )
 
 // DefaultNodeHome default home directories for the application daemon.
@@ -300,7 +300,6 @@ func New(
 	traceStore io.Writer,
 	loadLatest bool,
 	appOpts servertypes.AppOptions,
-	evmAppOptions EVMOptionsFn,
 	wasmOpts []wasmkeeper.Option,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) (*App, error) {
@@ -468,8 +467,13 @@ func New(
 
 	app.SetTxEncoder(app.txConfig.TxEncoder())
 
-	if err := evmAppOptions(app.ChainID()); err != nil {
-		panic(err)
+	if err := setupEVM(app.ChainID(), evmtypes.EvmCoinInfo{
+		Denom:         ChainDenom,
+		ExtendedDenom: ChainDenom,
+		Decimals:      DenomDecimals,
+		DisplayDenom:  DisplayDenom,
+	}); err != nil {
+		return nil, err
 	}
 
 	app.MarketMapKeeper.SetHooks(app.OracleKeeper.Hooks())

--- a/warden/app/sim_bench_test.go
+++ b/warden/app/sim_bench_test.go
@@ -42,7 +42,7 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
-	bApp, err := app.New(logger, db, nil, true, appOptions, app.EVMAppOptions, nil, interBlockCacheOpt())
+	bApp, err := app.New(logger, db, nil, true, appOptions, nil, interBlockCacheOpt())
 	require.NoError(b, err)
 	require.Equal(b, app.Name, bApp.Name())
 
@@ -99,7 +99,7 @@ func BenchmarkInvariants(b *testing.B) {
 	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
-	bApp, err := app.New(logger, db, nil, true, appOptions, app.EVMAppOptions, nil, interBlockCacheOpt())
+	bApp, err := app.New(logger, db, nil, true, appOptions, nil, interBlockCacheOpt())
 	require.NoError(b, err)
 	require.Equal(b, app.Name, bApp.Name())
 

--- a/warden/app/sim_test.go
+++ b/warden/app/sim_test.go
@@ -84,7 +84,7 @@ func BenchmarkSimulation(b *testing.B) {
 	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
-	bApp, err := app.New(logger, db, nil, true, appOptions, app.EVMAppOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	bApp, err := app.New(logger, db, nil, true, appOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.NoError(b, err)
 	require.Equal(b, app.Name, bApp.Name())
 
@@ -131,7 +131,7 @@ func TestAppImportExport(t *testing.T) {
 	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
-	bApp, err := app.New(logger, db, nil, true, appOptions, app.EVMAppOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	bApp, err := app.New(logger, db, nil, true, appOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.NoError(t, err)
 	require.Equal(t, app.Name, bApp.Name())
 
@@ -172,7 +172,7 @@ func TestAppImportExport(t *testing.T) {
 		require.NoError(t, os.RemoveAll(newDir))
 	}()
 
-	newApp, err := app.New(log.NewNopLogger(), newDB, nil, true, appOptions, app.EVMAppOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	newApp, err := app.New(log.NewNopLogger(), newDB, nil, true, appOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.NoError(t, err)
 	require.Equal(t, app.Name, newApp.Name())
 
@@ -254,7 +254,7 @@ func TestAppSimulationAfterImport(t *testing.T) {
 	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
-	bApp, err := app.New(logger, db, nil, true, appOptions, app.EVMAppOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	bApp, err := app.New(logger, db, nil, true, appOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.NoError(t, err)
 	require.Equal(t, app.Name, bApp.Name())
 
@@ -300,7 +300,7 @@ func TestAppSimulationAfterImport(t *testing.T) {
 		require.NoError(t, os.RemoveAll(newDir))
 	}()
 
-	newApp, err := app.New(log.NewNopLogger(), newDB, nil, true, appOptions, app.EVMAppOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	newApp, err := app.New(log.NewNopLogger(), newDB, nil, true, appOptions, nil, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.NoError(t, err)
 	require.Equal(t, app.Name, newApp.Name())
 
@@ -347,7 +347,7 @@ func TestAppStateDeterminism(t *testing.T) {
 	appOptions := viper.New()
 
 	if FlagEnableStreamingValue {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 		m["streaming.abci.keys"] = []string{"*"}
 		m["streaming.abci.plugin"] = "abci_v1"
 		m["streaming.abci.stop-node-on-err"] = true
@@ -389,7 +389,6 @@ func TestAppStateDeterminism(t *testing.T) {
 				nil,
 				true,
 				appOptions,
-				app.EVMAppOptions,
 				nil,
 				interBlockCacheOpt(),
 				baseapp.SetChainID(chainID),


### PR DESCRIPTION
I removed `app.EVMAppOptions` that was mapping chain ids into coin types, in favor of hardcoding the values of the coin (`award`, 18 decimals).

We couldn't run devnet or other chains as their chain ids was not being mapped to a coin type.