### PR TITLE
fix(x/async): missing Solver field in precompile queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- (x/async) Fix missing Solver field in precompile queries
+
 ## [v0.6.3](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.6.3) - 2025-04-16
 
 ### Features (non-breaking)

--- a/precompiles/async/types.go
+++ b/precompiles/async/types.go
@@ -161,6 +161,7 @@ func mapTask(task types.Task) (Task, error) {
 			ExecutorReward:      mapSdkCoins(task.Fee.ExecutorReward),
 		},
 		CallbackId: task.CallbackId,
+		Solver:     task.Solver,
 		CreatedAt:  mapTimestamp(task.CreatedAt),
 	}, nil
 }


### PR DESCRIPTION
Queries made through x/async precompile were not returning the solver address.