### PR TITLE
fix(x/evm): disable unused precompiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+## [v0.7.7](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.7.7) - 2026-01-26
+
+This upgrade re-aligns the network binary version after the v0.7.6 emergency
+upgrade, enforcing that all nodes (even non-validators) are running the latest
+version.
+
+### Consensus Breaking Changes
+
+- x/evm: disable unused precompiles.
+
 ## [v0.7.6](https://github.com/warden-protocol/wardenprotocol/releases/tag/v0.7.6) - 2026-01-23
 
 This is an emergency upgrade. It will be applied without going through the

--- a/warden/app/upgrades.go
+++ b/warden/app/upgrades.go
@@ -2,14 +2,11 @@ package app
 
 import (
 	"context"
-	"fmt"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/evm/x/erc20/types"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 func (app App) RegisterUpgradeHandlers() {
@@ -20,22 +17,31 @@ func (app App) RegisterUpgradeHandlers() {
 		Decimals:      18,
 	})
 
-	app.UpgradeKeeper.SetUpgradeHandler("v0.7.4", func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+	app.UpgradeKeeper.SetUpgradeHandler("v0.7.7", func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-		nativeErc20Address := "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
-		pair := types.NewTokenPair(
-			common.HexToAddress(nativeErc20Address),
-			"award",
-			types.OWNER_MODULE,
-		)
+		params := app.EVMKeeper.GetParams(sdkCtx)
 
-		if err := app.Erc20Keeper.SetToken(sdkCtx, pair); err != nil {
-			return nil, fmt.Errorf("erc20 set token: %w", err)
+		var newPrecompiles []string
+
+		for _, addr := range params.ActiveStaticPrecompiles {
+			if addr == "0x0000000000000000000000000000000000000802" ||
+				addr == "0x0000000000000000000000000000000000000900" ||
+				addr == "0x0000000000000000000000000000000000000901" ||
+				addr == "0x0000000000000000000000000000000000000902" ||
+				addr == "0x0000000000000000000000000000000000000903" ||
+				addr == "0x0000000000000000000000000000000000000904" ||
+				addr == "0x0000000000000000000000000000000000000905" {
+				continue
+			}
+
+			newPrecompiles = append(newPrecompiles, addr)
 		}
 
-		if err := app.Erc20Keeper.EnableNativePrecompile(sdkCtx, common.HexToAddress(nativeErc20Address)); err != nil {
-			return nil, fmt.Errorf("erc20 enable native precompile: %w", err)
+		params.ActiveStaticPrecompiles = newPrecompiles
+
+		if err := app.EVMKeeper.SetParams(sdkCtx, params); err != nil {
+			return fromVM, err
 		}
 
 		return app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)


### PR DESCRIPTION
This update disables all the precompiles we don't need.