### PR TITLE
wardend: bump cosmos/evm to latest available commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Consensus Breaking Changes
 
 - Disable x/warden, x/act, x/sched, x/async and CosmWasm.
+- Bump cosmos/evm to [latest commit](https://github.com/cosmos/evm/commit/bb6162e10da6ed984856922cbecdd1eaf10e2f38).
 
 ### Features (non-breaking)
 

--- a/go.mod
+++ b/go.mod
@@ -44,8 +44,8 @@ require (
 	github.com/cosmos/cosmos-db v1.1.3
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
 	github.com/cosmos/cosmos-sdk v0.53.4
-	github.com/cosmos/evm v1.0.0-rc2.0.20250829202347-ec57b964505b
-	github.com/cosmos/evm/evmd v0.0.0-20250822211227-2d3df2ba510c
+	github.com/cosmos/evm v1.0.0-rc2.0.20250918213135-bb6162e10da6
+	github.com/cosmos/evm/evmd v0.0.0-20250918213135-bb6162e10da6
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/gogoproto v1.7.0
 	github.com/cosmos/ibc-go/v10 v10.3.0

--- a/go.sum
+++ b/go.sum
@@ -941,10 +941,10 @@ github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+R
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
 github.com/cosmos/cosmos-sdk v0.53.4 h1:kPF6vY68+/xi1/VebSZGpoxQqA52qkhUzqkrgeBn3Mg=
 github.com/cosmos/cosmos-sdk v0.53.4/go.mod h1:7U3+WHZtI44dEOnU46+lDzBb2tFh1QlMvi8Z5JugopI=
-github.com/cosmos/evm v1.0.0-rc2.0.20250829202347-ec57b964505b h1:LjGixJinEUkjb+f9HWTw24Alu7f6y1b0RZn3JZv8Dd0=
-github.com/cosmos/evm v1.0.0-rc2.0.20250829202347-ec57b964505b/go.mod h1:0MieO7SusZtzF1rwdVzcel0UAWI+JBN98bNLteRDK2E=
-github.com/cosmos/evm/evmd v0.0.0-20250822211227-2d3df2ba510c h1:hCjQ8XVK5JKybVEXwCGbpdDwcEuLOSCDX7vRELzA5QQ=
-github.com/cosmos/evm/evmd v0.0.0-20250822211227-2d3df2ba510c/go.mod h1:afe8FBtwa3BqBa7nfnxl43XN8NTFx8e0mQ1wcbD5vec=
+github.com/cosmos/evm v1.0.0-rc2.0.20250918213135-bb6162e10da6 h1:px5DJT+bN9dIpCi++a6cQlKPMQGf7JBXYqUTsW5CSF4=
+github.com/cosmos/evm v1.0.0-rc2.0.20250918213135-bb6162e10da6/go.mod h1:hkJhjv6j4c/dITmed0M0OvHZm8J4fMn56mWPx0JoVp8=
+github.com/cosmos/evm/evmd v0.0.0-20250918213135-bb6162e10da6 h1:ljJ4jhGTzKz6dUlkjXwYObhPeHdo97yQFLVoafWjw0I=
+github.com/cosmos/evm/evmd v0.0.0-20250918213135-bb6162e10da6/go.mod h1:B9yQ4LV0aGn4W+9TlcOHr5aD49fwHyhtmRB15VewVBE=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/go-ethereum v1.16.2-cosmos-1 h1:QIaIS6HIdPSBdTvpFhxswhMLUJgcr4irbd2o9ZKldAI=
@@ -956,8 +956,6 @@ github.com/cosmos/gogoproto v1.7.0 h1:79USr0oyXAbxg3rspGh/m4SWNyoz/GLaAh0QlCe2fr
 github.com/cosmos/gogoproto v1.7.0/go.mod h1:yWChEv5IUEYURQasfyBW5ffkMHR/90hiHgbNgrtp4j0=
 github.com/cosmos/iavl v1.2.4 h1:IHUrG8dkyueKEY72y92jajrizbkZKPZbMmG14QzsEkw=
 github.com/cosmos/iavl v1.2.4/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
-github.com/cosmos/ibc-go/modules/capability v1.0.1 h1:ibwhrpJ3SftEEZRxCRkH0fQZ9svjthrX2+oXdZvzgGI=
-github.com/cosmos/ibc-go/modules/capability v1.0.1/go.mod h1:rquyOV262nGJplkumH+/LeYs04P3eV8oB7ZM4Ygqk4E=
 github.com/cosmos/ibc-go/v10 v10.3.0 h1:w5DkHih8qn15deAeFoTk778WJU+xC1krJ5kDnicfUBc=
 github.com/cosmos/ibc-go/v10 v10.3.0/go.mod h1:CthaR7n4d23PJJ7wZHegmNgbVcLXCQql7EwHrAXnMtw=
 github.com/cosmos/ics23/go v0.11.0 h1:jk5skjT0TqX5e5QJbEnwXIS2yI2vnmLOgpQPeM5RtnU=

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -520,6 +520,20 @@ func NewApp(
 		&app.ConsensusParamsKeeper,
 		&app.Erc20Keeper,
 		tracer,
+	).WithStaticPrecompiles(
+		NewAvailableStaticPrecompiles(
+			*app.StakingKeeper,
+			app.DistrKeeper,
+			app.PreciseBankKeeper,
+			&app.Erc20Keeper,
+			&app.TransferKeeper,
+			app.IBCKeeper.ChannelKeeper,
+			app.EVMKeeper,
+			app.GovKeeper,
+			app.SlashingKeeper,
+			app.OracleKeeper,
+			app.AppCodec(),
+		),
 	)
 
 	app.Erc20Keeper = erc20keeper.NewKeeper(
@@ -537,7 +551,6 @@ func NewApp(
 	app.TransferKeeper = transferkeeper.NewKeeper(
 		appCodec,
 		runtime.NewKVStoreService(keys[ibctransfertypes.StoreKey]),
-		app.GetSubspace(ibctransfertypes.ModuleName),
 		app.IBCKeeper.ChannelKeeper,
 		app.IBCKeeper.ChannelKeeper,
 		app.MsgServiceRouter(),
@@ -597,24 +610,6 @@ func NewApp(
 
 	// Override the ICS20 app module
 	transferModule := transfer.NewAppModule(app.TransferKeeper)
-
-	// NOTE: we are adding all available Cosmos EVM EVM extensions.
-	// Not all of them need to be enabled, which can be configured on a per-chain basis.
-	app.EVMKeeper.WithStaticPrecompiles(
-		NewAvailableStaticPrecompiles(
-			*app.StakingKeeper,
-			app.DistrKeeper,
-			app.PreciseBankKeeper,
-			app.Erc20Keeper,
-			app.TransferKeeper,
-			app.IBCKeeper.ChannelKeeper,
-			app.EVMKeeper,
-			app.GovKeeper,
-			app.SlashingKeeper,
-			app.OracleKeeper,
-			app.AppCodec(),
-		),
-	)
 
 	/****  Module Options ****/
 

--- a/warden/app/precompiles.go
+++ b/warden/app/precompiles.go
@@ -2,25 +2,14 @@ package app
 
 import (
 	"fmt"
-	"maps"
 
-	"cosmossdk.io/core/address"
 	"github.com/cosmos/cosmos-sdk/codec"
-	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	distributionkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
-	bankprecompile "github.com/cosmos/evm/precompiles/bank"
-	"github.com/cosmos/evm/precompiles/bech32"
 	cmn "github.com/cosmos/evm/precompiles/common"
-	distprecompile "github.com/cosmos/evm/precompiles/distribution"
-	govprecompile "github.com/cosmos/evm/precompiles/gov"
-	ics20precompile "github.com/cosmos/evm/precompiles/ics20"
-	"github.com/cosmos/evm/precompiles/p256"
-	slashingprecompile "github.com/cosmos/evm/precompiles/slashing"
-	stakingprecompile "github.com/cosmos/evm/precompiles/staking"
+	precompiletypes "github.com/cosmos/evm/precompiles/types"
 	erc20Keeper "github.com/cosmos/evm/x/erc20/keeper"
 	transferkeeper "github.com/cosmos/evm/x/ibc/transfer/keeper"
 	evmkeeper "github.com/cosmos/evm/x/vm/keeper"
@@ -33,45 +22,6 @@ import (
 	wardenprecompiles "github.com/warden-protocol/wardenprotocol/precompiles"
 )
 
-// Optionals define some optional params that can be applied to _some_ precompiles.
-// Extend this struct, add a sane default to defaultOptionals, and an Option function to provide users with a non-breaking
-// way to provide custom args to certain precompiles.
-type Optionals struct {
-	AddressCodec       address.Codec // used by gov/staking
-	ValidatorAddrCodec address.Codec // used by slashing
-	ConsensusAddrCodec address.Codec // used by slashing
-}
-
-func defaultOptionals() Optionals {
-	return Optionals{
-		AddressCodec:       addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
-		ValidatorAddrCodec: addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
-		ConsensusAddrCodec: addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
-	}
-}
-
-type Option func(opts *Optionals)
-
-func WithAddressCodec(codec address.Codec) Option {
-	return func(opts *Optionals) {
-		opts.AddressCodec = codec
-	}
-}
-
-func WithValidatorAddrCodec(codec address.Codec) Option {
-	return func(opts *Optionals) {
-		opts.ValidatorAddrCodec = codec
-	}
-}
-
-func WithConsensusAddrCodec(codec address.Codec) Option {
-	return func(opts *Optionals) {
-		opts.ConsensusAddrCodec = codec
-	}
-}
-
-const bech32PrecompileBaseGas = 6_000
-
 // NewAvailableStaticPrecompiles returns the list of all available static precompiled contracts from EVM.
 //
 // NOTE: this should only be used during initialization of the Keeper.
@@ -79,104 +29,29 @@ func NewAvailableStaticPrecompiles(
 	stakingKeeper stakingkeeper.Keeper,
 	distributionKeeper distributionkeeper.Keeper,
 	bankKeeper cmn.BankKeeper,
-	erc20Keeper erc20Keeper.Keeper,
-	transferKeeper transferkeeper.Keeper,
+	erc20Keeper *erc20Keeper.Keeper,
+	transferKeeper *transferkeeper.Keeper,
 	channelKeeper *channelkeeper.Keeper,
 	evmKeeper *evmkeeper.Keeper,
 	govKeeper govkeeper.Keeper,
 	slashingKeeper slashingkeeper.Keeper,
 	oracleKeeper *oraclekeeper.Keeper,
 	codec codec.Codec,
-	opts ...Option,
 ) map[common.Address]vm.PrecompiledContract {
-	options := defaultOptionals()
-	for _, opt := range opts {
-		opt(&options)
-	}
-
-	// Clone the mapping from the latest EVM fork.
-	precompiles := maps.Clone(vm.PrecompiledContractsBerlin)
-
-	// secp256r1 precompile as per EIP-7212
-	p256Precompile := &p256.Precompile{}
-
-	bech32Precompile, err := bech32.NewPrecompile(bech32PrecompileBaseGas)
-	if err != nil {
-		panic(fmt.Errorf("failed to instantiate bech32 precompile: %w", err))
-	}
-
-	stakingPrecompile, err := stakingprecompile.NewPrecompile(
+	// init cosmos/evm precompiles
+	precompiles := precompiletypes.DefaultStaticPrecompiles(
 		stakingKeeper,
-		stakingkeeper.NewMsgServerImpl(&stakingKeeper),
-		stakingkeeper.NewQuerier(&stakingKeeper),
-		bankKeeper,
-		options.AddressCodec,
-	)
-	if err != nil {
-		panic(fmt.Errorf("failed to instantiate staking precompile: %w", err))
-	}
-
-	distributionPrecompile, err := distprecompile.NewPrecompile(
 		distributionKeeper,
-		distributionkeeper.NewMsgServerImpl(distributionKeeper),
-		distributionkeeper.NewQuerier(distributionKeeper),
-		stakingKeeper,
 		bankKeeper,
-		options.AddressCodec,
-	)
-	if err != nil {
-		panic(fmt.Errorf("failed to instantiate distribution precompile: %w", err))
-	}
-
-	ibcTransferPrecompile, err := ics20precompile.NewPrecompile(
-		bankKeeper,
-		stakingKeeper,
+		erc20Keeper,
 		transferKeeper,
 		channelKeeper,
-	)
-	if err != nil {
-		panic(fmt.Errorf("failed to instantiate ICS20 precompile: %w", err))
-	}
-
-	bankPrecompile, err := bankprecompile.NewPrecompile(bankKeeper, erc20Keeper)
-	if err != nil {
-		panic(fmt.Errorf("failed to instantiate bank precompile: %w", err))
-	}
-
-	govPrecompile, err := govprecompile.NewPrecompile(
-		govkeeper.NewMsgServerImpl(&govKeeper),
-		govkeeper.NewQueryServer(&govKeeper),
-		bankKeeper,
-		codec,
-		options.AddressCodec,
-	)
-	if err != nil {
-		panic(fmt.Errorf("failed to instantiate gov precompile: %w", err))
-	}
-
-	slashingPrecompile, err := slashingprecompile.NewPrecompile(
+		govKeeper,
 		slashingKeeper,
-		slashingkeeper.NewMsgServerImpl(slashingKeeper),
-		bankKeeper,
-		options.ValidatorAddrCodec,
-		options.ConsensusAddrCodec,
+		codec,
 	)
-	if err != nil {
-		panic(fmt.Errorf("failed to instantiate slashing precompile: %w", err))
-	}
 
-	// Stateless precompiles
-	precompiles[bech32Precompile.Address()] = bech32Precompile
-	precompiles[p256Precompile.Address()] = p256Precompile
-
-	// Stateful precompiles
-	precompiles[stakingPrecompile.Address()] = stakingPrecompile
-	precompiles[distributionPrecompile.Address()] = distributionPrecompile
-	precompiles[ibcTransferPrecompile.Address()] = ibcTransferPrecompile
-	precompiles[bankPrecompile.Address()] = bankPrecompile
-	precompiles[govPrecompile.Address()] = govPrecompile
-	precompiles[slashingPrecompile.Address()] = slashingPrecompile
-
+	// init warden precompiles
 	wardenprecompiles, err := wardenprecompiles.NewWardenPrecompiles(
 		bankKeeper,
 		*oracleKeeper,
@@ -186,6 +61,7 @@ func NewAvailableStaticPrecompiles(
 		panic(err)
 	}
 
+	// merge warden precompiles list
 	for a, p := range wardenprecompiles {
 		_, found := precompiles[a]
 		if found {


### PR DESCRIPTION
Update cosmos/evm, this update includes some fixes but also consensus breaking changes from v0.7.0-rc4.

One particular bug that was fixed is a crash during the blocksync process.

I also took advantage of the new `precompiletypes.DefaultStaticPrecompiles(...)` function to simplify our initialization logic and remove some boilerplate.