### PR TITLE
docs(app): fix typos in comments

### DIFF
--- a/warden/app/ante.go
+++ b/warden/app/ante.go
@@ -145,7 +145,7 @@ func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
 					// This check prevents any external user to submit a transaction using the
 					// ExtensionOptionsCallbacks.
 					// If a validator still builds a proposal containing an invalid transaction,
-					// the rest of the validators should reject such proposal during
+					// the rest of the validators should reject such a proposal during
 					// ProcessProposal.
 					if ctx.IsCheckTx() {
 						return ctx, errorsmod.Wrapf(

--- a/warden/app/app_config.go
+++ b/warden/app/app_config.go
@@ -322,7 +322,7 @@ func moduleConfig() depinject.Config {
 					Name: stakingtypes.ModuleName,
 					Config: appconfig.WrapAny(&stakingmodulev1.Module{
 						// NOTE: specifying a prefix is only necessary when using bech32 addresses
-						// If not specfied, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
+						// If not specified, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
 						Bech32PrefixValidator: wardenconfig.Bech32PrefixValAddr,
 						Bech32PrefixConsensus: wardenconfig.Bech32PrefixConsAddr,
 					}),


### PR DESCRIPTION
- Corrected grammar in ante.go ("such proposal" → "such a proposal")
- Fixed typo in app_config.go ("specfied" → "specified")
