### PR TITLE
Update Archway CosmWasm documentation link to the correct URL

### DIFF
--- a/docs/developer-docs/docs/build-an-app/deploy-smart-contracts-on-warden/useful-links.md
+++ b/docs/developer-docs/docs/build-an-app/deploy-smart-contracts-on-warden/useful-links.md
@@ -20,7 +20,7 @@ sidebar_position: 4
   - [Documentation for the storage helpers](https://docs.rs/cosmwasm-storage/latest/cosmwasm_storage/index.html)
 - **CosmWasm guides and examples**
   - [Awesome CosmWasm: a collection of resources](https://github.com/CosmWasm/awesome-cosmwasm)
-  - [Guides by Archway](https://docs.archway.io/developers/cosmwasm-documentation/introduction)
+  - [Guides by Archway](https://docs.archway.io/developers/smart-contracts/introduction)
   - [Creating CosmWasm contracts with sylvia](https://cosmwasm.github.io/sylvia-book/)
   - [Area-52: CosmWasm courses](https://area-52.io/)
   - [Examples of CosmWasm contracts by Deus Labs](https://github.com/deus-labs/cw-contracts)


### PR DESCRIPTION
Replaced the outdated/broken Archway CosmWasm documentation link in the useful links section with the current and correct URL: https://docs.archway.io/developers/smart-contracts/introduction. This ensures users are directed to the latest official resources for developing CosmWasm smart contracts on Archway.