### PR TITLE
fix(ci): adds the packages which are missing

### DIFF
--- a/cmd/wardend/.goreleaser.yaml
+++ b/cmd/wardend/.goreleaser.yaml
@@ -24,6 +24,8 @@ builds:
               echo "checksum mismatch!" >&2
               exit 1
             fi
+            apt-get update
+            apt-get install -y musl-dev gcc musl-tools libc6-dev-amd64-cross
             cp /usr/x86_64-linux-gnu/lib/libm-2.31.a /usr/lib/x86_64-linux-gnu/libm-2.31.a
             cp /usr/x86_64-linux-gnu/lib/libmvec.a /usr/lib/x86_64-linux-gnu/libmvec.a
           '


### PR DESCRIPTION
This fixes the issue where the packages were missing from the container. It works without the cp commands but I left those in for the local building.