### PR TITLE
wardend: fix query gas limit option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - oracle: Enable Slinky pre-blocker to store prices onchain.
 
+### Bug Fixes
+
+- Fix `query-gas-limit` in `app.toml` being ignored.
+
 ## [v0.7.0](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.7.0) - 2025-09-22
 
 ### Consensus Breaking Changes

--- a/cmd/wardend/cmd/root.go
+++ b/cmd/wardend/cmd/root.go
@@ -334,6 +334,7 @@ func newApp(
 	baseappOptions := []func(*baseapp.BaseApp){
 		baseapp.SetPruning(pruningOpts),
 		baseapp.SetMinGasPrices(cast.ToString(appOpts.Get(sdkserver.FlagMinGasPrices))),
+		baseapp.SetQueryGasLimit(cast.ToUint64(appOpts.Get(sdkserver.FlagQueryGasLimit))),
 		baseapp.SetHaltHeight(cast.ToUint64(appOpts.Get(sdkserver.FlagHaltHeight))),
 		baseapp.SetHaltTime(cast.ToUint64(appOpts.Get(sdkserver.FlagHaltTime))),
 		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(sdkserver.FlagMinRetainBlocks))),


### PR DESCRIPTION
Same as https://github.com/cosmos/evm/pull/641, we were ignoring the gas limit for queries, if set.

Closes ENG-713.