### PR TITLE
feat: remove deprecated module x/crisis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (x/async) Task can return errors instead of outputs, one of "output" or "error" fields will be set
 - (x/async) Add PruneTaskTimeout param. After a task is completed (i.e. has a result) it will be permanently deleted from the appdb after this timeout elapses.
 - (x/async) Add Plugin's timeout param. This is the maximum time a solver has for submitting the result before the Task is marked as errored automatically.
+- (x/crisis) Remove deprecated x/crisis module. See https://github.com/cosmos/cosmos-sdk/pull/23722. Will be removed in Cosmos SDK v0.54.
 
 ### Bug Fixes
 

--- a/cmd/wardend/cmd/commands.go
+++ b/cmd/wardend/cmd/commands.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/cosmos/cosmos-sdk/x/crisis"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
@@ -94,7 +93,6 @@ func AddTendermintCommandAlias(rootCmd *cobra.Command) {
 }
 
 func addModuleInitFlags(startCmd *cobra.Command) {
-	crisis.AddModuleInitFlags(startCmd)
 }
 
 // Analog of sdk's CommandsWithCustomMigrationMap without AddGenesisAccountCmd, that should be embedded separately.

--- a/localnet.just
+++ b/localnet.just
@@ -86,7 +86,7 @@ start bin="wardend" install="true":
       fi
     }
 
-    (post_start &) && {{bin}} start --x-crisis-skip-assert-invariants
+    (post_start &) && {{bin}} start
 
 start-2 bin="wardend" install="true":
     #!/usr/bin/env bash
@@ -157,7 +157,7 @@ start-2 bin="wardend" install="true":
 
     echo "run \"wardend --home ~/.warden-val2 start\" to start node 2"
     node2_id=$({{bin}} comet show-node-id --home ~/.warden-val2)
-    {{bin}} start --x-crisis-skip-assert-invariants --p2p.persistent_peers $node2_id@127.0.0.1:26696
+    {{bin}} start --p2p.persistent_peers $node2_id@127.0.0.1:26696
 
 
 # deploy a .wasm binary to the chain and return the contract address

--- a/tests/framework/exec/warden_node.go
+++ b/tests/framework/exec/warden_node.go
@@ -85,7 +85,7 @@ func (w *WardenNode) Start(t *testing.T, snapshot string) {
 
 	p.Free(t)
 
-	err = w.run(t.Context(), "--log_no_color", "start", "--home", w.Home, "--x-crisis-skip-assert-invariants")
+	err = w.run(t.Context(), "--log_no_color", "start", "--home", w.Home)
 	if errors.Is(t.Context().Err(), context.Canceled) {
 		return
 	}

--- a/tests/testdata/snapshot-base/config/genesis.json
+++ b/tests/testdata/snapshot-base/config/genesis.json
@@ -92,12 +92,6 @@
       "disabled_type_urls": []
     },
     "consensus": null,
