### PR TITLE
ci: upgrade to golangci-lint v2.3

### DIFF
--- a/.github/workflows/faucet.yml
+++ b/.github/workflows/faucet.yml
@@ -36,9 +36,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.3
           args: --timeout=10m ${{ env.modules }}
 
   unit-test:

--- a/.github/workflows/go-client.yml
+++ b/.github/workflows/go-client.yml
@@ -22,9 +22,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.3
           args: --timeout=10m ./go-client/...
 
   unit-test:

--- a/.github/workflows/keychain-sdk.yml
+++ b/.github/workflows/keychain-sdk.yml
@@ -22,9 +22,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.3
           args: --timeout=10m ./keychain-sdk/...
 
   unit-test:

--- a/.github/workflows/shield.yml
+++ b/.github/workflows/shield.yml
@@ -22,9 +22,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.3
           args: --timeout=10m ./shield/...
 
   unit-test:

--- a/.github/workflows/soliditygen.yml
+++ b/.github/workflows/soliditygen.yml
@@ -22,9 +22,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.3
           args: --timeout=10m ./cmd/soliditygen/...
 
   unit-test:

--- a/.github/workflows/wardend.yaml
+++ b/.github/workflows/wardend.yaml
@@ -35,9 +35,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.3
           args: --timeout=10m ${{ env.modules }}
 
   unit-test:

--- a/.github/workflows/wardenkms.yml
+++ b/.github/workflows/wardenkms.yml
@@ -30,9 +30,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.0
+          version: v2.3
           args: --timeout=10m ./cmd/wardenkms/...
 
   unit-test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - gocognit
+    - goconst
     - gocritic
     - gocyclo
     - godox
@@ -31,6 +32,7 @@ linters:
     - nestif
     - nilerr
     - nilnil
+    - noinlineerr
     - nolintlint
     - nonamedreturns
     - paralleltest

--- a/cmd/faucet/main.go
+++ b/cmd/faucet/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"html/template"
 	"io"
@@ -22,7 +23,7 @@ type Templates struct {
 	templates *template.Template
 }
 
