### PR TITLE
fix(wardend): manually register cosmos/evm codec types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (x/async) Initial version of a Venice.ai plugin for LLM completions
 - (x/async) PFP image generation plugin using Venice.ai
 - (wardend) Fixed EVM initialization on chain id different than "warden-1337_1"
+- (wardend) Use upstream cosmos-sdk instead of our fork
 
 ### Consensus Breaking Changes
 

--- a/cmd/wardend/cmd/root.go
+++ b/cmd/wardend/cmd/root.go
@@ -146,6 +146,7 @@ func ProvideClientContext(
 	txConfig client.TxConfig,
 	legacyAmino *codec.LegacyAmino,
 ) client.Context {
+	app.RegisterEVMCodec(legacyAmino, interfaceRegistry)
 	clientCtx := client.Context{}.
 		WithCodec(appCodec).
 		WithInterfaceRegistry(interfaceRegistry).

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ replace (
 	// Pin this pebble version to avoid breaking compilation of geth
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593
 	// evm integration
-	github.com/cosmos/cosmos-sdk => github.com/warden-protocol/cosmos-sdk v0.53.2-warden-evm
 	github.com/cosmos/evm => github.com/warden-protocol/evm v1.0.0-rc2-warden
 	github.com/cosmos/evm/evmd => github.com/cosmos/evm/evmd v0.0.0-20250613235838-578b3468a80b
 

--- a/go.sum
+++ b/go.sum
@@ -939,6 +939,8 @@ github.com/cosmos/cosmos-db v1.1.3 h1:7QNT77+vkefostcKkhrzDK9uoIEryzFrU9eoMeaQOP
 github.com/cosmos/cosmos-db v1.1.3/go.mod h1:kN+wGsnwUJZYn8Sy5Q2O0vCYA99MJllkKASbs6Unb9U=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
+github.com/cosmos/cosmos-sdk v0.53.2 h1:QUok0dUzdxZedwunZ7N1GgJrctaGGGO8DUnKqkVRf1k=
+github.com/cosmos/cosmos-sdk v0.53.2/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
 github.com/cosmos/evm/evmd v0.0.0-20250613235838-578b3468a80b h1:nfs8tok0wSKpm7HRWoYD8YtI8aeI8vfDWi8wshoctGU=
 github.com/cosmos/evm/evmd v0.0.0-20250613235838-578b3468a80b/go.mod h1:nZthZXnzj6S1VDYTvFp3ITQm7kfyCMsHeI8Q6O8SLVU=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
@@ -1900,8 +1902,6 @@ github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnn
 github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/warden-protocol/connect v1.2.2 h1:00nfcbnCI0bhHdg3KrDCLx10RyO0mLCkJYf0chvze/Y=
 github.com/warden-protocol/connect v1.2.2/go.mod h1:ZiS2VuO4pC90hfsvpLr8TvcQds6xDaczB3EKdFbm2pM=
-github.com/warden-protocol/cosmos-sdk v0.53.2-warden-evm h1:xW5aKodIXTGUJo03jwaPPAezZ8C8TJ2d9yZYBmdHD14=
-github.com/warden-protocol/cosmos-sdk v0.53.2-warden-evm/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
 github.com/warden-protocol/evm v1.0.0-rc2-warden h1:GsPC2y15U/57SadQLsBfocIVBtY9VwYf+xrwz2bzk+E=
 github.com/warden-protocol/evm v1.0.0-rc2-warden/go.mod h1:p0noo/TdImnDfr9HjAAVHE0GBEKQZ+KbCJ8Zfbpyi+A=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/warden/app/config.go
+++ b/warden/app/config.go
@@ -7,7 +7,12 @@ import (
 	"strings"
 
 	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/evm/crypto/ethsecp256k1"
+	evmcodec "github.com/cosmos/evm/encoding/codec"
 	"github.com/cosmos/evm/ethereum/eip712"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 )
@@ -19,6 +24,16 @@ var coinInfo = evmtypes.EvmCoinInfo{
 	ExtendedDenom: "award",
 	DisplayDenom:  "WARD",
 	Decimals:      evmtypes.EighteenDecimals,
+}
+
+func RegisterEVMCodec(legacyAmino *codec.LegacyAmino, interfaceRegistry codectypes.InterfaceRegistry) {
+	legacyAmino.RegisterConcrete(&ethsecp256k1.PubKey{},
+		ethsecp256k1.PubKeyName, nil)
+	legacyAmino.RegisterConcrete(&ethsecp256k1.PrivKey{},
+		ethsecp256k1.PrivKeyName, nil)
+	legacy.Cdc = legacyAmino
+
+	evmcodec.RegisterInterfaces(interfaceRegistry)
 }
 
 func (app *App) setupEVM() error {


### PR DESCRIPTION
This PR removes the need our cosmos-sdk fork.

The only thing missing was to register some codec, we have to do it "manually" both in `root.go` (when building the client context) and in `app.go` (when preparing the `App`), but from my brief testing it looks like the chain starts and I can send transactions as usual.

Closes ENG-40