### PR TITLE
wardend: prepare release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,16 +42,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Consensus Breaking Changes
 
+### Features (non-breaking)
+
+### Bug Fixes
+
+## [v0.6.5](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.6.5) - 2025-07-23
+
+### Consensus Breaking Changes
+
 - (x/warden) Change the way Keychain's addresses are generated. They now are 20-bytes long to be compatible with EVM.
 - (precompiles) Fix panics when dealing with NewKeychainEvent and UpdateKeychainEvent from the x/warden precompiled contract.
 - (precompiles/json) Add a new API (`build()`) that allows to build an entire json object with a single function call.
 - (precompiles/json) Add a new API (`parse()`) that allows to parse a json object into a schema with a single function call.
+- (x/async) Add metrics for Plugins (usage counter, bytes in, bytes out, task average time, total fees paid, success ratio).
+- Bump to Cosmos SDK v0.53.3.
 
 ### Features (non-breaking)
 
 - (plugin/veniceimg) Generate large image and resize it afterwards, locally. This leads to a much higher image quality.
-
-### Bug Fixes
 
 ## [v0.6.4](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.6.4) - 2025-07-07
 

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/cometbft/cometbft v0.38.17
 	github.com/cosmos/cosmos-db v1.1.3
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
-	github.com/cosmos/cosmos-sdk v0.53.2
+	github.com/cosmos/cosmos-sdk v0.53.3
 	github.com/cosmos/evm v1.0.0-rc2.0.20250707012801-af6f8d436a41
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/gogoproto v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -939,8 +939,8 @@ github.com/cosmos/cosmos-db v1.1.3 h1:7QNT77+vkefostcKkhrzDK9uoIEryzFrU9eoMeaQOP
 github.com/cosmos/cosmos-db v1.1.3/go.mod h1:kN+wGsnwUJZYn8Sy5Q2O0vCYA99MJllkKASbs6Unb9U=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.53.2 h1:QUok0dUzdxZedwunZ7N1GgJrctaGGGO8DUnKqkVRf1k=
-github.com/cosmos/cosmos-sdk v0.53.2/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
+github.com/cosmos/cosmos-sdk v0.53.3 h1:GbDJNUP9OD0gGDVnjecZVZr0ZReD1BtIIxmtgrAsWiw=
+github.com/cosmos/cosmos-sdk v0.53.3/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
 github.com/cosmos/evm v1.0.0-rc2.0.20250707012801-af6f8d436a41 h1:fUHKxX2UYHFNVWdUqkZEM7DUuUrvbsv7Q5qeg09C3Us=
 github.com/cosmos/evm v1.0.0-rc2.0.20250707012801-af6f8d436a41/go.mod h1:ZIHdhiKJkmYumuAVTlqc5Gb7csy+9SU+khYcjXg8J3g=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,6 +17,7 @@ import (
 	evidencekeeper "cosmossdk.io/x/evidence/keeper"
 	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -540,6 +542,10 @@ func New(
 	maxGasWanted := cast.ToUint64(appOpts.Get(srvflags.EVMMaxTxGasWanted))
 
 	app.setAnteHandler(app.txConfig, wasmConfig, app.GetKey(wasmtypes.StoreKey), maxGasWanted)
+
+	app.UpgradeKeeper.SetUpgradeHandler("v0.6.5", func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)
+	})
 
 	if err := app.Load(loadLatest); err != nil {
 		return nil, err

--- a/warden/x/async/keeper/migrations.go
+++ b/warden/x/async/keeper/migrations.go
@@ -13,6 +13,12 @@
 
 package keeper
 
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
+)
+
 // Migrator is a struct for handling in-place store migrations.
 type Migrator struct {
 	keeper Keeper
@@ -21,4 +27,15 @@ type Migrator struct {
 // NewMigrator returns a new Migrator.
 func NewMigrator(keeper Keeper) Migrator {
 	return Migrator{keeper: keeper}
+}
+
+func (m *Migrator) Migrate3to4(ctx sdk.Context) error {
+	return m.keeper.plugins.Walk(ctx, nil, func(key string, p v1beta1.Plugin) (bool, error) {
+		err := m.keeper.pluginMetrics.Set(ctx, p.Id, v1beta1.NewPluginMetrics(p.Id))
+		if err != nil {
+			return true, err
+		}
+
+		return false, nil
+	})
 }

--- a/warden/x/async/module/module.go
+++ b/warden/x/async/module/module.go
@@ -132,6 +132,11 @@ func NewAppModule(
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+
+	m := keeper.NewMigrator(am.keeper)
+	if err := cfg.RegisterMigration(types.ModuleName, 3, m.Migrate3to4); err != nil {
+		panic(fmt.Sprintf("failed to migrate x/async from version 3 to 4: %v", err))
+	}
 }
 
 // InitGenesis performs the module's genesis initialization. It returns no validator updates.
@@ -152,7 +157,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 // ConsensusVersion is a sequence number for state-breaking change of the module.
 // It should be incremented on each consensus-breaking change introduced by the module.
 // To avoid wrong/empty versions, the initial version should be set to 1.
-func (AppModule) ConsensusVersion() uint64 { return 3 }
+func (AppModule) ConsensusVersion() uint64 { return 4 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block.
 // The begin block implementation is optional.


### PR DESCRIPTION
This PR prepares wardend for v0.6.5.

It adds the necessary x/async migration for creating the new plugin metrics entries in the db.