### PR TITLE
feat(oracle): enable slinky pre-blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+## [v0.7.1](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.7.1) - 2025-10-02
+
+### Consensus Breaking Changes
+
+- oracle: Enable Slinky pre-blocker to store prices onchain.
+
 ## [v0.7.0](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.7.0) - 2025-09-22
 
 ### Consensus Breaking Changes

--- a/cmd/wardend/config/wardend_config.go
+++ b/cmd/wardend/config/wardend_config.go
@@ -21,7 +21,8 @@ import (
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
 	corevm "github.com/ethereum/go-ethereum/core/vm"
-	oracleconfig "github.com/skip-mev/slinky/oracle/config"
+
+	oracleconfig "github.com/warden-protocol/connect/oracle/config"
 
 	httpconfig "github.com/warden-protocol/wardenprotocol/prophet/plugins/http/config"
 	pfpconfig "github.com/warden-protocol/wardenprotocol/prophet/plugins/pfp/config"

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,6 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/sethvargo/go-envconfig v1.3.0
-	github.com/skip-mev/slinky v1.2.0
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -1802,8 +1802,6 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skip-mev/chaintestutil v0.0.0-20240514161515-056d7ba45610 h1:4JlsiRVt/YZOvrKH525T7sZXgEWUEjqSDMwE6fXNbdo=
 github.com/skip-mev/chaintestutil v0.0.0-20240514161515-056d7ba45610/go.mod h1:kB8gFZX07CyJnw8q9iEZijI3qJTIe1K/Y++P5VGkrcg=
-github.com/skip-mev/slinky v1.2.0 h1:KxVegrUetwbqramH0Ovmx8Clv8PCAeL1/7aWISEbPBQ=
-github.com/skip-mev/slinky v1.2.0/go.mod h1:mDiBJqXDjUA3oro4v7i1OjLEieGrKP+P+M26Cja1cFs=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/warden/app/app.go
+++ b/warden/app/app.go
@@ -837,7 +837,6 @@ func NewApp(
 
 	// initialize BaseApp
 	app.SetInitChainer(app.InitChainer)
-	app.SetPreBlocker(app.PreBlocker)
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
 
@@ -877,7 +876,7 @@ func NewApp(
 		fmt.Fprintln(os.Stderr, err.Error())
 	}
 
-	app.UpgradeKeeper.SetUpgradeHandler("v0.7.0", func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+	app.UpgradeKeeper.SetUpgradeHandler("v0.7.1", func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		return app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)
 	})
 
@@ -924,10 +923,6 @@ func (app *App) InitChainer(ctx sdk.Context, req *abci.RequestInitChain) (*abci.
 	}
 
 	return app.ModuleManager.InitGenesis(ctx, app.appCodec, genesisState)
-}
-
-func (app *App) PreBlocker(ctx sdk.Context, _ *abci.RequestFinalizeBlock) (*sdk.ResponsePreBlock, error) {
-	return app.ModuleManager.PreBlock(ctx)
 }
 
 // LoadHeight loads a particular height.


### PR DESCRIPTION
This PR makes wardend actually use the wrapped preblocker from slinky so that prices are recorded onchain.

It also already prepares for a v0.7.1 network upgrade and release.

Closes ENG-712.