### PR TITLE
fix(docs): update broken internal links in HTTP plugin introduction

### DIFF
--- a/docs/developer-docs/docs/build-an-app/run-offchain-computations/use-the-http-plugin/introduction.md
+++ b/docs/developer-docs/docs/build-an-app/run-offchain-computations/use-the-http-plugin/introduction.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 You can make **HTTP requests** to **any external API** from your smart contract, receive responses asynchronously, and process the data within the contract.
 
-To achieve this, call the [`x/async` precompile](../../precompiles/x-async) and use the `http` [AVR Plugin](/learn/warden-protocol-modules/x-async#avr-plugins). The `http` Plugin supports multiple APIs, so in this sense it includes multiple AVRs.
+To achieve this, call the [`x/async` precompile](../../precompiles/x-async.md) and use the `http` [AVR Plugin](/learn/warden-protocol-modules/x-async#avr-plugins). The `http` Plugin supports multiple APIs, so in this sense it includes multiple AVRs.
 
 Follow tutorials in this section to learn how to do the following:
 
@@ -18,10 +18,10 @@ Follow tutorials in this section to learn how to do the following:
 
 ## JSON parsing
 
-Responses from HTTP requests are returned as JSON data. To extract specific values from these responses, you can use the [JSON precompile](../../precompiles/json), which provides a convenient way to parse JSON data within your smart contract.
+Responses from HTTP requests are returned as JSON data. To extract specific values from these responses, you can use the [JSON precompile](../../precompiles/json.md), which provides a convenient way to parse JSON data within your smart contract.
 
-Parsing data requires using the [`read()` function](../../precompiles/json#get-multiple-values) of the precompile, as shown in [Extract data](extract-data).
+Parsing data requires using the [`read()` function](../../precompiles/json.md#get-multiple-values) of the precompile, as shown in [Extract data](extract-data.md).
 
 ## Get started
 
-To get started, [set up your environment](set-up-the-environment).
+To get started, [set up your environment](set-up-the-environment.md).


### PR DESCRIPTION
Updated all outdated or broken internal documentation links in `use-the-http-plugin/introduction.md` to point to the correct files and anchors. This ensures all references to precompiles, JSON parsing, and setup guides are accurate and functional.