### PR TITLE
wardend: prepare release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,16 +42,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Consensus Breaking Changes
 
+### Features (non-breaking)
+
+### Bug Fixes
+
+## [v0.7.0](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.7.0) - 2025-09-22
+
+### Consensus Breaking Changes
+
 - Disable x/warden, x/act, x/sched, x/async and CosmWasm.
-- Bump cosmos/evm to [latest commit](https://github.com/cosmos/evm/commit/bb6162e10da6ed984856922cbecdd1eaf10e2f38).
+- Bump cosmos/evm to [latest commit](https://github.com/cosmos/evm/commit/bb6162e10da6ed984856922cbecdd1eaf10e2f38) (pre-v0.5.0).
 
 ### Features (non-breaking)
 
 - Update to Go 1.25
 - Remove depinject, return to classic Cosmos SDK app wiring
-- Update cosmos/evm to v0.5.0-rc
-
-### Bug Fixes
 
 ## [v0.6.5](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.6.5) - 2025-07-23
 

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,7 +26,6 @@ import (
 	"cosmossdk.io/x/upgrade"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -149,10 +149,6 @@ import (
 	"github.com/warden-protocol/wardenprotocol/prophet/plugins/venice"
 	"github.com/warden-protocol/wardenprotocol/prophet/plugins/veniceimg"
 	"github.com/warden-protocol/wardenprotocol/warden/app/ante"
-	acttypes "github.com/warden-protocol/wardenprotocol/warden/x/act/types/v1beta1"
-	asynctypes "github.com/warden-protocol/wardenprotocol/warden/x/async/types/v1beta1"
-	schedtypes "github.com/warden-protocol/wardenprotocol/warden/x/sched/types/v1beta1"
-	wardentypes "github.com/warden-protocol/wardenprotocol/warden/x/warden/types/v1beta3"
 )
 
 func init() {
@@ -278,9 +274,9 @@ func NewApp(
 		// Slinky store keys
 		oracletypes.StoreKey, marketmaptypes.StoreKey,
 		// CosmWasm store keys
-		wasmtypes.StoreKey,
+		// wasmtypes.StoreKey,
 		// Warden Protocol store keys
-		acttypes.StoreKey, asynctypes.StoreKey, schedtypes.StoreKey, wardentypes.StoreKey,
+		// acttypes.StoreKey, asynctypes.StoreKey, schedtypes.StoreKey, wardentypes.StoreKey,
 	)
 
 	tkeys := storetypes.NewTransientStoreKeys(paramstypes.TStoreKey, evmtypes.TransientKey, feemarkettypes.TransientKey)
@@ -702,10 +698,10 @@ func NewApp(
 		oracletypes.ModuleName, marketmaptypes.ModuleName,
 
 		// CosmWasm modules
-		wasmtypes.ModuleName,
+		// wasmtypes.ModuleName,
 
 		// Warden modules
-		acttypes.ModuleName, wardentypes.ModuleName, asynctypes.ModuleName, schedtypes.ModuleName,
+		// acttypes.ModuleName, wardentypes.ModuleName, asynctypes.ModuleName, schedtypes.ModuleName,
 	)
 
 	// NOTE: the feemarket module should go last in order of end blockers that are actually doing something,
@@ -718,10 +714,10 @@ func NewApp(
 		oracletypes.ModuleName, marketmaptypes.ModuleName,
 
 		// CosmWasm modules
-		wasmtypes.ModuleName,
+		// wasmtypes.ModuleName,
 
 		// Warden modules
-		acttypes.ModuleName, wardentypes.ModuleName, asynctypes.ModuleName, schedtypes.ModuleName,
+		// acttypes.ModuleName, wardentypes.ModuleName, asynctypes.ModuleName, schedtypes.ModuleName,
 
 		// Cosmos EVM EndBlockers
 		evmtypes.ModuleName, erc20types.ModuleName, feemarkettypes.ModuleName,
@@ -762,10 +758,10 @@ func NewApp(
 		oracletypes.ModuleName, marketmaptypes.ModuleName,
 
 		// CosmWasm modules
-		wasmtypes.ModuleName,
+		// wasmtypes.ModuleName,
 
 		// Warden modules
-		acttypes.ModuleName, wardentypes.ModuleName, asynctypes.ModuleName, schedtypes.ModuleName,
+		// acttypes.ModuleName, wardentypes.ModuleName, asynctypes.ModuleName, schedtypes.ModuleName,
 	}
 	app.ModuleManager.SetOrderInitGenesis(genesisModuleOrder...)
 	app.ModuleManager.SetOrderExportGenesis(genesisModuleOrder...)
@@ -880,6 +876,10 @@ func NewApp(
 		// want to panic here instead of logging a warning.
 		fmt.Fprintln(os.Stderr, err.Error())
 	}
+
+	app.UpgradeKeeper.SetUpgradeHandler("v0.7.0", func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)
+	})
 
 	if loadLatest {
 		if err := app.LoadLatestVersion(); err != nil {


### PR DESCRIPTION
This PR updates the changelog and registers a new upgrade called `v0.7.0` needed for upgrading our testnet.