### PR TITLE
fix: correct typos in code comments

### DIFF
--- a/keychain-sdk/config.go
+++ b/keychain-sdk/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	Mnemonic string
 
 	// BatchInterval is the time to wait before sending a batch of requests to
-	// the blockchain. Tipically, this interval should be set to the average
+	// the blockchain. Typically, this interval should be set to the average
 	// block time of the chain.
 	BatchInterval time.Duration
 

--- a/warden/app/app_config.go
+++ b/warden/app/app_config.go
@@ -322,7 +322,7 @@ func moduleConfig() depinject.Config {
 					Name: stakingtypes.ModuleName,
 					Config: appconfig.WrapAny(&stakingmodulev1.Module{
 						// NOTE: specifying a prefix is only necessary when using bech32 addresses
-						// If not specfied, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
+						// If not specified, the auth Bech32Prefix appended with "valoper" and "valcons" is used by default
 						Bech32PrefixValidator: wardenconfig.Bech32PrefixValAddr,
 						Bech32PrefixConsensus: wardenconfig.Bech32PrefixConsAddr,
 					}),

--- a/warden/x/act/types/v1beta1/action.pb.go
+++ b/warden/x/act/types/v1beta1/action.pb.go
@@ -38,7 +38,7 @@ const (
 	ActionStatus_ACTION_STATUS_UNSPECIFIED ActionStatus = 0
 	// Action is pending approval. This is the initial status.
 	ActionStatus_ACTION_STATUS_PENDING ActionStatus = 1
-	// Template has been satified, action has been executed.
+	// Template has been satisfied, action has been executed.
 	ActionStatus_ACTION_STATUS_COMPLETED ActionStatus = 2
 	// Action has been revoked by its creator.
 	ActionStatus_ACTION_STATUS_REVOKED ActionStatus = 3


### PR DESCRIPTION


## Changes
- **keychain-sdk/config.go**: Fixed "Tipically" → "Typically" in comment
- **warden/app/app_config.go**: Fixed "specfied" → "specified" in comment  
- **warden/x/act/types/v1beta1/action.pb.go**: Fixed "satified" → "satisfied" in comment

