### PR TITLE
Fix Typos in UI Text and Error Messages

### DIFF
--- a/spaceward/src/features/modals/CreateKey.tsx
+++ b/spaceward/src/features/modals/CreateKey.tsx
@@ -162,7 +162,7 @@ export default function CreateKeyModal({
 						<div>1,234</div>
 					</div>
 					<div className="flex items-center justify-between py-1">
-						<div>Last actvity</div>
+						<div>Last activity</div>
 						<div>Use this Keychain</div>
 					</div>
 				</div> */}

--- a/spaceward/src/utils/contract.tsx
+++ b/spaceward/src/utils/contract.tsx
@@ -56,7 +56,7 @@ export async function assertChain(
 			toastResult = toast({
 				title: "Error",
 				description:
-					(e as any)?.message ?? "An unexpected error has occured",
+					(e as any)?.message ?? "An unexpected error has occurred",
 				action: <a href={`https://chainlist.org/chain/${id}`} target="_blank" onClick={() => toastResult.dismiss()}>ChainList</a>,
 				duration: 999999,
 			});
@@ -118,7 +118,7 @@ export async function handleContractWrite(
 			id,
 			title: TxStatus.Failed,
 			description:
-				(e as any)?.message ?? "An unexpected error has occured",
+				(e as any)?.message ?? "An unexpected error has occurred",
 		});
 
 		throw e;


### PR DESCRIPTION


Description:
- Corrected the spelling of "activity" in the CreateKey modal.
- Fixed the typo "occured" to "occurred" in error messages within contract utilities.
- Minor improvements for better user experience and clarity.