### PR TITLE
fix(x/warden): use 20-bytes hashed keychain AccAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Consensus Breaking Changes
 
+- (x/warden) Change the way Keychain's addresses are generated. They now are 20-bytes long to be compatible with EVM.
+
 ### Features (non-breaking)
 
 ### Bug Fixes

--- a/warden/x/warden/types/v1beta3/keychain.go
+++ b/warden/x/warden/types/v1beta3/keychain.go
@@ -4,36 +4,29 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"slices"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func (k *Keychain) AccAddress() sdk.AccAddress {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, k.Id)
-	addr := append([]byte("keychain-"), bz...)
+
+	h := crypto.Keccak256Hash([]byte("keychain-"), bz)
+	addr := h[len(h)-common.AddressLength:]
 
 	return addr
 }
 
 func (k *Keychain) IsWriter(address string) bool {
-	for _, w := range k.Writers {
-		if w == address {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(k.Writers, address)
 }
 
 func (k *Keychain) IsAdmin(address string) bool {
-	for _, admin := range k.Admins {
-		if admin == address {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(k.Admins, address)
 }
 
 func (k *Keychain) AddWriter(address string) {

--- a/warden/x/warden/types/v1beta3/keychain_test.go
+++ b/warden/x/warden/types/v1beta3/keychain_test.go
@@ -1,11 +1,13 @@
 package v1beta3_test
 
 import (
+	"fmt"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+
 	types "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
@@ -14,13 +16,27 @@ func init() {
 	config.SetBech32PrefixForAccount("warden", "wardenpub")
 }
 
-func TestCosmosAddressEthCollision(t *testing.T) {
-	t.Run("cosmos_addresses_eth_address_collision", func(t *testing.T) {
-		k := types.Keychain{Id: 1}
-		addr1 := k.AccAddress()
-		addr2, err := sdk.AccAddressFromBech32("warden1qqqqq6m9093ksctfdcksqqqqqqqqqqqp73dme3")
-		require.NoError(t, err)
-		require.NotEqual(t, sdk.AccAddress(addr1).String(), addr2.String())
-		require.Equal(t, common.BytesToAddress(addr1), common.BytesToAddress(addr2))
-	})
+func TestKeychainAddressCanBeConvertedToEthereumAddress(t *testing.T) {
+	ids := []uint64{
+		0,
+		1,
+		0xFFFFFFFFFFFFFFFF, // max uint64
+	}
+
+	for _, id := range ids {
+		t.Run(fmt.Sprintf("id=%d", id), func(t *testing.T) {
+			k := types.Keychain{Id: id}
+			addr := k.AccAddress()
+			got := common.Address(addr)
+			require.NotEmpty(t, got)
+			require.NotZero(t, got)
+		})
+	}
+}
+
+func TestKeychainAddress(t *testing.T) {
+	k := types.Keychain{Id: 1}
+	addr1 := k.AccAddress()
+	expected := common.HexToAddress("0xd14Bb409Ccf9DCc22a3153996Ee689D75FF1B582")
+	require.Equal(t, expected, common.Address(addr1))
 }


### PR DESCRIPTION
We hit a bug while integrating with cosmos/evm as the addresses used as escrow when working with keychains are not 20-bytes long (every EVM address must be exactly 20 bytes long). This led to subtle bugs that were hard to track down.

Cosmos SDK allows for addresses of any length, but we shouldn't use them.

See also: https://github.com/cosmos/evm/issues/272.