### PR TITLE
fix(precompiles): deprecate ParseSdkEvent and add a safer version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,6 +84,16 @@ linters:
         rules:
           json: snake
           yaml: snake
+    staticcheck:
+      checks:
+        - "all"
+        - "-ST1000"
+        - "-ST1003"
+        - "-ST1016"
+        - "-ST1020"
+        - "-ST1021"
+        - "-ST1022"
+        - "-SA1019"
   exclusions:
     generated: lax
     presets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Consensus Breaking Changes
 
 - (x/warden) Change the way Keychain's addresses are generated. They now are 20-bytes long to be compatible with EVM.
+- (precompiles) Fix panics when dealing with NewKeychainEvent and UpdateKeychainEvent from the x/warden precompiled contract.
 
 ### Features (non-breaking)
 

--- a/precompiles/act/events.go
+++ b/precompiles/act/events.go
@@ -63,7 +63,7 @@ func parseCreateTemplateEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 
 	typedEvent := v1beta1.EventCreateTemplate{}
 
-	err := common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge)
+	err := common.ParseSdkEventDeprecated(sdkEvent, typedEvent.XXX_Merge)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func parseUpdateTemplateEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 
 	typedEvent := v1beta1.EventUpdateTemplate{}
 
-	err := common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge)
+	err := common.ParseSdkEventDeprecated(sdkEvent, typedEvent.XXX_Merge)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func parseCreateActionEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 
 	typedEvent := v1beta1.EventCreateAction{}
 
-	err := common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge)
+	err := common.ParseSdkEventDeprecated(sdkEvent, typedEvent.XXX_Merge)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func parseActionVotedEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 
 	typedEvent := v1beta1.EventActionVoted{}
 
