### PR TITLE
Update Fusion Chain GitHub link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ With the exception of the SpaceWard folder and the x/async module, this project
 is released under the terms of the Apache 2.0 License - see [LICENSE](./LICENSE) 
 for details.
 
+Elements of this project are based on the work made by Qredo Ltd on 
+Fusion Chain and were released under 
+the Apache 2 license. See [NOTICE](./NOTICE) for more details.
+
 **IMPORTANT EXCEPTION:**
 
 The following module(s) included in this repository are **NOT** covered by the 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ is released under the terms of the Apache 2.0 License - see [LICENSE](./LICENSE)
 for details.
 
 Elements of this project are based on the work made by Qredo Ltd on 
-[Fusion Chain](https://github.com/qredo/fusionchain) and were released under 
+[Fusion Chain](https://github.com/sashaduke/fusionchain) and were released under 
 the Apache 2 license. See [NOTICE](./NOTICE) for more details.
 
 **IMPORTANT EXCEPTION:**

--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ With the exception of the SpaceWard folder and the x/async module, this project
 is released under the terms of the Apache 2.0 License - see [LICENSE](./LICENSE) 
 for details.
 
-Elements of this project are based on the work made by Qredo Ltd on 
-[Fusion Chain](https://github.com/sashaduke/fusionchain) and were released under 
-the Apache 2 license. See [NOTICE](./NOTICE) for more details.
-
 **IMPORTANT EXCEPTION:**
 
 The following module(s) included in this repository are **NOT** covered by the 


### PR DESCRIPTION
Replaced the outdated Fusion Chain repository link (https://github.com/qredo/fusionchain) with the current working URL (https://github.com/sashaduke/fusionchain) in the README file to ensure users can access the correct source.