### PR TITLE
wardend: fix derivation path by setting coin_type=60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-## [v0.7.2](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.7.2) - 2025-10-XX
+## [v0.7.3](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.7.3) - 2025-11-19
+
+### Bug Fixes
+
+- wardend: fix wrong coin_type in the HD derivation path, causing mnemonics to being derived into the wrong private keys and addresses
+
+## [v0.7.2](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.7.2) - 2025-10-21
 
 ### Consensus Breaking Changes
 

--- a/cmd/wardend/config/config.go
+++ b/cmd/wardend/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/evm/crypto/hd"
 )
 
 const (
@@ -34,4 +35,11 @@ func SetBech32Prefixes(config *sdk.Config) {
 	config.SetBech32PrefixForAccount(Bech32PrefixAccAddr, Bech32PrefixAccPub)
 	config.SetBech32PrefixForValidator(Bech32PrefixValAddr, Bech32PrefixValPub)
 	config.SetBech32PrefixForConsensusNode(Bech32PrefixConsAddr, Bech32PrefixConsPub)
+}
+
+// SetBip44CoinType sets the global coin type to be used in hierarchical deterministic wallets.
+func SetBip44CoinType(config *sdk.Config) {
+	config.SetCoinType(hd.Bip44CoinType)
+	config.SetPurpose(sdk.Purpose)               // Shared
+	config.SetFullFundraiserPath(hd.BIP44HDPath) //nolint: staticcheck
 }

--- a/cmd/wardend/main.go
+++ b/cmd/wardend/main.go
@@ -24,5 +24,6 @@ func main() {
 func setupSDKConfig() {
 	config := sdk.GetConfig()
 	wardendconfig.SetBech32Prefixes(config)
+	wardendconfig.SetBip44CoinType(config)
 	config.Seal()
 }


### PR DESCRIPTION
This caused wrong private keys being derived from mnemonic, for example when using `wardend keys add --recover`.

This regression was introduced with v0.7.2.