-    "crisis": {
-      "constant_fee": {
-        "denom": "award",
-        "amount": "1000"
-      }
-    },
     "distribution": {
       "params": {
         "community_tax": "0.020000000000000000",

--- a/tests/testdata/snapshot-keychain/config/genesis.json
+++ b/tests/testdata/snapshot-keychain/config/genesis.json
@@ -124,12 +124,6 @@
       "disabled_type_urls": []
     },
     "consensus": null,
-    "crisis": {
-      "constant_fee": {
-        "denom": "award",
-        "amount": "1000"
-      }
-    },
     "distribution": {
       "params": {
         "community_tax": "0.020000000000000000",

--- a/tests/testdata/snapshot-many-users/config/genesis.json
+++ b/tests/testdata/snapshot-many-users/config/genesis.json
@@ -124,12 +124,6 @@
       "disabled_type_urls": []
     },
     "consensus": null,
-    "crisis": {
-      "constant_fee": {
-        "denom": "award",
-        "amount": "1000"
-      }
-    },
     "distribution": {
       "params": {
         "community_tax": "0.020000000000000000",

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -41,7 +41,6 @@ import (
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	consensuskeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
-	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
@@ -131,7 +130,6 @@ type App struct {
 	MintKeeper            mintkeeper.Keeper
 	DistrKeeper           distrkeeper.Keeper
 	GovKeeper             *govkeeper.Keeper
-	CrisisKeeper          *crisiskeeper.Keeper
 	UpgradeKeeper         *upgradekeeper.Keeper
 	ParamsKeeper          paramskeeper.Keeper
 	AuthzKeeper           authzkeeper.Keeper
@@ -404,7 +402,6 @@ func New(
 		&app.MintKeeper,
 		&app.DistrKeeper,
 		&app.GovKeeper,
-		&app.CrisisKeeper,
 		&app.UpgradeKeeper,
 		&app.ParamsKeeper,
 		&app.AuthzKeeper,
@@ -506,8 +503,6 @@ func New(
 	}
 
 	/****  Module Options ****/
-
-	app.ModuleManager.RegisterInvariants(app.CrisisKeeper)
 
 	// add test gRPC service for testing gRPC queries in isolation
 	testdata_pulsar.RegisterQueryServer(app.GRPCQueryRouter(), testdata_pulsar.QueryImpl{})

--- a/warden/app/app_config.go
+++ b/warden/app/app_config.go
@@ -10,7 +10,6 @@ import (
 	bankmodulev1 "cosmossdk.io/api/cosmos/bank/module/v1"
 	circuitmodulev1 "cosmossdk.io/api/cosmos/circuit/module/v1"
 	consensusmodulev1 "cosmossdk.io/api/cosmos/consensus/module/v1"
-	crisismodulev1 "cosmossdk.io/api/cosmos/crisis/module/v1"
 	distrmodulev1 "cosmossdk.io/api/cosmos/distribution/module/v1"
 	evidencemodulev1 "cosmossdk.io/api/cosmos/evidence/module/v1"
 	feegrantmodulev1 "cosmossdk.io/api/cosmos/feegrant/module/v1"
@@ -48,8 +47,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	_ "github.com/cosmos/cosmos-sdk/x/consensus" // import for side-effects
 	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
-	_ "github.com/cosmos/cosmos-sdk/x/crisis" // import for side-effects
-	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	_ "github.com/cosmos/cosmos-sdk/x/distribution" // import for side-effects
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
@@ -126,7 +123,6 @@ var (
 		slashingtypes.ModuleName,
 		govtypes.ModuleName,
 		minttypes.ModuleName,
-		crisistypes.ModuleName,
 		ibcexported.ModuleName,
 		// evm modules
 		evmtypes.ModuleName,
@@ -202,7 +198,6 @@ var (
 
 	endBlockers = []string{
 		// cosmos sdk modules
-		crisistypes.ModuleName,
 		govtypes.ModuleName,
 		stakingtypes.ModuleName,
 		feegrant.ModuleName,
@@ -382,10 +377,6 @@ func moduleConfig() depinject.Config {
 				{
 					Name:   govtypes.ModuleName,
 					Config: appconfig.WrapAny(&govmodulev1.Module{}),
-				},
-				{
-					Name:   crisistypes.ModuleName,
-					Config: appconfig.WrapAny(&crisismodulev1.Module{}),
 				},
 				{
 					Name:   consensustypes.ModuleName,

--- a/warden/app/export.go
+++ b/warden/app/export.go
@@ -69,9 +69,6 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		allowedAddrsMap[addr] = true
 	}
 
-	/* Just to be safe, assert the invariants on current state. */
-	app.CrisisKeeper.AssertInvariants(ctx)
-
 	/* Handle fee distribution state. */
 
 	// withdraw all validator commission

--- a/warden/app/sim_bench_test.go
+++ b/warden/app/sim_bench_test.go
@@ -1,11 +1,9 @@
 package app_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
-	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
@@ -70,79 +68,5 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 
 	if config.Commit {
 		simtestutil.PrintStats(db)
-	}
-}
-
-func BenchmarkInvariants(b *testing.B) {
-	b.ReportAllocs()
-
-	config := simcli.NewConfigFromFlags()
-	config.ChainID = SimAppChainID
-
-	db, dir, logger, skip, err := simtestutil.SetupSimulation(config, "leveldb-app-invariant-bench", "Simulation", simcli.FlagVerboseValue, simcli.FlagEnabledValue)
-	if err != nil {
-		b.Fatalf("simulation setup failed: %s", err.Error())
-	}
-
-	if skip {
-		b.Skip("skipping benchmark application simulation")
-	}
-
-	config.AllInvariants = false
-
-	defer func() {
-		require.NoError(b, db.Close())
-		require.NoError(b, os.RemoveAll(dir))
-	}()
-
-	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
-	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-
-	bApp, err := app.New(logger, db, nil, true, appOptions, nil, interBlockCacheOpt())
-	require.NoError(b, err)
-	require.Equal(b, app.Name, bApp.Name())
-
-	// run randomized simulation
-	_, simParams, simErr := simulation.SimulateFromSeed(
-		b,
-		os.Stdout,
-		bApp.BaseApp,
-		simtestutil.AppStateFn(bApp.AppCodec(), bApp.SimulationManager(), bApp.DefaultGenesis()),
-		simtypes.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
-		app.BlockedAddresses(),
-		config,
-		bApp.AppCodec(),
-	)
-
-	// export state and simParams before the simulation error is checked
-	if err = simtestutil.CheckExportSimulation(bApp, config, simParams); err != nil {
-		b.Fatal(err)
-	}
-
-	if simErr != nil {
-		b.Fatal(simErr)
-	}
-
-	if config.Commit {
-		simtestutil.PrintStats(db)
-	}
-
-	ctx := bApp.NewContextLegacy(true, cmtproto.Header{Height: bApp.LastBlockHeight() + 1})
-
-	// 3. Benchmark each invariant separately
-	//
-	// NOTE: We use the crisis keeper as it has all the invariants registered with
-	// their respective metadata which makes it useful for testing/benchmarking.
-	for _, cr := range bApp.CrisisKeeper.Routes() {
-		b.Run(fmt.Sprintf("%s/%s", cr.ModuleName, cr.Route), func(b *testing.B) {
-			if res, stop := cr.Invar(ctx); stop {
-				b.Fatalf(
-					"broken invariant at block %d of %d\n%s",
-					ctx.BlockHeight()-1, config.NumBlocks, res,
-				)
-			}
-		})
 	}
 }


### PR DESCRIPTION
Removing x/crisis as it's being deprecated and going to be removed in the next version of Cosmos SDK.

See https://github.com/cosmos/cosmos-sdk/blob/b86275242a183c0919398edbaa0042f7ac0e4d06/x/crisis/README.md?plain=1#L7
 and https://github.com/cosmos/cosmos-sdk/pull/23722

Closes ENG-212.