### PR TITLE
wardend: statically link binary on alpine with musl

### DIFF
--- a/cmd/wardend/Dockerfile
+++ b/cmd/wardend/Dockerfile
@@ -1,7 +1,12 @@
-FROM golang:1.25-trixie AS build
+FROM golang:1.25-alpine AS build
 
-# Install just
-RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
+RUN set -eux; apk add --no-cache ca-certificates build-base linux-headers git curl just;
+
+ARG WASMVM_VERSION
+ARG WASMVM_AMD64_CHECKSUM
+ARG WASMVM_ARM64_CHECKSUM
+ADD --checksum=sha256:${WASMVM_AMD64_CHECKSUM} --chmod=755 https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+ADD --checksum=sha256:${WASMVM_ARM64_CHECKSUM} --chmod=755 https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
 
 WORKDIR /warden
 
@@ -13,7 +18,7 @@ RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
 RUN --mount=type=bind,source=.,target=.,readonly\
     --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
     --mount=type=cache,target=/go/pkg/mod,sharing=locked \
-    OUTPUT_DIR=/dist just wardend build
+    OUTPUT_DIR=/dist LINK_STATIC=true just wardend build
 
 FROM scratch AS binary
 ARG TARGETOS
@@ -22,20 +27,12 @@ ARG WARDEND_VERSION="unknown"
 COPY --from=build /dist/wardend /wardend-$WARDEND_VERSION-$TARGETOS-$TARGETARCH
 ENTRYPOINT ["/wardend-$WARDEND_VERSION-$TARGETOS-$TARGETARCH"]
 
-FROM debian:trixie-slim AS runtime
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt update && apt install -y \
-    ca-certificates curl
+FROM alpine:3.18 AS runtime
+RUN set -eux; apk add --no-cache ca-certificates curl;
 
-RUN useradd -M -u 1000 -U -s /bin/sh -d /data warden && \
-    install -o 1000 -g 1000 -d /data
-
-ARG WASMVM_VERSION
-ARG WASMVM_AMD64_CHECKSUM
-ARG WASMVM_ARM64_CHECKSUM
-ADD --checksum=sha256:${WASMVM_AMD64_CHECKSUM} --chmod=755 https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm.x86_64.so /usr/lib/libwasmvm.x86_64.so
-ADD --checksum=sha256:${WASMVM_ARM64_CHECKSUM} --chmod=755 https://github.com/CosmWasm/wasmvm/releases/download/${WASMVM_VERSION}/libwasmvm.aarch64.so /usr/lib/libwasmvm.aarch64.so
+RUN addgroup -S -g 1000 warden && \
+    adduser -S -u 1000 -G warden -h /data -s /bin/sh warden && \
+    install -o warden -g warden -d /data
 
 COPY --from=build /dist/wardend /usr/bin/wardend
 

--- a/justfile
+++ b/justfile
@@ -26,8 +26,8 @@ deploy-contract contract from="shulgin" label="":
 
 # variables for building and releasing
 wasmvm_version := `go list -m -f '{{ .Version }}' github.com/CosmWasm/wasmvm/v3`
-wasmvm_amd64_checksum := 'f2fab51ec2b393ffe6912ff31497c6f8a14c04ad2490a1a3a9fa11a37cb4ce33'
-wasmvm_arm64_checksum := 'f82e608707be7b193a78f5a7f7c6163b633a94ca6a0017a7fa3501cc8e9fbff5'
+wasmvm_amd64_checksum := 'b249396cf884b207f49f46bcf5b8d1fd73b8618eebbe35afb8bf60a8bb24f30a'
+wasmvm_arm64_checksum := 'b9df5056ab9f61d3f9b944060b44e893d7ade7dad6ff134b36276be0f9a4185a'
 commit := `git rev-parse HEAD`
 short_commit := `git rev-parse --short HEAD`
 date := `date -u +"%Y-%m-%dT%H:%M:%SZ"`

--- a/wardend.just
+++ b/wardend.just
@@ -6,8 +6,13 @@ ldflags := "-ldflags \"
     -X github.com/cosmos/cosmos-sdk/version.Name=" + app_name + "
     -X github.com/cosmos/cosmos-sdk/version.AppName=" + app_name + "d
     -X github.com/cosmos/cosmos-sdk/version.Version=" + version + "
-    -X github.com/cosmos/cosmos-sdk/version.Commit=" + commit + '"'
-build_tags := "-tags ledger"
+    -X github.com/cosmos/cosmos-sdk/version.Commit=" + commit + if env("LINK_STATIC", "false") == "true" {
+        "
+        -linkmode=external -extldflags '-Wl,-z,muldefs -static'" + '"'
+    } else {
+        '"'
+    }
+build_tags := "-tags \"netgo,muslc\" -trimpath"
 output_dir := env("OUTPUT_DIR", "./build")
 
 # build (wardend|wardenkms|clichain). Eg. "just build wardend".


### PR DESCRIPTION
Use alpine and statically link the wardend binary (especially the wasmvm dependency). This makes it easier to use the binaries we publish, as there should be no external dependency.