-func (t *Templates) Render(w io.Writer, name string, data interface{}, _ echo.Context) error {
+func (t *Templates) Render(w io.Writer, name string, data any, _ echo.Context) error {
 	return t.templates.ExecuteTemplate(w, name, data)
 }
 
@@ -81,6 +82,7 @@ func newPage() Page {
 }
 
 func main() {
+	ctx := context.Background()
 	e := echo.New()
 
 	logLevel, err := log.ParseLevel(config.GetLogLevel())
@@ -105,7 +107,7 @@ func main() {
 	page := newPage()
 	e.Renderer = newTemplate()
 
-	f, err := InitFaucet(logger)
+	f, err := InitFaucet(ctx, logger)
 	if err != nil {
 		e.Logger.Fatal(err)
 	}
@@ -169,7 +171,7 @@ func main() {
 
 		reqCount.Inc()
 
-		txHash, httpStatusCode, err = f.Send(c.FormValue("address"), false)
+		txHash, httpStatusCode, err = f.Send(c.Request().Context(), c.FormValue("address"), false)
 		if err != nil {
 			logger.Error().Msgf("error sending tokens: %s", err)
 

--- a/cmd/faucet/pkg/config/config.go
+++ b/cmd/faucet/pkg/config/config.go
@@ -54,7 +54,6 @@ func LoadConfig() (Config, error) {
 	cfg := Config{}
 
 	var err error
-
 	if err = env.Parse(&cfg); err != nil {
 		return Config{}, configError(err.Error())
 	}

--- a/cmd/shield_repl/main.go
+++ b/cmd/shield_repl/main.go
@@ -16,6 +16,7 @@ func main() {
 
 	for {
 		fmt.Print("> ") //nolint:forbidigo
+
 		sn := scanner.Scan()
 		if !sn {
 			return

--- a/cmd/soliditygen/main.go
+++ b/cmd/soliditygen/main.go
@@ -29,6 +29,7 @@ func main() {
 	if *contractName == "" || *solOutputPath == "" {
 		usageAndExit("You must provide --contractName and --output")
 	}
+
 	if *outputFile == "" || *outputName == "" {
 		usageAndExit("You must provide --outputFile and --outputName (output is required)")
 	}
@@ -37,13 +38,17 @@ func main() {
 	if *inputFile != "" && *inputName == "" {
 		usageAndExit("If you pass --inputFile, you must pass --inputName")
 	}
+
 	if *inputName != "" && *inputFile == "" {
 		usageAndExit("If you pass --inputName, you must pass --inputFile")
 	}
 
 	// 1) Read optional input JSON (if provided)
-	var inJSON []byte
-	var err error
+	var (
+		inJSON []byte
+		err    error
+	)
+
 	if *inputFile != "" {
 		inJSON, err = readAllOrStdin(*inputFile)
 		if err != nil {
@@ -72,6 +77,7 @@ func main() {
 		if os.IsPermission(err) {
 			log.Fatalf("Permission denied: Cannot write to %s", *solOutputPath)
 		}
+
 		log.Fatalf("Failed writing Solidity file: %v", err)
 	}
 
@@ -106,5 +112,6 @@ func readAllOrStdin(filePath string) ([]byte, error) {
 	if filePath == "-" {
 		return io.ReadAll(os.Stdin)
 	}
+
 	return os.ReadFile(filePath)
 }

--- a/cmd/wardenkms/bip44.go
+++ b/cmd/wardenkms/bip44.go
@@ -23,6 +23,7 @@ func FromSeedPhrase(seedPhrase, password string) (*Bip44Keychain, error) {
 	}
 
 	masterKey, chainCode := hd.ComputeMastersFromSeed(seedBytes)
+
 	return &Bip44Keychain{
 		masterSeed: masterKey,
 		chainCode:  chainCode,
@@ -72,14 +73,17 @@ func (k *Bip44Keychain) Sign(keyID [4]byte, message []byte) ([]byte, error) {
 func generateECDSASignature(seed, message []byte, recoveryID bool) ([]byte, error) {
 	privateKey, _ := btcec.PrivKeyFromBytes(seed[:])
 	ecdsaPriv := privateKey.ToECDSA()
+
 	prvD := math.PaddedBigBytes(ecdsaPriv.D, 32)
 	if len(prvD) != 32 {
 		return nil, fmt.Errorf("error generating ecdsa private key: Priv key bitlength: %v", 8*len(prvD))
 	}
+
 	prv, err := crypto.ToECDSA(prvD)
 	if err != nil {
 		return nil, fmt.Errorf("error generating ecdsa private key: Error %v. Priv key length: %v", err, 8*len(seed))
 	}
+
 	sigBytes, err := crypto.Sign(message, prv)
 	if err != nil {
 		return nil, fmt.Errorf("error signing msg: %x. error: %v", message, err)
@@ -101,14 +105,17 @@ func generateECDSASignature(seed, message []byte, recoveryID bool) ([]byte, erro
 func generateECDSAPubKey(seed []byte) (pubKeyBytes []byte, err error) {
 	privateKey, _ := btcec.PrivKeyFromBytes(seed[:])
 	ecdsaPriv := privateKey.ToECDSA()
+
 	prvD := math.PaddedBigBytes(ecdsaPriv.D, 32)
 	if len(prvD) != 32 {
 		return nil, fmt.Errorf("error generating ecdsa private key: Priv key bit length: %v", 8*len(prvD))
 	}
+
 	prv, err := crypto.ToECDSA(prvD)
 	if err != nil {
 		return nil, fmt.Errorf("error generating ecdsa private/public key pair: Error %v. Priv key bitlength: %v", err, 8*len(seed))
 	}
+
 	pubKeyBytes = crypto.CompressPubkey(&prv.PublicKey)
 
 	return pubKeyBytes, nil
@@ -124,6 +131,7 @@ func derivationPathFromKeyID(keyID [4]byte) (string, error) {
 		Change:       false,
 		AddressIndex: idx,
 	}.String() + "'" // BIP44 Hardened keys  - https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#extended-keys
+
 	return hardenedPath, nil
 }
 
@@ -133,6 +141,7 @@ func (k *Bip44Keychain) getSeedFromPath(derivationPath string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive private key: %w", err)
 	}
+
 	return derivedSeed, nil
 }
 

--- a/go-client/query_client.go
+++ b/go-client/query_client.go
@@ -16,11 +16,6 @@ type QueryClient struct {
 	conn *grpc.ClientConn
 }
 
-// Conn returns the gRPC client connection.
-func (c *QueryClient) Conn() *grpc.ClientConn {
-	return c.conn
-}
-
 // NewQueryClient returns a QueryClient. The supplied url must be a GRPC compatible endpoint for wardend.
 func NewQueryClient(url string, insecure bool) (*QueryClient, error) {
 	opts := []grpc.DialOption{}
@@ -30,6 +25,7 @@ func NewQueryClient(url string, insecure bool) (*QueryClient, error) {
 		creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: false})
 		opts = append(opts, grpc.WithTransportCredentials(creds))
 	}
+
 	grpcConn, err := grpc.NewClient(url, opts...)
 	if err != nil {
 		return nil, err
@@ -45,4 +41,9 @@ func NewQueryClientWithConn(c *grpc.ClientConn) *QueryClient {
 		WardenQueryClient: NewWardenQueryClient(c),
 		conn:              c,
 	}
+}
+
+// Conn returns the gRPC client connection.
+func (c *QueryClient) Conn() *grpc.ClientConn {
+	return c.conn
 }

--- a/go-client/tx_client.go
+++ b/go-client/tx_client.go
@@ -12,6 +12,7 @@ type TxClient struct {
 // NewTxClient returns a TxClient.
 func NewTxClient(id Identity, chainID string, c *grpc.ClientConn, accountFetcher AccountFetcher) *TxClient {
 	raw := NewRawTxClient(id, chainID, c, accountFetcher)
+
 	return &TxClient{
 		RawTxClient: raw,
 	}

--- a/go-client/tx_identity.go
+++ b/go-client/tx_identity.go
@@ -31,6 +31,7 @@ func NewIdentityFromSeed(seedPhrase string) (Identity, error) {
 
 	// Create a master key and derive the desired key
 	masterKey, ch := hd.ComputeMastersFromSeed(seedBytes)
+
 	derivedKey, err := hd.DerivePrivateKeyForPath(masterKey, ch, DefaultDerivationPath)
 	if err != nil {
 		return Identity{}, fmt.Errorf("failed to derive private key: %w", err)

--- a/go-client/tx_raw_client.go
+++ b/go-client/tx_raw_client.go
@@ -74,6 +74,7 @@ func (c *RawTxClient) BuildTx(ctx context.Context, gasLimit uint64, fees sdk.Coi
 	if err != nil {
 		return nil, fmt.Errorf("fetch account: %w", err)
 	}
+
 	accSeq := account.GetSequence()
 	accNum := account.GetAccountNumber()
 
@@ -103,6 +104,7 @@ func (c *RawTxClient) BuildTx(ctx context.Context, gasLimit uint64, fees sdk.Coi
 		},
 		Sequence: accSeq,
 	}
+
 	err = txBuilder.SetSignatures(sigV2)
 	if err != nil {
 		return nil, fmt.Errorf("set empty signature: %w", err)

--- a/keychain-sdk/example_keychain_test.go
+++ b/keychain-sdk/example_keychain_test.go
@@ -38,14 +38,14 @@ func Main() {
 	app.SetKeyRequestHandler(func(ctx context.Context, w keychain.Writer, req *keychain.KeyRequest) {
 		// handle key request
 		if err := w.Fulfil(ctx, []byte("public key data")); err != nil {
-			logger.Error("could not fulfill key request", "error", err)
+			logger.ErrorContext(ctx, "could not fulfill key request", "error", err)
 		}
 	})
 
 	app.SetSignRequestHandler(func(ctx context.Context, w keychain.Writer, req *keychain.SignRequest) {
 		// handle sign request
 		if err := w.Fulfil(ctx, []byte("signature data")); err != nil {
-			logger.Error("could not fulfill sign request", "error", err)
+			logger.ErrorContext(ctx, "could not fulfill sign request", "error", err)
 		}
 	})
 

--- a/keychain-sdk/internal/enc/enc.go
+++ b/keychain-sdk/internal/enc/enc.go
@@ -12,7 +12,9 @@ func ValidateEncryptionKey(pub []byte) error {
 	if len(pub) == 0 {
 		return nil
 	}
+
 	_, err := parseECDSAPublicKey(pub)
+
 	return err
 }
 
@@ -23,6 +25,7 @@ func Encrypt(pub []byte, data []byte) ([]byte, error) {
 	}
 
 	encKey := ecies.ImportECDSAPublic(pubKey)
+
 	encryptedPayload, err := ecies.Encrypt(rand.Reader, encKey, data, nil, nil)
 	if err != nil {
 		return nil, err

--- a/keychain-sdk/internal/enc/enc_test.go
+++ b/keychain-sdk/internal/enc/enc_test.go
@@ -12,6 +12,7 @@ func TestEncrypt(t *testing.T) {
 	// generate a new key pair
 	privKey, err := ethcrypto.GenerateKey()
 	require.NoError(t, err)
+
 	pk := ethcrypto.CompressPubkey(&privKey.PublicKey)
 
 	// encrypt a message

--- a/keychain-sdk/internal/tracker/tracker.go
+++ b/keychain-sdk/internal/tracker/tracker.go
@@ -18,18 +18,22 @@ func New() *T {
 func (t *T) IsNew(id uint64) bool {
 	t.rw.RLock()
 	defer t.rw.RUnlock()
+
 	_, ok := t.ingested[id]
+
 	return !ok
 }
 
 func (t *T) Ingested(id uint64) {
 	t.rw.Lock()
 	defer t.rw.Unlock()
+
 	t.ingested[id] = struct{}{}
 }
 
 func (t *T) Done(id uint64) {
 	t.rw.Lock()
 	defer t.rw.Unlock()
+
 	delete(t.ingested, id)
 }

--- a/precompiles/act/act.go
+++ b/precompiles/act/act.go
@@ -30,6 +30,7 @@ var f embed.FS
 // Precompile defines the precompiled contract for x/act.
 type Precompile struct {
 	evmcmn.Precompile
+
 	actmodulekeeper actmodulekeeper.Keeper
 	eventsRegistry  *common.EthEventsRegistry
 	queryServer     types.QueryServer

--- a/precompiles/async/async.go
+++ b/precompiles/async/async.go
@@ -30,6 +30,7 @@ var f embed.FS
 // Precompile defines the precompiled contract for x/async.
 type Precompile struct {
 	evmcmn.Precompile
+
 	asyncmodulekeeper asyncmodulekeeper.Keeper
 	eventsRegistry    *common.EthEventsRegistry
 	queryServer       types.QueryServer

--- a/precompiles/async/tx.go
+++ b/precompiles/async/tx.go
@@ -27,6 +27,7 @@ func (p *Precompile) AddTaskMethod(
 	args []interface{},
 ) ([]byte, error) {
 	msgServer := actmodulekeeper.NewMsgServerImpl(p.asyncmodulekeeper)
+
 	message, err := newMsgAddTask(args, origin, method)
 	if err != nil {
 		return nil, err

--- a/precompiles/json/builder.go
+++ b/precompiles/json/builder.go
@@ -59,6 +59,7 @@ func (j jsonBool) serialize() string {
 	if j.val {
 		return "true"
 	}
+
 	return "false"
 }
 
@@ -77,6 +78,7 @@ func (j jsonArray) serialize() string {
 	for i, el := range j.elements {
 		serEls[i] = el.serialize()
 	}
+
 	return "[" + strings.Join(serEls, ",") + "]"
 }
 
@@ -89,6 +91,7 @@ func (j jsonObject) serialize() string {
 	for i, el := range j.elements {
 		serEls[i] = fmt.Sprintf(`"%s":%s`, el.key, el.value.serialize())
 	}
+
 	return "{" + strings.Join(serEls, ",") + "}"
 }
 
@@ -155,6 +158,7 @@ func (b *builder) nextValue() (jsonValue, error) {
 
 func (b *builder) nextJsonObject() (jsonValue, error) {
 	b.cur++ // startObject
+
 	var obj jsonObject
 
 	for b.cur < len(b.ops) && b.ops[b.cur] != EndObject {
@@ -174,9 +178,11 @@ func (b *builder) nextJsonObject() (jsonValue, error) {
 	if b.cur >= len(b.ops) {
 		return nil, errors.New("unexpected end of operations while parsing object")
 	}
+
 	if b.ops[b.cur] != EndObject {
 		return nil, fmt.Errorf("expected object end, got: %d", b.ops[b.cur])
 	}
+
 	b.cur++
 
 	return obj, nil
@@ -186,13 +192,16 @@ func (b *builder) nextKey() (string, error) {
 	if b.ops[b.cur] != Key {
 		return "", fmt.Errorf("expected json key, got op: %d (with data: %x)", b.ops[b.cur], b.vals[b.cur])
 	}
+
 	val := string(b.vals[b.cur])
 	b.cur++
+
 	return val, nil
 }
 
 func (b *builder) nextJsonArray() (jsonValue, error) {
 	b.cur++ // startArray
+
 	var array jsonArray
 
 	for b.cur < len(b.ops) && b.ops[b.cur] != EndArray {
@@ -200,15 +209,18 @@ func (b *builder) nextJsonArray() (jsonValue, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		array.elements = append(array.elements, val)
 	}
 
 	if b.cur >= len(b.ops) {
 		return nil, errors.New("unexpected end of operations while parsing array")
 	}
+
 	if b.ops[b.cur] != EndArray {
 		return nil, fmt.Errorf("expected array end, got: %d", b.ops[b.cur])
 	}
+
 	b.cur++
 
 	return array, nil
@@ -217,6 +229,7 @@ func (b *builder) nextJsonArray() (jsonValue, error) {
 func (b *builder) nextJsonString() (jsonValue, error) {
 	val := string(b.vals[b.cur])
 	b.cur++
+
 	return jsonString{val}, nil
 }
 
@@ -225,7 +238,9 @@ func (b *builder) nextJsonUint() (jsonValue, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	n := arg.(*big.Int)
+
 	return jsonNumber{n.String()}, nil
 }
 
@@ -234,7 +249,9 @@ func (b *builder) nextJsonInt() (jsonValue, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	n := arg.(*big.Int)
+
 	return jsonNumber{n.String()}, nil
 }
 
@@ -243,6 +260,7 @@ func (b *builder) nextJsonBool() (jsonValue, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return jsonBool{arg.(bool)}, nil
 }
 
@@ -251,7 +269,9 @@ func (b *builder) nextJsonAddress() (jsonValue, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	hexStr := arg.(common.Address).Hex()
+
 	return jsonString{hexStr}, nil
 }
 
@@ -262,6 +282,7 @@ func (b *builder) nextJsonBytes() (jsonValue, error) {
 	}
 
 	hexStr := "0x" + hex.EncodeToString(arg.([]byte))
+
 	return jsonString{hexStr}, nil
 }
 
@@ -275,10 +296,12 @@ func (b *builder) nextJsonFixedPointNumber() (jsonValue, error) {
 		{Type: abiTypes["int256"]},
 		{Type: abiTypes["uint8"]},
 	}
+
 	args, err := arguments.Unpack(b.vals[b.cur])
 	if err != nil {
 		return nil, fmt.Errorf("unpack JsonFixedPointNumber: %w", err)
 	}
+
 	b.cur++
 
 	mantissa := args[0].(*big.Int)
@@ -323,17 +346,21 @@ func (b *builder) nextJsonRawNumber() (jsonValue, error) {
 	}
 
 	b.cur++
+
 	return jsonNumber{val}, nil
 }
 
 func (b *builder) decodeAbi(typ string) (any, error) {
 	abiType := abiTypes[typ]
 	arguments := abi.Arguments{{Type: abiType}}
+
 	args, err := arguments.Unpack(b.vals[b.cur])
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", typ, err)
 	}
+
 	b.cur++
+
 	return args[0], nil
 }
 
@@ -356,6 +383,7 @@ func init() {
 		if err != nil {
 			panic(fmt.Errorf("%s: %w", t, err))
 		}
+
 		abiTypes[t] = abiType
 	}
 }

--- a/precompiles/json/builder_test.go
+++ b/precompiles/json/builder_test.go
@@ -20,6 +20,7 @@ func newOpsBuilder() *opsBuilder { return &opsBuilder{} }
 func (ob *opsBuilder) push(o op, v []byte) *opsBuilder {
 	ob.ops = append(ob.ops, o)
 	ob.vals = append(ob.vals, v)
+
 	return ob
 }
 
@@ -35,6 +36,7 @@ func (ob *opsBuilder) uint(v uint64) *opsBuilder {
 	uint256Type, _ := abi.NewType("uint256", "", nil)
 	arguments := abi.Arguments{{Type: uint256Type}}
 	b, _ := arguments.Pack(new(big.Int).SetUint64(v))
+
 	return ob.push(UintValue, b)
 }
 
@@ -42,6 +44,7 @@ func (ob *opsBuilder) int(v int64) *opsBuilder {
 	int256Type, _ := abi.NewType("int256", "", nil)
 	arguments := abi.Arguments{{Type: int256Type}}
 	b, _ := arguments.Pack(new(big.Int).SetInt64(v))
+
 	return ob.push(IntValue, b)
 }
 
@@ -49,6 +52,7 @@ func (ob *opsBuilder) bool(v bool) *opsBuilder {
 	boolType, _ := abi.NewType("bool", "", nil)
 	arguments := abi.Arguments{{Type: boolType}}
 	b, _ := arguments.Pack(v)
+
 	return ob.push(BoolValue, b)
 }
 
@@ -56,6 +60,7 @@ func (ob *opsBuilder) address(addr common.Address) *opsBuilder {
 	addressType, _ := abi.NewType("address", "", nil)
 	arguments := abi.Arguments{{Type: addressType}}
 	b, _ := arguments.Pack(addr)
+
 	return ob.push(AddressValue, b)
 }
 
@@ -64,11 +69,14 @@ func (ob *opsBuilder) bytes(data []byte) *opsBuilder {
 	if err != nil {
 		panic(err)
 	}
+
 	arguments := abi.Arguments{{Type: bytesType}}
+
 	b, err := arguments.Pack(data)
 	if err != nil {
 		panic(err)
 	}
+
 	return ob.push(BytesValue, b)
 }
 
@@ -83,6 +91,7 @@ func (ob *opsBuilder) fixedPoint(mantissa int64, decimals uint8) *opsBuilder {
 		{Type: int256Type},
 		{Type: uint8Type},
 	}
+
 	b, err := arguments.Pack(new(big.Int).SetInt64(mantissa), decimals)
 	if err != nil {
 		panic(err)
@@ -262,16 +271,20 @@ func TestBuild(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(cmp.Or(tt.name, tt.want), func(t *testing.T) {
 			b := builder{ops: tt.builder.ops, vals: tt.builder.vals}
+
 			got, gotErr := b.build()
 			if gotErr != nil {
 				if !tt.wantErr {
 					require.NoError(t, gotErr)
 				}
+
 				return
 			}
+
 			if tt.wantErr {
 				require.Error(t, gotErr, "output: %s", got)
 			}
+
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/precompiles/json/json.go
+++ b/precompiles/json/json.go
@@ -28,6 +28,7 @@ var f embed.FS
 // Precompile defines the precompiled contract for x/async.
 type Precompile struct {
 	evmcmn.Precompile
+
 	abiEncoder *wardencommon.AbiEncoder
 }
 

--- a/precompiles/json/parser_test.go
+++ b/precompiles/json/parser_test.go
@@ -21,8 +21,10 @@ func (f *abiTupleBuilder) push(expected any, abiName string) *abiTupleBuilder {
 	if err != nil {
 		panic(err)
 	}
+
 	f.abiArgs = append(f.abiArgs, abi.Argument{Type: abiType})
 	f.values = append(f.values, expected)
+
 	return f
 }
 
@@ -47,6 +49,7 @@ func (f *abiTupleBuilder) uintArray(expected ...uint64) *abiTupleBuilder {
 	for _, e := range expected {
 		uints = append(uints, new(big.Int).SetUint64(e))
 	}
+
 	return f.push(uints, "uint256[]")
 }
 
@@ -55,6 +58,7 @@ func (f *abiTupleBuilder) intArray(expected ...int64) *abiTupleBuilder {
 	for _, e := range expected {
 		ints = append(ints, new(big.Int).SetInt64(e))
 	}
+
 	return f.push(ints, "int256[]")
 }
 
@@ -89,6 +93,7 @@ func (f *abiTupleBuilder) build() []byte {
 	if err != nil {
 		panic(err)
 	}
+
 	return res
 }
 
@@ -230,16 +235,20 @@ func TestParse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(cmp.Or(tt.name, tt.schema), func(t *testing.T) {
 			p := parser{json: []byte(tt.json), schema: []byte(tt.schema)}
+
 			got, gotErr := p.parse()
 			if gotErr != nil {
 				if !tt.wantErr {
 					require.NoError(t, gotErr)
 				}
+
 				return
 			}
+
 			if tt.wantErr {
 				require.Error(t, gotErr, "output: %x", got)
 			}
+
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/precompiles/json/query.go
+++ b/precompiles/json/query.go
@@ -36,6 +36,7 @@ func (p Precompile) Build(
 	}
 
 	jb := builder{ops: ops, vals: data}
+
 	j, err := jb.build()
 	if err != nil {
 		return nil, fmt.Errorf("invalid json ops: %w", err)
@@ -64,6 +65,7 @@ func (p Precompile) Parse(
 	}
 
 	pr := parser{json: jsonBz, schema: schema}
+
 	res, err := pr.parse()
 	if err != nil {
 		return nil, fmt.Errorf("invalid json: %w", err)

--- a/precompiles/sched/sched.go
+++ b/precompiles/sched/sched.go
@@ -30,6 +30,7 @@ var f embed.FS
 // Precompile defines the precompiled contract for x/sched.
 type Precompile struct {
 	evmcmn.Precompile
+
 	schedKeeper    schedkeeper.Keeper
 	evmKeeper      *evmkeeper.Keeper
 	eventsRegistry *common.EthEventsRegistry

--- a/precompiles/slinky/slinky.go
+++ b/precompiles/slinky/slinky.go
@@ -31,6 +31,7 @@ const PrecompileAddress = "0x0000000000000000000000000000000000000902"
 // Precompile defines the precompiled contract for slinky.
 type Precompile struct {
 	cmn.Precompile
+
 	oraclekeeper   oraclekeeper.Keeper
 	eventsRegistry *precommon.EthEventsRegistry
 	queryServer    types.QueryServer

--- a/precompiles/warden/events.go
+++ b/precompiles/warden/events.go
@@ -148,6 +148,7 @@ func (p Precompile) GetNewKeyEvent(ctx sdk.Context, _ *common.Address, eventNewK
 	if err != nil {
 		return nil, err
 	}
+
 	typedEvent := protoEvent.(*wardentypes.EventNewKey)
 
 	packed, err := event.Inputs.NonIndexed().Pack(
@@ -191,6 +192,7 @@ func (p Precompile) GetRejectKeyRequestEvent(ctx sdk.Context, _ *common.Address,
 	}
 
 	var err error
+
 	topics[1], err = evmcmn.MakeTopic(typedEvent.GetId())
 	if err != nil {
 		return nil, err
@@ -221,6 +223,7 @@ func (p Precompile) GetFulfilSignRequestEvent(ctx sdk.Context, _ *common.Address
 	}
 
 	var err error
+
 	topics[1], err = evmcmn.MakeTopic(typedEvent.GetId())
 	if err != nil {
 		return nil, err
@@ -251,6 +254,7 @@ func (p Precompile) GetRejectSignRequestEvent(ctx sdk.Context, _ *common.Address
 	}
 
 	var err error
+
 	topics[1], err = evmcmn.MakeTopic(typedEvent.GetId())
 	if err != nil {
 		return nil, err
@@ -286,6 +290,7 @@ func (p Precompile) GetNewKeychainEvent(ctx sdk.Context, creator *common.Address
 	if err != nil {
 		return nil, err
 	}
+
 	typedEvent := protoEvent.(*wardentypes.EventNewKeychain)
 
 	b.Write(append(make([]byte, 12), creator.Bytes()...))
@@ -410,6 +415,7 @@ func (p Precompile) GetUpdateKeychainEvent(ctx sdk.Context, _ *common.Address, e
 	if err != nil {
 		return nil, err
 	}
+
 	typedEvent := protoEvent.(*wardentypes.EventUpdateKeychain)
 
 	topics[1], err = evmcmn.MakeTopic(typedEvent.GetId())
@@ -571,6 +577,7 @@ func (p Precompile) GetNewSignRequestEvent(ctx sdk.Context, _ *common.Address, n
 	b.Write(evmcmn.PackNum(reflect.ValueOf(typedEvent.GetKeyId())))
 	b.Write(append(make([]byte, 12), creatorAddress.Bytes()...))
 	b.Write(evmcmn.PackNum(reflect.ValueOf(typedEvent.GetBroadcastType())))
+
 	topics[1], err = evmcmn.MakeTopic(typedEvent.GetId())
 	if err != nil {
 		return nil, err

--- a/precompiles/warden/warden.go
+++ b/precompiles/warden/warden.go
@@ -33,6 +33,7 @@ const PrecompileAddress = "0x0000000000000000000000000000000000000900"
 // Precompile defines the precompiled contract for x/warden.
 type Precompile struct {
 	cmn.Precompile
+
 	wardenkeeper   wardenmodulekeeper.Keeper
 	actkeeper      actmodulekeeper.Keeper
 	eventsRegistry *precommon.EthEventsRegistry

--- a/prophet/dedup.go
+++ b/prophet/dedup.go
@@ -39,6 +39,7 @@ func newDedup[T getIDer](ch <-chan T) (*dedup[T], error) {
 			}
 
 			c.Add(req.getID(), struct{}{})
+
 			out <- req
 		}
 	}()

--- a/prophet/exec.go
+++ b/prophet/exec.go
@@ -20,18 +20,19 @@ func ExecTasks(r TaskReader, w TaskResultWriter) error {
 	go func() {
 		for task := range r.Read() {
 			log := log.With("task", task.ID)
+			ctx := context.TODO()
 
-			log.Debug("running task")
+			log.DebugContext(ctx, "running task")
 
-			output, err := Execute(context.TODO(), task)
+			output, err := Execute(ctx, task)
 			if err != nil {
-				log.Error("failed to run task", "err", err)
+				log.ErrorContext(ctx, "failed to run task", "err", err)
 				continue
 			}
 
 			err = w.Write(output)
 			if err != nil {
-				log.Error("failed to write task result", "err", err)
+				log.ErrorContext(ctx, "failed to write task result", "err", err)
 				continue
 			}
 		}
@@ -55,15 +56,16 @@ func ExecVotes(r TaskResultReader, w VoteWriter) error {
 	go func() {
 		for proposal := range r.Read() {
 			plog := log.With("task", proposal.ID)
+			ctx := context.TODO()
 
-			plog.Debug("verifying task proposal")
+			plog.DebugContext(ctx, "verifying task proposal")
 
-			err := Verify(context.TODO(), proposal)
+			err := Verify(ctx, proposal)
 			if err := w.Write(Vote{
 				ID:  proposal.ID,
 				Err: err,
 			}); err != nil {
-				plog.Error("failed to write vote", "err", err)
+				plog.ErrorContext(ctx, "failed to write vote", "err", err)
 				continue
 			}
 		}

--- a/prophet/plugins.go
+++ b/prophet/plugins.go
@@ -33,11 +33,12 @@ func Execute(ctx context.Context, f Task) (res TaskResult, err error) {
 	}
 
 	log := slog.With("task", "Execute", "task", f.ID, "plugin", f.Plugin)
-	log.Debug("start")
+	log.DebugContext(ctx, "start")
 
 	start := time.Now()
+
 	defer func() {
-		log.Debug("end", "took", time.Since(start))
+		log.DebugContext(ctx, "end", "took", time.Since(start))
 	}()
 
 	output, err := s.Execute(ctx, f.Input)
@@ -68,7 +69,7 @@ func Verify(ctx context.Context, f TaskResult) (err error) {
 	}
 
 	log := slog.With("task", "Verify", "task", f.ID, "plugin", f.Plugin)
-	log.Debug("start")
+	log.DebugContext(ctx, "start")
 
 	start := time.Now()
 
@@ -76,7 +77,7 @@ func Verify(ctx context.Context, f TaskResult) (err error) {
 		return err
 	}
 
-	log.Debug("end", "took", time.Since(start))
+	log.DebugContext(ctx, "end", "took", time.Since(start))
 
 	return nil
 }

--- a/prophet/plugins/http/http.go
+++ b/prophet/plugins/http/http.go
@@ -104,6 +104,7 @@ func (h *Plugin) Execute(ctx context.Context, input []byte) ([]byte, error) {
 	}
 
 	var responseData interface{}
+
 	contentType := resp.Header.Get("Content-Type")
 	if strings.Contains(contentType, "application/json") {
 		if err := json.Unmarshal(bodyBytes, &responseData); err != nil {

--- a/prophet/plugins/http/http_test.go
+++ b/prophet/plugins/http/http_test.go
@@ -74,6 +74,7 @@ func TestPlugin_Execute_WithCborBody(t *testing.T) {
 		require.Equal(t, "application/json", r.Header.Get("Content-Type"), "Plugin should send JSON")
 
 		var received testPayload
+
 		err := json.NewDecoder(r.Body).Decode(&received)
 		require.NoError(t, err, "Server should decode JSON body")
 		require.Equal(t, originalPayload.Foo, received.Foo, "Foo should match")

--- a/prophet/plugins/pfp/pfp.go
+++ b/prophet/plugins/pfp/pfp.go
@@ -179,6 +179,7 @@ func (p *Plugin) UploadToBucket(ctx context.Context, image []byte, prompt string
 	if err != nil {
 		return "", err
 	}
+
 	metaFilename := imgName + ".json"
 
 	// Upload the meta file

--- a/prophet/plugins/stoicquote/stoicquote_test.go
+++ b/prophet/plugins/stoicquote/stoicquote_test.go
@@ -38,6 +38,7 @@ func TestPlugin_Execute(t *testing.T) {
 	require.NoError(t, err, "decodeOutput should not fail")
 
 	var expected generated.StoicQuoteResponse
+
 	err = json.Unmarshal([]byte(jsonResponse), &expected)
 	require.NoError(t, err, "Should unmarshal the mock server JSON")
 

--- a/prophet/plugins/veniceimg/veniceimg.go
+++ b/prophet/plugins/veniceimg/veniceimg.go
@@ -60,6 +60,7 @@ func (p Plugin) Execute(ctx context.Context, input []byte) ([]byte, error) {
 	newImage := resize.Resize(256, 0, img, resize.Lanczos3)
 
 	buf := new(bytes.Buffer)
+
 	options := webp.Options{Lossless: false, Quality: 80}
 	if err := webp.Encode(buf, newImage, options); err != nil {
 		return nil, err

--- a/prophet/prophet.go
+++ b/prophet/prophet.go
@@ -94,6 +94,7 @@ func (p *P) Run(tendermintRpc string) error {
 
 			p.selfAddressRwLock.Lock()
 			defer p.selfAddressRwLock.Unlock()
+
 			p.selfAddress = status.ValidatorInfo.Address
 
 			return
@@ -166,7 +167,7 @@ func (q *q[T]) Add(item T) {
 	select {
 	case q.ch <- item:
 	default:
-		slog.Warn("q.Add: queue is full, dropped item", "item", item)
+		slog.Warn("q.Add: queue is full, dropped item", "item", item) //nolint:noctx
 	}
 }
 

--- a/prophet/task.go
+++ b/prophet/task.go
@@ -21,6 +21,7 @@ type TaskReader interface {
 // TaskResult is the result of the computation of a task.
 type TaskResult struct {
 	Task
+
 	Output []byte
 	Error  error
 }

--- a/shield/ast/ast.go
+++ b/shield/ast/ast.go
@@ -62,6 +62,7 @@ func UnwrapIdentifier(expr *Expression) (*Identifier, bool) {
 	if ident, ok := expr.Value.(*Expression_Identifier); ok {
 		return ident.Identifier, true
 	}
+
 	return nil, false
 }
 
@@ -69,6 +70,7 @@ func UnwrapIntegerLiteral(expr *Expression) (*IntegerLiteral, bool) {
 	if ident, ok := expr.Value.(*Expression_IntegerLiteral); ok {
 		return ident.IntegerLiteral, true
 	}
+
 	return nil, false
 }
 
@@ -76,6 +78,7 @@ func UnwrapBooleanLiteral(expr *Expression) (*BooleanLiteral, bool) {
 	if ident, ok := expr.Value.(*Expression_BooleanLiteral); ok {
 		return ident.BooleanLiteral, true
 	}
+
 	return nil, false
 }
 
@@ -83,6 +86,7 @@ func UnwrapStringLiteral(expr *Expression) (*StringLiteral, bool) {
 	if v, ok := expr.Value.(*Expression_StringLiteral); ok {
 		return v.StringLiteral, true
 	}
+
 	return nil, false
 }
 
@@ -90,6 +94,7 @@ func UnwrapArrayLiteral(expr *Expression) (*ArrayLiteral, bool) {
 	if ident, ok := expr.Value.(*Expression_ArrayLiteral); ok {
 		return ident.ArrayLiteral, true
 	}
+
 	return nil, false
 }
 
@@ -97,6 +102,7 @@ func UnwrapPrefixExpression(expr *Expression) (*PrefixExpression, bool) {
 	if ident, ok := expr.Value.(*Expression_PrefixExpression); ok {
 		return ident.PrefixExpression, true
 	}
+
 	return nil, false
 }
 
@@ -104,6 +110,7 @@ func UnwrapInfixExpression(expr *Expression) (*InfixExpression, bool) {
 	if ident, ok := expr.Value.(*Expression_InfixExpression); ok {
 		return ident.InfixExpression, true
 	}
+
 	return nil, false
 }
 
@@ -111,6 +118,7 @@ func UnwrapCallExpression(expr *Expression) (*CallExpression, bool) {
 	if ident, ok := expr.Value.(*Expression_CallExpression); ok {
 		return ident.CallExpression, true
 	}
+
 	return nil, false
 }
 

--- a/shield/internal/evaluator/evaluator.go
+++ b/shield/internal/evaluator/evaluator.go
@@ -16,11 +16,13 @@ func Eval(exp *ast.Expression, env env.Environment) object.Object {
 		if !success {
 			return newError("invalid IntegerLiteral value: %s", exp.IntegerLiteral.Value)
 		}
+
 		return &object.Integer{Value: value}
 	case *ast.Expression_BooleanLiteral:
 		if exp.BooleanLiteral.Value {
 			return object.TRUE
 		}
+
 		return object.FALSE
 	case *ast.Expression_StringLiteral:
 		return &object.String{Value: exp.StringLiteral.Value}
@@ -29,6 +31,7 @@ func Eval(exp *ast.Expression, env env.Environment) object.Object {
 		for _, el := range exp.ArrayLiteral.Elements {
 			elements = append(elements, Eval(el, env))
 		}
+
 		return &object.Array{Elements: elements}
 	case *ast.Expression_Identifier:
 		if v, ok := builtins[exp.Identifier.Value]; ok {
@@ -51,6 +54,7 @@ func Eval(exp *ast.Expression, env env.Environment) object.Object {
 	case *ast.Expression_CallExpression:
 		fn := Eval(ast.NewIdentifier(exp.CallExpression.Function), env)
 		args := evalExpressions(exp.CallExpression.Arguments, env)
+
 		return applyFunction(fn, args)
 	}
 
@@ -63,6 +67,7 @@ func evalExpressions(exps []*ast.Expression, env env.Environment) []object.Objec
 		evaluated := Eval(e, env)
 		result = append(result, evaluated)
 	}
+
 	return result
 }
 
@@ -100,6 +105,7 @@ func evalPrefixSubOperator(right object.Object) object.Object {
 	}
 
 	v := right.(*object.Integer).Value
+
 	return &object.Integer{Value: new(big.Int).Neg(v)}
 }
 
@@ -175,24 +181,28 @@ func evalInfixExpression(exp *ast.InfixExpression, env env.Environment) object.O
 		if err != nil {
 			return err
 		}
+
 		return nativeBoolToBooleanObject(sign > 0)
 	case left.Type() == object.STRING_OBJ && right.Type() == object.STRING_OBJ && exp.Operator == "<":
 		sign, err := cmpBigInt(left, right)
 		if err != nil {
 			return err
 		}
+
 		return nativeBoolToBooleanObject(sign < 0)
 	case left.Type() == object.STRING_OBJ && right.Type() == object.STRING_OBJ && exp.Operator == ">=":
 		sign, err := cmpBigInt(left, right)
 		if err != nil {
 			return err
 		}
+
 		return nativeBoolToBooleanObject(sign >= 0)
 	case left.Type() == object.STRING_OBJ && right.Type() == object.STRING_OBJ && exp.Operator == "<=":
 		sign, err := cmpBigInt(left, right)
 		if err != nil {
 			return err
 		}
+
 		return nativeBoolToBooleanObject(sign <= 0)
 
 	// arithmetic operators
@@ -217,15 +227,18 @@ func nativeBoolToBooleanObject(input bool) *object.Boolean {
 	if input {
 		return object.TRUE
 	}
+
 	return object.FALSE
 }
 
 func parseBigInt(s string) (*big.Int, *object.Error) {
 	bigInt := new(big.Int)
+
 	bigInt, ok := bigInt.SetString(s, 10)
 	if !ok {
 		return nil, newError("invalid string number: %s", s)
 	}
+
 	return bigInt, nil
 }
 

--- a/shield/internal/evaluator/evaluator_test.go
+++ b/shield/internal/evaluator/evaluator_test.go
@@ -116,10 +116,12 @@ func TestNilEnv(t *testing.T) {
 func testEval(input string, envMap map[string]bool) object.Object {
 	l := lexer.New(input)
 	p := parser.New(l)
+
 	env := object.NewEnvironment()
 	for k, v := range envMap {
 		env.Set(k, &object.Boolean{Value: v})
 	}
+
 	return Eval(p.Parse(), env)
 }
 

--- a/shield/internal/lexer/lexer.go
+++ b/shield/internal/lexer/lexer.go
@@ -14,6 +14,7 @@ type Lexer struct {
 func New(input string) *Lexer {
 	l := &Lexer{input: input}
 	l.readChar()
+
 	return l
 }
 
@@ -101,10 +102,12 @@ func (l *Lexer) NextToken() token.Token {
 		if isLetter(l.ch) {
 			tok.Literal = l.readIdentifier()
 			tok.Type = token.LookupIdent(tok.Literal)
+
 			return tok
 		} else if isDigit(l.ch) {
 			tok.Type = token.Type_INT
 			tok.Literal = l.readNumber()
+
 			return tok
 		} else {
 			tok = newToken(token.Type_ILLEGAL, l.ch)
@@ -122,6 +125,7 @@ func (l *Lexer) readChar() {
 	} else {
 		l.ch = l.input[l.readPosition]
 	}
+
 	l.position = l.readPosition
 	l.readPosition++
 }
@@ -130,6 +134,7 @@ func (l *Lexer) peekChar() byte {
 	if l.readPosition >= len(l.input) {
 		return 0
 	}
+
 	return l.input[l.readPosition]
 }
 
@@ -138,6 +143,7 @@ func (l *Lexer) readIdentifier() string {
 	for isLetter(l.ch) || isDigit(l.ch) || isDot(l.ch) {
 		l.readChar()
 	}
+
 	return l.input[position:l.position]
 }
 
@@ -146,6 +152,7 @@ func (l *Lexer) readNumber() string {
 	for isDigit(l.ch) {
 		l.readChar()
 	}
+
 	return l.input[position:l.position]
 }
 

--- a/shield/internal/metadata/metadata.go
+++ b/shield/internal/metadata/metadata.go
@@ -26,6 +26,7 @@ func (m *Metadata) AddFunction(identifier string) {
 func ExtractMetadata(expr *ast.Expression) Metadata {
 	var metadata Metadata
 	processNode(expr, &metadata)
+
 	return metadata
 }
 
@@ -40,6 +41,7 @@ func processNode(node *ast.Expression, metadata *Metadata) {
 		processNode(n.InfixExpression.Right, metadata)
 	case *ast.Expression_CallExpression:
 		metadata.AddFunction(n.CallExpression.Function.Value)
+
 		for _, arg := range n.CallExpression.Arguments {
 			processNode(arg, metadata)
 		}

--- a/shield/internal/metadata/metadata_test.go
+++ b/shield/internal/metadata/metadata_test.go
@@ -92,12 +92,15 @@ func TestExtractMetadata(t *testing.T) {
 
 func testExtractMetadata(t *testing.T, code string) (*ast.Expression, Metadata) {
 	t.Helper()
+
 	l := lexer.New(code)
+
 	p := parser.New(l)
 	if p.Errors() != nil {
 		t.Fatalf("parser errors: %v", p.Errors())
 	}
 
 	expr := p.Parse()
+
 	return expr, ExtractMetadata(expr)
 }

--- a/shield/internal/preprocess/preprocess.go
+++ b/shield/internal/preprocess/preprocess.go
@@ -26,22 +26,27 @@ func Preprocess(ctx context.Context, node *ast.Expression, expander ast.Expander
 func preprocessElements(ctx context.Context, elements []*ast.Expression, expander ast.Expander) error {
 	for i, elem := range elements {
 		var err error
+
 		elements[i], err = Preprocess(ctx, elem, expander)
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
 func preprocessPrefixExpression(ctx context.Context, prefix *ast.PrefixExpression, expander ast.Expander) error {
 	var err error
+
 	prefix.Right, err = Preprocess(ctx, prefix.Right, expander)
+
 	return err
 }
 
 func preprocessInfixExpression(ctx context.Context, infix *ast.InfixExpression, expander ast.Expander) error {
 	var err error
+
 	infix.Left, err = Preprocess(ctx, infix.Left, expander)
 	if err != nil {
 		return err

--- a/shield/internal/preprocess/preprocess_test.go
+++ b/shield/internal/preprocess/preprocess_test.go
@@ -37,6 +37,7 @@ func TestPreprocess(t *testing.T) {
 	ctx := t.Context()
 	expression := parseExpression(t, "foo1(foo2(), false || true, [false, [10, 11, 12]])")
 	expander := NoopExpander{}
+
 	proc, err := Preprocess(ctx, expression, expander)
 	if err != nil {
 		t.Error(err)
@@ -61,6 +62,7 @@ func TestPreprocess(t *testing.T) {
 
 	arr2 := arr1.Elements[1].GetArrayLiteral()
 	require.Len(t, arr2.Elements, 3)
+
 	for i, arrElem := range arr2.Elements {
 		intVal := arrElem.GetIntegerLiteral()
 		require.NotNil(t, intVal)
@@ -108,6 +110,7 @@ func TestPreprocessInfixExpression(t *testing.T) {
 
 	inf2Left := inf2.Left.GetBooleanLiteral()
 	require.Equal(t, inf2Left.Value, true)
+
 	inf2Right := inf2.Right.GetBooleanLiteral()
 	require.Equal(t, inf2Right.Value, false)
 }

--- a/shield/shield.go
+++ b/shield/shield.go
@@ -22,6 +22,7 @@ type Environment = env.Environment
 func Parse(input string) (*ast.Expression, error) {
 	l := lexer.New(input)
 	p := parser.New(l)
+
 	root := p.Parse()
 	if len(p.Errors()) > 0 {
 		return nil, fmt.Errorf("parser errors: %v", p.Errors())

--- a/shield/token/idents.go
+++ b/shield/token/idents.go
@@ -9,5 +9,6 @@ func LookupIdent(ident string) Type {
 	if tok, ok := keywords[ident]; ok {
 		return tok
 	}
+
 	return Type_IDENT
 }

--- a/tests/cases/async_callbacks.go
+++ b/tests/cases/async_callbacks.go
@@ -55,6 +55,7 @@ func (c *Test_AsyncCallbacks) Run(t *testing.T, f *framework.F) {
 	checks.Eventually(t, func(ctx context.Context) (bool, bool) {
 		got1, err := instance.Got1(aliceCallEvm)
 		require.NoError(t, err)
+
 		return got1, got1
 	})
 
@@ -75,6 +76,7 @@ func (c *Test_AsyncCallbacks) Run(t *testing.T, f *framework.F) {
 	checks.Eventually(t, func(ctx context.Context) (bool, bool) {
 		got2, err := instance.Got2(aliceCallEvm)
 		require.NoError(t, err)
+
 		return got2, got2
 	})
 

--- a/tests/cases/create_space.go
+++ b/tests/cases/create_space.go
@@ -37,6 +37,7 @@ func (c *Test_CreateSpace) Run(t *testing.T, f *framework.F) {
 		defer cancel()
 
 		res, err := client.Warden.Spaces(ctx, &types.QuerySpacesRequest{})
+
 		return err == nil && len(res.Spaces) == 1 && res.Spaces[0].Nonce == 0
 	}, 10*time.Second, 10*time.Millisecond)
 }

--- a/tests/cases/reject_any_3_action.go
+++ b/tests/cases/reject_any_3_action.go
@@ -50,6 +50,7 @@ func (c *Test_RejectAny3Action) Run(t *testing.T, _ *framework.F) {
 	newRejectTemplateDefinition := "\"any(3, warden.space.owners)\""
 	resNewTemplate := alice.Tx(t, "act new-template --name reject_requires_three --definition "+newRejectTemplateDefinition)
 	checks.SuccessTx(t, resNewTemplate)
+
 	newApproveTemplateDefinition := "\"any(2, warden.space.owners)\""
 	resNewTemplate2 := alice.Tx(t, "act new-template --name approve_requires_two --definition "+newApproveTemplateDefinition)
 	checks.SuccessTx(t, resNewTemplate2)

--- a/tests/cases/warden_precompile.go
+++ b/tests/cases/warden_precompile.go
@@ -66,6 +66,7 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, f *framework.F) {
 
 		keychainAdmins := []common.Address{}
 		keychainWriters := []common.Address{}
+
 		keychainAdmins = append(keychainAdmins, alice.From)
 		require.Equal(t, warden.Keychain{
 			Id:          1,
@@ -287,6 +288,7 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, f *framework.F) {
 
 		keyRequest, err := iWardenClient.KeyRequestById(alice.CallOps(t), 1)
 		require.NoError(t, err)
+
 		deductedKeychainFees := []warden.TypesCoin{{
 			Denom:  "award",
 			Amount: new(big.Int).SetInt64(1),
@@ -401,6 +403,7 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, f *framework.F) {
 		// reject sign request
 		newSignReqTx = alice.Tx(t, "warden new-action new-sign-request --key-id 1 --input 'HoZ4Z+ZU7Zd08kUR5NcbtFZrmGKF18mSBJ29dg0qI44=' --max-keychain-fees \"1award\" --nonce 0")
 		checks.SuccessTx(t, newSignReqTx)
+
 		signRequestRejectReason := "test reject reason"
 		rejectSignRequestTx, err := iWardenClient.RejectSignRequest(alice.TransactOps(t), 2, signRequestRejectReason)
 		require.NoError(t, err)
@@ -415,6 +418,7 @@ func (c *Test_WardenPrecompile) Run(t *testing.T, f *framework.F) {
 
 		signRequest, err = iWardenClient.SignRequestById(alice.CallOps(t), 2)
 		require.NoError(t, err)
+
 		result := []byte(signRequestRejectReason)
 		require.Equal(t, warden.SignRequest{
 			Id:                   2,

--- a/tests/framework/checks/checks.go
+++ b/tests/framework/checks/checks.go
@@ -11,13 +11,17 @@ import (
 
 func Eventually[T any](t *testing.T, f func(ctx context.Context) (T, bool)) T {
 	var result T
+
 	require.Eventually(t, func() bool {
 		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 		defer cancel()
+
 		r, ok := f(ctx)
 		result = r
+
 		return ok
 	}, 10*time.Second, time.Second)
+
 	return result
 }
 

--- a/tests/framework/checks/eth_checks.go
+++ b/tests/framework/checks/eth_checks.go
@@ -12,6 +12,7 @@ func GetParsedEventsOnly[T any](txReceipt *types.Receipt, eventParser func(types
 	}
 
 	result := make([]T, 0)
+
 	for _, log := range txReceipt.Logs {
 		if log == nil {
 			continue

--- a/tests/framework/exec/exec.go
+++ b/tests/framework/exec/exec.go
@@ -20,12 +20,15 @@ type Exec struct {
 
 func (e *Exec) Run(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, e.Bin, e.Args...)
+
 	cmd.Dir = e.Pwd
 	if e.Stdin != "" {
 		cmd.Stdin = strings.NewReader(e.Stdin)
 	}
+
 	cmd.Stdout = e.Stdout
 	cmd.Stderr = e.Stderr
+
 	err := cmd.Run()
 	if err != nil {
 		return fmt.Errorf("exec: %s %s\nerr: %w\nstdout: %s\nstderr: %s", e.Bin, strings.Join(e.Args, " "), err, e.Stdout.String(), e.Stderr.String())

--- a/tests/framework/exec/warden_eth.go
+++ b/tests/framework/exec/warden_eth.go
@@ -15,6 +15,7 @@ import (
 
 type WardendEth struct {
 	*Wardend
+
 	Client     EthClient
 	From       common.Address
 	PrivateKey *ecdsa.PrivateKey
@@ -77,6 +78,7 @@ type EthClient struct {
 func (c EthClient) WaitDeployed(t *testing.T, tx *types.Transaction) common.Address {
 	addr, err := bind.WaitDeployed(t.Context(), c.Client, tx)
 	require.NoError(t, err)
+
 	return addr
 }
 
@@ -84,6 +86,7 @@ func (c EthClient) WaitMined(t *testing.T, tx *types.Transaction, status uint64)
 	receipt, err := bind.WaitMined(t.Context(), c.Client, tx)
 	require.NoError(t, err)
 	require.Equal(t, status, receipt.Status)
+
 	return receipt
 }
 

--- a/tests/framework/exec/warden_node.go
+++ b/tests/framework/exec/warden_node.go
@@ -37,6 +37,7 @@ type WardenNode struct {
 
 func NewWardenNode(t *testing.T, binPath string) *WardenNode {
 	home := t.TempDir()
+
 	return &WardenNode{
 		BinPath: binPath,
 		Home:    home,
@@ -103,6 +104,7 @@ func (w *WardenNode) PrintLogsAtTheEnd(t *testing.T, filters []string) {
 		logs := strings.Split(w.Stdout.String(), "\n")
 		// Filter out lines that contain filter
 		var filteredLogs []string
+
 		for _, line := range logs {
 			for _, filter := range filters {
 				if strings.Contains(line, filter) {
@@ -146,6 +148,7 @@ func (w *WardenNode) run(ctx context.Context, args ...string) error {
 		Stdout: w.Stdout,
 		Stderr: w.Stderr,
 	}
+
 	return cmd.Run(ctx)
 }
 

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -61,9 +61,12 @@ func (f *F) GetWardenNode() *exec.WardenNode {
 
 func (f *F) StartNodeFromSnapshot(t *testing.T, opts snapshots.BuildOptions) *exec.WardenNode {
 	node := f.GetWardenNode()
+
 	snap := f.GetSnapshot(opts)
 	go node.Start(t, snap) // use t instead of f.t here so we stop the node when the caller is done
+
 	node.WaitRunning(t)
+
 	return node
 }
 
@@ -95,10 +98,12 @@ func goModRoot(t *testing.T) string {
 
 	for path != "/" && path != "" {
 		testPath := filepath.Join(path, "go.mod")
+
 		_, err := os.Stat(testPath)
 		if err == nil {
 			return path
 		}
+
 		path = filepath.Dir(path)
 	}
 

--- a/tests/framework/iowriter/iowriter.go
+++ b/tests/framework/iowriter/iowriter.go
@@ -15,6 +15,7 @@ func (w *IOWriter) Write(p []byte) (n int, err error) {
 	if w == nil {
 		return len(p), nil
 	}
+
 	return w.b.Write(p)
 }
 
@@ -22,5 +23,6 @@ func (w *IOWriter) String() string {
 	if w == nil {
 		return "[not recorded]"
 	}
+
 	return w.b.String()
 }

--- a/tests/framework/ports/ports.go
+++ b/tests/framework/ports/ports.go
@@ -14,12 +14,16 @@ type FreePort struct {
 
 func ReservePorts(t *testing.T, count int) *FreePort {
 	t.Helper()
-	var ports []int
-	var lsns []net.Listener
+
+	var (
+		ports []int
+		lsns  []net.Listener
+	)
 
 	for range count {
-		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		ln, err := new(net.ListenConfig).Listen(t.Context(), "tcp", "127.0.0.1:0")
 		require.NoError(t, err)
+
 		ports = append(ports, ln.Addr().(*net.TCPAddr).Port)
 		lsns = append(lsns, ln)
 	}

--- a/tests/framework/snapshot/snapshots.go
+++ b/tests/framework/snapshot/snapshots.go
@@ -68,10 +68,12 @@ func Build(t *testing.T, wardendPath, savePath string, opts BuildOptions) {
 	for _, account := range opts.Accounts {
 		b.AddKeys(account.Name)
 		b.AddGenesisAccount(account.Name, account.Amount)
+
 		if account.StakedAmount != "" {
 			b.GenTx(account.Name, account.StakedAmount)
 		}
 	}
+
 	b.CollectGenTxs()
 
 	for _, s := range opts.Spaces {
@@ -89,9 +91,11 @@ func Build(t *testing.T, wardendPath, savePath string, opts BuildOptions) {
 	genesis := b.Genesis()
 	genesis.Set("app_state.evm.params.active_static_precompiles", opts.Precompiles)
 	genesis.Set("consensus.params.abci.vote_extensions_enable_height", "2")
+
 	if opts.EditGenesis != nil {
 		opts.EditGenesis(genesis)
 	}
+
 	genesis.Save()
 
 	b.SetConfig("app", "minimum-gas-prices", "0"+b.denom)
@@ -147,6 +151,7 @@ func (s *wardend) execStdout(t *testing.T, args ...string) string {
 		Stderr: nil,
 	}
 	require.NoError(t, e.Run(t.Context()))
+
 	return strings.TrimSpace(stdout.String())
 }
 
@@ -252,6 +257,7 @@ func (b *Builder) Replace(path, old, new string) {
 	fullPath := filepath.Join(b.home, path)
 	content, err := os.ReadFile(fullPath)
 	require.NoError(b.t, err)
+
 	content = bytes.ReplaceAll(content, []byte(old), []byte(new))
 	require.NoError(b.t, os.WriteFile(fullPath, content, 0o644))
 }
@@ -266,6 +272,7 @@ func (b *Builder) Genesis() *GenesisBuilder {
 	genesisPath := filepath.Join(b.home, "config/genesis.json")
 	c, err := gabs.ParseJSONFile(genesisPath)
 	require.NoError(b.t, err)
+
 	return &GenesisBuilder{
 		t:    b.t,
 		path: genesisPath,

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -24,11 +24,14 @@ func TestMain(m *testing.M) {
 //nolint:forbidigo
 func TestIntegration(t *testing.T) {
 	casesToRun := cases.List()
+
 	if list {
 		fmt.Println("Available test cases:")
+
 		for _, c := range casesToRun {
 			fmt.Println("*", getName(c))
 		}
+
 		return
 	}
 

--- a/warden/app/ante.go
+++ b/warden/app/ante.go
@@ -177,6 +177,7 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 						if err != nil {
 							return ctx, err
 						}
+
 						txIdx := uint64(i) //nolint:gosec // G115
 						evmante.EmitTxHashEvent(ctx, ethMsg, decUtils.BlockTxIndex, txIdx)
 					}

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -115,6 +115,7 @@ var (
 // capabilities aren't needed for testing.
 type App struct {
 	*runtime.App
+
 	legacyAmino       *codec.LegacyAmino
 	appCodec          codec.Codec
 	txConfig          client.TxConfig
@@ -205,6 +206,7 @@ func registerProphetHandlers(appOpts servertypes.AppOptions) {
 
 	if cast.ToBool(appOpts.Get("pricepred.enabled")) {
 		u := cast.ToString(appOpts.Get("pricepred.url"))
+
 		url, err := url.Parse(u)
 		if err != nil {
 			panic(fmt.Errorf("invalid pricepred url: %s", u))

--- a/warden/app/config.go
+++ b/warden/app/config.go
@@ -46,6 +46,7 @@ func (app *App) setupEVM() error {
 	chainID := app.ChainID()
 	from := strings.LastIndexByte(chainID, '_')
 	to := strings.LastIndexByte(chainID, '-')
+
 	evmChainID, err := strconv.ParseUint(chainID[from+1:to], 10, 64)
 	if err != nil {
 		return fmt.Errorf("can't parse evm chain id from %s: %w", chainID, err)

--- a/warden/app/export.go
+++ b/warden/app/export.go
@@ -109,6 +109,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		if err != nil {
 			panic(err)
 		}
+
 		delAddr := sdk.MustAccAddressFromBech32(del.DelegatorAddress)
 
 		if err := app.DistrKeeper.Hooks().BeforeDelegationCreated(ctx, delAddr, valAddr); err != nil {

--- a/warden/app/legacy.go
+++ b/warden/app/legacy.go
@@ -248,6 +248,7 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 	// integration point for custom authentication modules
 	// see https://medium.com/the-interchain-foundation/ibc-go-v6-changes-to-interchain-accounts-and-how-it-impacts-your-chain-806c185300d7
 	var noAuthzModule porttypes.IBCModule
+
 	icaControllerStack = icacontroller.NewIBCMiddlewareWithAuth(noAuthzModule, app.ICAControllerKeeper)
 	icaControllerStack = icacontroller.NewIBCMiddlewareWithAuth(icaControllerStack, app.ICAControllerKeeper)
 	icaControllerStack = ibccallbacks.NewIBCMiddleware(icaControllerStack, app.IBCKeeper.ChannelKeeper, wasmStackIBCHandler, wasm.DefaultMaxIBCCallbackGas)
@@ -261,6 +262,7 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 
 	// Create Transfer Stack
 	var transferStack porttypes.IBCModule
+
 	transferStack = transfer.NewIBCModule(app.TransferKeeper)
 	maxCallbackGas := uint64(1_000_000)
 	transferStack = erc20.NewIBCMiddleware(app.Erc20Keeper, transferStack)
@@ -276,6 +278,7 @@ func (app *App) registerLegacyModules(appOpts servertypes.AppOptions, wasmOpts [
 	app.TransferKeeper.WithICS4Wrapper(transferICS4Wrapper)
 
 	var transferStackV2 ibcapi.IBCModule
+
 	transferStackV2 = transferv2.NewIBCModule(app.TransferKeeper)
 	transferStackV2 = erc20v2.NewIBCMiddleware(transferStackV2, app.Erc20Keeper)
 

--- a/warden/app/sim_test.go
+++ b/warden/app/sim_test.go
@@ -176,6 +176,7 @@ func TestAppImportExport(t *testing.T) {
 	require.Equal(t, app.Name, newApp.Name())
 
 	var genesisState app.GenesisState
+
 	err = json.Unmarshal(exported.AppState, &genesisState)
 	require.NoError(t, err)
 

--- a/warden/repo/seqcollection.go
+++ b/warden/repo/seqcollection.go
@@ -16,6 +16,7 @@ var ErrInvalidID = errors.New("invalid ID")
 // for example when marshalling data as JSON default values are omitted by default.
 type SeqCollection[V any] struct {
 	collections.Map[uint64, V]
+
 	seq   collections.Sequence
 	setId func(*V, uint64)
 }
@@ -67,6 +68,7 @@ func (c SeqCollection[V]) next(ctx context.Context) (uint64, error) {
 func (c SeqCollection[V]) Import(ctx context.Context, values []V, getIDFn func(V) uint64) error {
 	for _, v := range values {
 		id := getIDFn(v)
+
 		actualID, err := c.Append(ctx, &v)
 		if err != nil {
 			return fmt.Errorf("ID mismatch: expected %d, got %d: cannot import this list of values", id, actualID)

--- a/warden/x/act/keeper/keeper.go
+++ b/warden/x/act/keeper/keeper.go
@@ -104,10 +104,10 @@ func (k Keeper) Logger() log.Logger {
 	return k.logger.With("module", "x/"+types.ModuleName)
 }
 
-func (k Keeper) getBlockTime(ctx context.Context) time.Time {
-	return sdk.UnwrapSDKContext(ctx).HeaderInfo().Time
-}
-
 func (k Keeper) TemplatesRegistry() *types.TemplatesRegistry {
 	return k.templatesRegistry
+}
+
+func (k Keeper) getBlockTime(ctx context.Context) time.Time {
+	return sdk.UnwrapSDKContext(ctx).HeaderInfo().Time
 }

--- a/warden/x/act/types/v1beta1/registry.go
+++ b/warden/x/act/types/v1beta1/registry.go
@@ -36,6 +36,7 @@ type registry interface {
 // correct type.
 func Register[T sdk.Msg](reg registry, fn ProviderFnG[T]) {
 	var msg T
+
 	typeUrl := sdk.MsgTypeURL(msg)
 	reg.Register(typeUrl, func(ctx context.Context, m sdk.Msg) (Template, Template, error) {
 		return fn(ctx, m.(T))
@@ -51,6 +52,7 @@ type registryWithCtx interface {
 // correct type.
 func RegisterCtx[T sdk.Msg](reg registryWithCtx, fn ProviderFnWithCtxG[T]) {
 	var msg T
+
 	typeUrl := sdk.MsgTypeURL(msg)
 	reg.RegisterCtx(typeUrl, func(ctx context.Context, m sdk.Msg) (context.Context, Template, Template, error) {
 		return fn(ctx, m.(T))

--- a/warden/x/async/keeper/abci.go
+++ b/warden/x/async/keeper/abci.go
@@ -44,6 +44,7 @@ func (k Keeper) BeginBlocker(ctx context.Context) error {
 		defer iterator.Close()
 
 		var oldTaskIDs []uint64
+
 		for ; iterator.Valid(); iterator.Next() {
 			v, err := iterator.Value()
 			if err != nil {
@@ -74,6 +75,7 @@ func (k Keeper) BeginBlocker(ctx context.Context) error {
 		}
 
 		var timeoutTasks []types.Task
+
 		for _, t := range pendingTasks {
 			plugin, err := k.plugins.Get(ctx, t.Plugin)
 			if err != nil {
@@ -145,6 +147,7 @@ func (k Keeper) ExtendVoteHandler() sdk.ExtendVoteHandler {
 			if r.Error != nil {
 				errorReason = r.Error.Error()
 			}
+
 			results[i] = &types.VEResultItem{
 				TaskId:      r.ID,
 				Output:      r.Output,
@@ -243,6 +246,7 @@ func (k Keeper) PrepareProposalHandler() sdk.PrepareProposalHandler {
 		if err != nil {
 			return 0, nil, err
 		}
+
 		return 1, asyncTx, nil
 	})
 }
@@ -351,18 +355,22 @@ func (k Keeper) processVE(ctx sdk.Context, fromAddr sdk.ConsAddress, ve types.As
 	}
 
 	ranger := collections.NewPrefixedPairRange[sdk.ConsAddress, string](fromAddr)
+
 	it, err := k.pluginsByValidator.Iterate(ctx, ranger)
 	if err != nil {
 		return fmt.Errorf("building iterator over registered plugins for %s", fromAddr.String())
 	}
+
 	keys, err := it.Keys()
 	if err != nil {
 		return fmt.Errorf("iterating over registered plugins for %s: %w", fromAddr.String(), err)
 	}
+
 	oldPlugins := make([]string, 0, len(keys))
 	for _, k := range keys {
 		oldPlugins = append(oldPlugins, k.K2())
 	}
+
 	if err := it.Close(); err != nil {
 		return fmt.Errorf("close iterator: %w", err)
 	}
@@ -388,6 +396,7 @@ func (k Keeper) processVE(ctx sdk.Context, fromAddr sdk.ConsAddress, ve types.As
 			if err := k.removeQueueParticipant(ctx, QueueID(r), fromAddr); err != nil {
 				return fmt.Errorf("remove %s from %s queue: %w", fromAddr.String(), r, err)
 			}
+
 			if err := k.pluginsByValidator.Remove(ctx, collections.Join(fromAddr, r)); err != nil {
 				return fmt.Errorf("remove %s from %s validators: %w", fromAddr.String(), r, err)
 			}
@@ -397,6 +406,7 @@ func (k Keeper) processVE(ctx sdk.Context, fromAddr sdk.ConsAddress, ve types.As
 			if err := k.newQueueParticipant(ctx, QueueID(r), fromAddr, weight); err != nil {
 				return fmt.Errorf("add %s to %s queue: %w", fromAddr.String(), r, err)
 			}
+
 			if err := k.pluginsByValidator.Set(ctx, collections.Join(fromAddr, r)); err != nil {
 				return fmt.Errorf("add %s to %s validators: %w", fromAddr.String(), r, err)
 			}
@@ -428,18 +438,21 @@ func diffSortedSlice[T cmp.Ordered](a, b []T) (onlyB, onlyA, both []T) {
 			both = append(both, a[i])
 			i++
 			j++
+
 			continue
 		}
 
 		if a[i] < b[j] {
 			onlyA = append(onlyA, a[i])
 			i++
+
 			continue
 		}
 
 		if a[i] > b[j] {
 			onlyB = append(onlyB, b[j])
 			j++
+
 			continue
 		}
 	}
@@ -447,6 +460,7 @@ func diffSortedSlice[T cmp.Ordered](a, b []T) (onlyB, onlyA, both []T) {
 	for ; i < len(a); i++ {
 		onlyA = append(onlyA, a[i])
 	}
+
 	for ; j < len(b); j++ {
 		onlyB = append(onlyB, b[j])
 	}

--- a/warden/x/async/keeper/genesis.go
+++ b/warden/x/async/keeper/genesis.go
@@ -47,9 +47,11 @@ func (k *Keeper) registerGenesisPlugins(ctx sdk.Context, activePlugins []types.G
 		if p.Timeout != nil {
 			timeout = *p.Timeout
 		}
+
 		if timeout == 0 {
 			return fmt.Errorf("timeout must be greater than zero, for plugin: %s", p.Name)
 		}
+
 		if timeout > maxTaskTimeout {
 			return fmt.Errorf("maximum timeout allowed for plugins: %s, got %s for %s", maxTaskTimeout, timeout, p.Name)
 		}

--- a/warden/x/async/keeper/msg_server_add_task.go
+++ b/warden/x/async/keeper/msg_server_add_task.go
@@ -25,6 +25,7 @@ import (
 
 func (k msgServer) AddTask(ctx context.Context, msg *types.MsgAddTask) (*types.MsgAddTaskResponse, error) {
 	var err error
+
 	if msg.Plugin == "" {
 		return nil, errorsmod.Wrapf(types.ErrInvalidPlugin, "cannot be empty")
 	}

--- a/warden/x/async/keeper/query_plugin_metrics_by_id.go
+++ b/warden/x/async/keeper/query_plugin_metrics_by_id.go
@@ -51,6 +51,7 @@ func (k Keeper) PluginMetricsById(ctx context.Context, req *types.QueryPluginMet
 	}
 
 	precision := int64(6)
+
 	successTaskRatio := cosmosmath.LegacyNewDec(0)
 	if metrics.TasksCount > 0 {
 		successfulTasksCount := cosmosmath.LegacyNewDecFromIntWithPrec(cosmosmath.NewIntFromUint64(metrics.ResultsCount*uint64(math.Pow10(int(precision)))), precision)
@@ -59,6 +60,7 @@ func (k Keeper) PluginMetricsById(ctx context.Context, req *types.QueryPluginMet
 	}
 
 	avgFee := []cosmos_types.DecCoin{}
+
 	for _, v := range metrics.TotalFees {
 		decAmount := cosmosmath.LegacyNewDecFromIntWithPrec(
 			v.Amount.Mul(cosmosmath.NewIntFromUint64(uint64(precision))),

--- a/warden/x/async/keeper/query_plugin_validators.go
+++ b/warden/x/async/keeper/query_plugin_validators.go
@@ -36,6 +36,7 @@ func (k Keeper) PluginValidators(ctx context.Context, req *types.QueryPluginVali
 	if errors.Is(err, collections.ErrNotFound) {
 		return nil, status.Error(codes.NotFound, "queue not found")
 	}
+
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -46,15 +47,18 @@ func (k Keeper) PluginValidators(ctx context.Context, req *types.QueryPluginVali
 	}
 
 	var priorities []types.QueuePriority
+
 	for ; it.Valid(); it.Next() {
 		key, err := it.Key()
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+
 		v, err := it.Value()
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+
 		priorities = append(priorities, types.QueuePriority{
 			Validator: key.K2(),
 			Priority:  int64(v),
@@ -71,15 +75,18 @@ func (k Keeper) PluginValidators(ctx context.Context, req *types.QueryPluginVali
 	}
 
 	var weights []types.QueueWeight
+
 	for ; it2.Valid(); it2.Next() {
 		key, err := it2.Key()
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+
 		v, err := it2.Value()
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+
 		weights = append(weights, types.QueueWeight{
 			Validator: key.K2(),
 			Weight:    int64(v),

--- a/warden/x/async/keeper/queues.go
+++ b/warden/x/async/keeper/queues.go
@@ -80,7 +80,6 @@ func (k *Keeper) QueueNext(ctx context.Context, id QueueID) (sdk.ConsAddress, er
 	// - slide
 	// after this, the participant with the highest priority value will be
 	// returned, and pushed at the end of the queue
-
 	totalWeight, err := k.queueTotalWeights.Get(ctx, id)
 	if err != nil {
 		return nil, err
@@ -92,14 +91,17 @@ func (k *Keeper) QueueNext(ctx context.Context, id QueueID) (sdk.ConsAddress, er
 
 	// load queuePriorities for QueueID into memory
 	rng := collections.NewPrefixedPairRange[QueueID, sdk.ConsAddress](id)
+
 	it, err := k.queuePriorities.Iterate(ctx, rng)
 	if err != nil {
 		return nil, err
 	}
+
 	m, err := it.KeyValues()
 	if err != nil {
 		return nil, err
 	}
+
 	if err := it.Close(); err != nil {
 		return nil, err
 	}
@@ -120,6 +122,7 @@ func (k *Keeper) QueueNext(ctx context.Context, id QueueID) (sdk.ConsAddress, er
 	}
 
 	diff := maxP - minP
+
 	threshold := 2 * totalWeight
 	if diff > threshold {
 		scale := diff / threshold
@@ -146,6 +149,7 @@ func (k *Keeper) QueueNext(ctx context.Context, id QueueID) (sdk.ConsAddress, er
 		nextP Priority = math.MinInt64
 		next  collections.Pair[QueueID, sdk.ConsAddress]
 	)
+
 	for i, kv := range m {
 		weight, err := k.queueWeights.Get(ctx, kv.Key)
 		if err != nil {

--- a/warden/x/async/keeper/tasks.go
+++ b/warden/x/async/keeper/tasks.go
@@ -107,6 +107,7 @@ func (k *TaskKeeper) Tasks() repo.SeqCollection[types.Task] {
 
 func (k *TaskKeeper) PendingTasks(ctx context.Context, solverAddr sdk.ConsAddress, limit int) ([]types.Task, error) {
 	ranger := collections.NewPrefixedPairRange[sdk.ConsAddress, uint64](solverAddr)
+
 	it, err := k.pendingTasks.Iterate(ctx, ranger)
 	if err != nil {
 		return nil, err

--- a/warden/x/sched/keeper/abci.go
+++ b/warden/x/sched/keeper/abci.go
@@ -42,6 +42,7 @@ func (k Keeper) PrepareProposalHandler(txConfig client.TxConfig) sdk.PrepareProp
 		if err != nil {
 			return 0, nil, err
 		}
+
 		return schedTxTriggerPosition, ethtx, nil
 	})
 }
@@ -64,15 +65,18 @@ func (k Keeper) ProcessProposalHandler(txConfig client.TxConfig) sdk.ProcessProp
 
 			if hasExtOptsTx, ok := tx.(authante.HasExtensionOptionsTx); ok {
 				opts := hasExtOptsTx.GetExtensionOptions()
+
 				typeURL := "/" + proto.MessageName(&types.ExtensionOptionsCallbacks{})
 				if len(opts) > 0 && opts[0].TypeUrl == typeURL {
 					if found {
 						// found a second transaction with the extensions
 						ctx.Logger().Error("invalid proposal: only one transaction per block can have the extension " + typeURL)
+
 						return &cometabci.ResponseProcessProposal{
 							Status: cometabci.ResponseProcessProposal_REJECT,
 						}, nil
 					}
+
 					position = i
 					found = true
 				}
@@ -89,6 +93,7 @@ func (k Keeper) ProcessProposalHandler(txConfig client.TxConfig) sdk.ProcessProp
 		// expect the tx to be at the block position [schedTxTriggerPosition]
 		if position != schedTxTriggerPosition {
 			ctx.Logger().Error("found x/sched injected transaction at the wrong position in block", "expected", schedTxTriggerPosition, "found", position)
+
 			return &cometabci.ResponseProcessProposal{
 				Status: cometabci.ResponseProcessProposal_REJECT,
 			}, nil
@@ -164,6 +169,7 @@ func buildCosmosWrappedTx(builder client.TxBuilder, signedEthTx *ethtypes.Transa
 	}
 
 	denom := vmtypes.GetEVMCoinDenom()
+
 	cosmosTx, err := tx.BuildTx(builder, denom)
 	if err != nil {
 		return nil, fmt.Errorf("BuildTx: %w", err)

--- a/warden/x/sched/keeper/callbacks.go
+++ b/warden/x/sched/keeper/callbacks.go
@@ -56,6 +56,18 @@ func (k *CallbackKeeper) SetResult(ctx context.Context, id uint64, result types.
 	return k.results.Set(ctx, id, result)
 }
 
+func (k *CallbackKeeper) GetResult(ctx context.Context, id uint64) (types.CallbackResult, error) {
+	return k.results.Get(ctx, id)
+}
+
+func (k *CallbackKeeper) Enqueue(ctx context.Context, id uint64, output []byte) error {
+	return k.queue.Set(ctx, id, output)
+}
+
+func (k *CallbackKeeper) Queue() collections.Map[uint64, []byte] {
+	return k.queue
+}
+
 func (k *CallbackKeeper) setSucceed(ctx context.Context, id uint64, output []byte) error {
 	return k.SetResult(ctx, id, types.CallbackResult{
 		Status: types.CallbackStatus_CALLBACK_STATUS_SUCCEED,
@@ -72,16 +84,4 @@ func (k *CallbackKeeper) setFailed(ctx context.Context, id uint64, reason string
 			FailReason: reason,
 		},
 	})
-}
-
-func (k *CallbackKeeper) GetResult(ctx context.Context, id uint64) (types.CallbackResult, error) {
-	return k.results.Get(ctx, id)
-}
-
-func (k *CallbackKeeper) Enqueue(ctx context.Context, id uint64, output []byte) error {
-	return k.queue.Set(ctx, id, output)
-}
-
-func (k *CallbackKeeper) Queue() collections.Map[uint64, []byte] {
-	return k.queue
 }

--- a/warden/x/sched/keeper/params.go
+++ b/warden/x/sched/keeper/params.go
@@ -11,22 +11,26 @@ import (
 // GetParams get all parameters as types.Params.
 func (k Keeper) GetParams(ctx context.Context) (params types.Params) {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+
 	bz := store.Get(types.ParamsKey)
 	if bz == nil {
 		return params
 	}
 
 	k.cdc.MustUnmarshal(bz, &params)
+
 	return params
 }
 
 // SetParams set the params.
 func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+
 	bz, err := k.cdc.Marshal(&params)
 	if err != nil {
 		return err
 	}
+
 	store.Set(types.ParamsKey, bz)
 
 	return nil

--- a/warden/x/sched/module/module.go
+++ b/warden/x/sched/module/module.go
@@ -75,6 +75,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncod
 	if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
 	}
+
 	return genState.Validate()
 }
 

--- a/warden/x/sched/module/simulation.go
+++ b/warden/x/sched/module/simulation.go
@@ -32,6 +32,7 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 	for i, acc := range simState.Accounts {
 		accs[i] = acc.Address.String()
 	}
+
 	schedGenesis := types.GenesisState{
 		Params: types.DefaultParams(),
 		// this line is used by starport scaffolding # simapp/module/genesisState

--- a/warden/x/sched/simulation/helpers.go
+++ b/warden/x/sched/simulation/helpers.go
@@ -11,5 +11,6 @@ func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, boo
 	if err != nil {
 		panic(err)
 	}
+
 	return simtypes.FindAccount(accs, creator)
 }

--- a/warden/x/sched/types/v1beta1/codec.go
+++ b/warden/x/sched/types/v1beta1/codec.go
@@ -9,7 +9,6 @@ import (
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	// this line is used by starport scaffolding # 3
-
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgUpdateParams{},
 	)

--- a/warden/x/sched/types/v1beta1/genesis.go
+++ b/warden/x/sched/types/v1beta1/genesis.go
@@ -17,6 +17,5 @@ func DefaultGenesis() *GenesisState {
 // failure.
 func (gs GenesisState) Validate() error {
 	// this line is used by starport scaffolding # genesis/types/validate
-
 	return gs.Params.Validate()
 }

--- a/warden/x/warden/keeper/keeper.go
+++ b/warden/x/warden/keeper/keeper.go
@@ -131,15 +131,15 @@ func (k Keeper) GetActAuthority() string {
 	return k.actAuthority
 }
 
+// Logger returns a module-specific logger.
+func (k Keeper) Logger() log.Logger {
+	return k.logger.With("module", "x/"+v1beta3.ModuleName)
+}
+
 func (k Keeper) assertActAuthority(addr string) error {
 	if k.GetActAuthority() != addr {
 		return errorsmod.Wrapf(v1beta3.ErrInvalidActionSigner, "invalid authority; expected %s, got %s", k.GetAuthority(), addr)
 	}
 
 	return nil
-}
-
-// Logger returns a module-specific logger.
-func (k Keeper) Logger() log.Logger {
-	return k.logger.With("module", "x/"+v1beta3.ModuleName)
 }

--- a/warden/x/warden/types/v1beta3/address.go
+++ b/warden/x/warden/types/v1beta3/address.go
@@ -59,6 +59,7 @@ func bech32Address(prefix string, key Key) (string, error) {
 	}
 
 	var pubkey secp256k1.PubKey
+
 	pubkey.Key = crypto.CompressPubkey(k)
 	bech32Address := sdk.MustBech32ifyAddressBytes(prefix, pubkey.Address())
 


### PR DESCRIPTION
This PR updates our CI to use golangci-lint v2.2 and fixes the new linter warnings.