### PR TITLE
fix: migrate staking and feemarket params to award

### DIFF
--- a/warden/app/upgrades.go
+++ b/warden/app/upgrades.go
@@ -48,18 +48,17 @@ func (app App) RegisterUpgradeHandlers() {
 
 		// Update staking params to use award as bond denom
 		stakingParams, err := app.StakingKeeper.GetParams(sdkCtx)
-		if err == nil {
-			stakingParams.BondDenom = "award"
-			if err := app.StakingKeeper.SetParams(sdkCtx, stakingParams); err != nil {
-				return fromVM, err
-			}
+		if err != nil {
+			return fromVM, err
+		}
+		stakingParams.BondDenom = "award"
+		if err := app.StakingKeeper.SetParams(sdkCtx, stakingParams); err != nil {
+			return fromVM, err
 		}
 
 		// Update feemarket params to use award
 		feemarketParams := app.FeeMarketKeeper.GetParams(sdkCtx)
-		feemarketParams.MinGasPrice = sdk.ZeroDec() // Or some other value? 
-		// Actually, if we just want to avoid the mismatch, setting it to 0 is one way, 
-		// but better to just ensure it's not uward.
+		feemarketParams.MinGasPrice = sdk.ZeroDec()
 		if err := app.FeeMarketKeeper.SetParams(sdkCtx, feemarketParams); err != nil {
 			return fromVM, err
 		}

--- a/warden/x/act/client/actions.go
+++ b/warden/x/act/client/actions.go
@@ -147,7 +147,7 @@ func addFlagsFromMsg(msg sdk.Msg, cmd *cobra.Command) {
 				cmd.Flags().BytesBase64(flagName, nil, "")
 			case reflect.Struct:
 				if v.Field(i).Type().Elem().AssignableTo(reflect.TypeOf(sdk.Coin{})) {
-					cmd.Flags().StringSlice(flagName, nil, "(e.g. 10uward)")
+					cmd.Flags().StringSlice(flagName, nil, "(e.g. 10award)")
 				} else {
 					panic(fmt.Sprintf("unsupported slice type %v (for field %s)", v.Field(i).Type().Elem().Kind(), fieldName))
 				}


### PR DESCRIPTION
This PR addresses issue #1635 by migrating the  module's  and the  module's  to use the new  denomination in the  upgrade handler. It also updates a CLI help string that still referenced .