-	err := common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge)
+	err := common.ParseSdkEventDeprecated(sdkEvent, typedEvent.XXX_Merge)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func parseActionStateChangeEvent(sdkEvent sdk.Event) (*bytes.Buffer, error) {
 
 	typedEvent := v1beta1.EventActionStateChange{}
 
-	err := common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge)
+	err := common.ParseSdkEventDeprecated(sdkEvent, typedEvent.XXX_Merge)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/async/events.go
+++ b/precompiles/async/events.go
@@ -25,7 +25,7 @@ func (p *Precompile) GetCreateTaskEvent(ctx sdk.Context, writerAddress *ethcmn.A
 	topics[0] = event.ID
 
 	typedEvent := v1beta1.EventCreateTask{}
-	if err = common.ParseSdkEvent(sdkEvent, typedEvent.XXX_Merge); err != nil {
+	if err = common.ParseSdkEventDeprecated(sdkEvent, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 

--- a/precompiles/common/events.go
+++ b/precompiles/common/events.go
@@ -1,14 +1,17 @@
 package common
 
 import (
+	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
 )
 
+// Deprecated: use ParseSdkEvent instead.
+//
 // Takes sdk.Event as proto msg, passes it to fillEvent.
 // fillEvent should create typed event for caller.
-func ParseSdkEvent(sdkEvent sdk.Event, fillEvent func(proto.Message)) error {
-	return ParseSdkEventSafe(sdkEvent, func(msg proto.Message) error {
+func ParseSdkEventDeprecated(sdkEvent sdk.Event, fillEvent func(proto.Message)) error {
+	return parseSdkEventSafeInternal(sdkEvent, func(msg proto.Message) error {
 		fillEvent(msg)
 		return nil
 	})
@@ -16,7 +19,7 @@ func ParseSdkEvent(sdkEvent sdk.Event, fillEvent func(proto.Message)) error {
 
 // Takes sdk.Event as proto msg, passes it to fillEvent.
 // fillEvent should create typed event for caller.
-func ParseSdkEventSafe(sdkEvent sdk.Event, fillEvent func(proto.Message) error) error {
+func parseSdkEventSafeInternal(sdkEvent sdk.Event, fillEvent func(proto.Message) error) error {
 	events := sdk.EmptyEvents().AppendEvent(sdkEvent).ToABCIEvents()
 	event := events[0]
 
@@ -26,4 +29,11 @@ func ParseSdkEventSafe(sdkEvent sdk.Event, fillEvent func(proto.Message) error) 
 	}
 
 	return fillEvent(msg)
+}
+
+func ParseSdkEvent(sdkEvent sdk.Event) (proto.Message, error) {
+	return sdk.ParseTypedEvent(abci.Event{
+		Type:       sdkEvent.Type,
+		Attributes: sdkEvent.Attributes,
+	})
 }

--- a/precompiles/warden/events.go
+++ b/precompiles/warden/events.go
@@ -7,7 +7,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	evmcmn "github.com/cosmos/evm/precompiles/common"
-	"github.com/cosmos/gogoproto/proto"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
@@ -66,7 +65,7 @@ func (p Precompile) GetAddKeychainAdminEvent(ctx sdk.Context, adminAddress *comm
 	var b bytes.Buffer
 
 	typedEvent := wardentypes.EventAddKeychainAdmin{}
-	if err := precommon.ParseSdkEvent(eventAddKeychainAdmin, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(eventAddKeychainAdmin, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -109,7 +108,7 @@ func (p Precompile) GetAddKeychainWriterEvent(ctx sdk.Context, writerAddress *co
 	var b bytes.Buffer
 
 	typedEvent := wardentypes.EventAddKeychainWriter{}
-	if err := precommon.ParseSdkEvent(eventAddKeychainWriter, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(eventAddKeychainWriter, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -145,10 +144,11 @@ func (p Precompile) GetNewKeyEvent(ctx sdk.Context, _ *common.Address, eventNewK
 	// The first topic is always the signature of the event.
 	topics[0] = event.ID
 
-	typedEvent := wardentypes.EventNewKey{}
-	if err := precommon.ParseSdkEvent(eventNewKey, typedEvent.XXX_Merge); err != nil {
+	protoEvent, err := precommon.ParseSdkEvent(eventNewKey)
+	if err != nil {
 		return nil, err
 	}
+	typedEvent := protoEvent.(*wardentypes.EventNewKey)
 
 	packed, err := event.Inputs.NonIndexed().Pack(
 		uint8(typedEvent.GetKeyType()),
@@ -186,7 +186,7 @@ func (p Precompile) GetRejectKeyRequestEvent(ctx sdk.Context, _ *common.Address,
 	topics[0] = event.ID
 
 	typedEvent := wardentypes.EventRejectKeyRequest{}
-	if err := precommon.ParseSdkEvent(eventRejectKeyRequest, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(eventRejectKeyRequest, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -216,7 +216,7 @@ func (p Precompile) GetFulfilSignRequestEvent(ctx sdk.Context, _ *common.Address
 	topics[0] = event.ID
 
 	typedEvent := wardentypes.EventFulfilSignRequest{}
-	if err := precommon.ParseSdkEvent(eventFulfilSignRequest, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(eventFulfilSignRequest, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -246,7 +246,7 @@ func (p Precompile) GetRejectSignRequestEvent(ctx sdk.Context, _ *common.Address
 	topics[0] = event.ID
 
 	typedEvent := wardentypes.EventRejectSignRequest{}
-	if err := precommon.ParseSdkEvent(eventRejectSignRequest, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(eventRejectSignRequest, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -282,10 +282,11 @@ func (p Precompile) GetNewKeychainEvent(ctx sdk.Context, creator *common.Address
 
 	var b bytes.Buffer
 
-	typedEvent := wardentypes.EventNewKeychain{}
-	if err = precommon.ParseSdkEvent(eventNewKeychain, typedEvent.XXX_Merge); err != nil {
+	protoEvent, err := precommon.ParseSdkEvent(eventNewKeychain)
+	if err != nil {
 		return nil, err
 	}
+	typedEvent := protoEvent.(*wardentypes.EventNewKeychain)
 
 	b.Write(append(make([]byte, 12), creator.Bytes()...))
 
@@ -321,7 +322,7 @@ func (p Precompile) GetNewSpaceEvent(ctx sdk.Context, creator *common.Address, e
 	var b bytes.Buffer
 
 	typedEvent := wardentypes.EventCreateSpace{}
-	if err = precommon.ParseSdkEvent(eventNewSpace, typedEvent.XXX_Merge); err != nil {
+	if err = precommon.ParseSdkEventDeprecated(eventNewSpace, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -364,7 +365,7 @@ func (p Precompile) GetRemoveKeychainAdminEvent(ctx sdk.Context, admin *common.A
 	var b bytes.Buffer
 
 	typedEvent := wardentypes.EventRemoveKeychainAdmin{}
-	if err = precommon.ParseSdkEvent(eventRemoveKeychainAdmin, typedEvent.XXX_Merge); err != nil {
+	if err = precommon.ParseSdkEventDeprecated(eventRemoveKeychainAdmin, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -402,19 +403,14 @@ func (p Precompile) GetUpdateKeychainEvent(ctx sdk.Context, _ *common.Address, e
 
 	var b bytes.Buffer
 
-	typedEvent := wardentypes.EventUpdateKeychain{}
-
 	// use Marshal/Unmarshal here cause big.Word=uint inside big.Int is not correctly merged in cosmos.gogoproto
 	var err error
 
-	var marshaled []byte
-
-	if err := precommon.ParseSdkEventSafe(eventUpdateKeychain, func(m proto.Message) error {
-		marshaled, err = proto.Marshal(m)
-		return typedEvent.Unmarshal(marshaled)
-	}); err != nil {
+	protoEvent, err := precommon.ParseSdkEvent(eventUpdateKeychain)
+	if err != nil {
 		return nil, err
 	}
+	typedEvent := protoEvent.(*wardentypes.EventUpdateKeychain)
 
 	topics[1], err = evmcmn.MakeTopic(typedEvent.GetId())
 	if err != nil {
@@ -450,7 +446,7 @@ func (p Precompile) GetAddSpaceOwnerEvent(ctx sdk.Context, _ *common.Address, ad
 	var b bytes.Buffer
 
 	typedEvent := wardentypes.EventAddSpaceOwner{}
-	if err := precommon.ParseSdkEvent(addSpaceOwnerEvent, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(addSpaceOwnerEvent, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -486,7 +482,7 @@ func (p Precompile) GetRemoveSpaceOwnerEvent(ctx sdk.Context, _ *common.Address,
 	var b bytes.Buffer
 
 	typedEvent := wardentypes.EventRemoveSpaceOwner{}
-	if err := precommon.ParseSdkEvent(removeSpaceOwnerEvent, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(removeSpaceOwnerEvent, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -522,7 +518,7 @@ func (p Precompile) GetNewKeyRequestEvent(ctx sdk.Context, _ *common.Address, ne
 	var b bytes.Buffer
 
 	typedEvent := wardentypes.EventNewKeyRequest{}
-	if err := precommon.ParseSdkEvent(newKeyRequestEvent, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(newKeyRequestEvent, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -563,7 +559,7 @@ func (p Precompile) GetNewSignRequestEvent(ctx sdk.Context, _ *common.Address, n
 	var b bytes.Buffer
 
 	typedEvent := wardentypes.EventNewSignRequest{}
-	if err := precommon.ParseSdkEvent(newSignRequestEvent, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(newSignRequestEvent, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -598,7 +594,7 @@ func (p Precompile) GetUpdateKeyEvent(ctx sdk.Context, _ *common.Address, update
 	topics[0] = event.ID
 
 	typedEvent := wardentypes.EventUpdateKey{}
-	if err := precommon.ParseSdkEvent(updateKeyEvent, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(updateKeyEvent, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 
@@ -633,7 +629,7 @@ func (p Precompile) GetUpdateSpaceEvent(ctx sdk.Context, _ *common.Address, upda
 	topics[0] = event.ID
 
 	typedEvent := wardentypes.EventUpdateSpace{}
-	if err := precommon.ParseSdkEvent(updateSpaceEvent, typedEvent.XXX_Merge); err != nil {
+	if err := precommon.ParseSdkEventDeprecated(updateSpaceEvent, typedEvent.XXX_Merge); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The old ParseSdkEvent has been renamed to ParseSdkEventDeprecated.

The new version is used in NewKeychainEvent and UpdateKeychainEvent,
that contain sdk.Coins objects that causes panics inside the XXX_merge
methods generated by gogoproto (as it doesn't support merging fields of
type *big.Int).