### PR TITLE
ci: fix wrongly added -dirty flag to wardend version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
+# Make sure that all the paths listed here are also present in .gitignore.
+# Failing to do so might cause the wardend version to contain a "-dirty" flag
+# when built from inside docker images.
 **docker-compose.yml
-**Dockerfile
-**Dockerfile**
 **node_modules
 **build
 **dist


### PR DESCRIPTION
Fix a wrongly added -dirty flag to wardend versions when built from CI's docker images.

closes ENG-804