### PR TITLE
fix(x/sched): build valid sdk.Coins when callback fees are zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (x/async) Add PruneTaskTimeout param. After a task is completed (i.e. has a result) it will be permanently deleted from the appdb after this timeout elapses.
 - (x/async) Add Plugin's timeout param. This is the maximum time a solver has for submitting the result before the Task is marked as errored automatically.
 - (x/crisis) Remove deprecated x/crisis module. See https://github.com/cosmos/cosmos-sdk/pull/23722. Will be removed in Cosmos SDK v0.54.
+- (x/sched) Fix a bug leading to invalid sdk.Coins when callback fees were zero
 
 ### Bug Fixes
 

--- a/warden/x/sched/keeper/keeper.go
+++ b/warden/x/sched/keeper/keeper.go
@@ -309,7 +309,7 @@ func (k Keeper) callbackFee(ctx context.Context, gas uint64) (*uint256.Int, sdk.
 	baseFee := evmKeeper.GetBaseFee(sdkCtx)
 	gasInt := new(big.Int).SetUint64(gas)
 	feeAmt := new(big.Int).Mul(baseFee, gasInt)
-	fee := sdk.Coins{{Denom: params.EvmDenom, Amount: sdkmath.NewIntFromBigInt(feeAmt)}}
+	fee := sdk.NewCoins(sdk.NewCoin(params.EvmDenom, sdkmath.NewIntFromBigInt(feeAmt)))
 
 	feeAmtUint256 := new(uint256.Int)
 	feeAmtUint256.SetFromBig(feeAmt)


### PR DESCRIPTION
Fix a bug leading to an invalid `sdk.Coins` object, where the fee amount was zero. By using the  provided constructors, we are sure we are building a valid `sdk.Coins` in every case.