### PR TITLE
docs(ward): add MiCAR white paper

### DIFF
--- a/docs/developer-docs/docs/ward/micar-whitepaper.md
+++ b/docs/developer-docs/docs/ward/micar-whitepaper.md
@@ -1,0 +1,821 @@
+---
+sidebar_position: 7
+title: MiCAR White Paper
+description: WARD Token MiCAR White Paper, drawn up in accordance with Regulation (EU) 2023/1114.
+---
+
+# MiCAR White Paper
+
+**"WARD TOKEN"**
+
+**Version 1.0 — January 2026**
+
+White Paper in accordance with Regulation (EU) 2023/1114 of 31 May 2023 on markets in crypto-assets (MiCAR).
+
+:::warning Notice
+
+This crypto-asset white paper has not been approved by any competent authority in any Member State of the European Union. The person seeking admission to trading of the crypto-asset is solely responsible for the content of this crypto-asset white paper.
+
+:::
+
+## Table of contents
+
+- Compliance statements
+- Summary
+- Part A – Information about the offeror or the person seeking admission to trading
+- Part B – Information about the issuer, if different from the offeror or person seeking admission to trading
+- Part C – Information about the operator of the trading platform in cases where it draws up the crypto-asset white paper and information about other persons drawing the crypto-asset white paper pursuant to Article 6(1), second subparagraph, of Regulation (EU) 2023/1114
+- Part D – Information about the crypto-asset project
+- Part E – Information about the offer to the public of crypto-assets and their admission to trading
+- Part F – Information about the crypto-assets
+- Part G – Information on the rights and obligations attached to the crypto-assets
+- Part H – Information on the underlying technology
+- Part I – Information on risks
+- Part J – Information on the sustainability indicators in relation to adverse impact on the climate and other environment-related adverse impacts
+
+## Compliance statements
+
+**1. Date of notification**
+
+2026-01-29
+
+**2. Statement in accordance with Article 6(3) of Regulation (EU) 2023/1114**
+
+This crypto-asset white paper has not been approved by any competent authority in any Member State of the European Union. The person seeking admission to trading of the crypto-asset is solely responsible for the content of this crypto-asset white paper.
+
+**3. Compliance statement in accordance with Article 6(6) of Regulation (EU) 2023/1114**
+
+This crypto-asset white paper complies with Title II of Regulation (EU) 2023/1114 and, to the best of the knowledge of the management body, the information presented in the crypto-asset white paper is fair, clear and not misleading and the crypto-asset white paper makes no omission likely to affect its import.
+
+**4. Statement in accordance with Article 6(5), points (a) (b) (c) of Regulation (EU) 2023/1114**
+
+The crypto-asset referred to in this white paper may lose its value in part or in full, may not always be transferable and may not be liquid.
+
+**5. Statement in accordance with Article 6(5), point (d), of Regulation (EU) 2023/1114**
+
+The utility token referred to in this white paper may not be exchangeable against the good or service promised in the crypto-asset white paper, especially in the case of a failure or discontinuation of the crypto-asset project.
+
+**6. Statement in accordance with Article 6(5), points (e) and (f), of Regulation (EU) 2023/1114**
+
+The crypto-asset referred to in this white paper is not covered by the investor compensation schemes under Directive 97/9/EC of the European Parliament and of the Council or the deposit guarantee schemes under Directive 2014/49/EU of the European Parliament and of the Council.
+
+## Summary
+
+**7. Warning**
+
+This summary should be read as an introduction to the crypto-asset white paper.
+
+The prospective holder should base any decision to purchase this crypto-asset on the content of the crypto-asset white paper as a whole and not on the summary alone. The offer to the public of this crypto-asset does not constitute an offer or solicitation to purchase financial instruments and any such offer or solicitation can be made only by means of a prospectus or other offer documents pursuant to the applicable national law.
+
+This crypto-asset white paper does not constitute a prospectus as referred to in Regulation (EU) 2017/1129 of the European Parliament and of the Council or any other offer document pursuant to Union or national law.
+
+**8. Characteristics of the crypto-asset**
+
+The crypto-asset referred to in this white paper is named "WARD Token" (**WARD**). WARD is the native utility token of the Warden Protocol ecosystem, designed to power the infrastructure for the emerging AI Agent economy. Warden Protocol is a decentralized full-stack framework comprising Warden Chain (an EVM-compatible Cosmos SDK blockchain), Warden Studio, the Warden Agent Hub, and the Warden App (**Warden Protocol** or **Warden Network**).
+
+WARD is not pegged to any currency, is not redeemable, and is not intended as a medium of exchange outside the project ecosystem.
+
+WARD functions as the network's utility token and is used for gas, access, governance, staking, and service payments within the ecosystem. In particular, it has the following core functions:
+
+- It is the native gas token for transactions and smart-contract execution on Warden Chain.
+- It is the medium of exchange for accessing premium and gated AI Agents within the Warden Agent Hub and for subscription access to premium features in the Warden App.
+- It is required for developer publishing of Agents (with on-chain identity and wallet) and for Verification-as-a-Service (model verification and proof-of-inference checks via SPEX).
+- It serves as a universal gas-abstraction token across integrated chains and as operator bonds securing network services.
+- It can be staked to secure the network and earn inflationary rewards, and it confers governance voting and delegation rights within the protocol.
+
+Initial total supply: 1,000,000,000 WARD. Token type: native EVM gas token (not an ERC-20). The token features dynamic issuance with approximately 5% annual inflation for validator rewards, balanced by programmatic burns (3% of protocol fees) and manual burns.
+
+**9. Utility token benefits and transferability**
+
+WARD grants access to network services by enabling gas payments on Warden Chain, paid access to AI Agents in the Warden Agent Hub, subscription access to premium Warden App features, and developer publishing of Agents with on-chain identity. Holders may stake WARD to secure the network and earn rewards, delegate to validators, participate in governance through voting and delegation, and use WARD as the universal gas-abstraction token across integrated chains on certain applications.
+
+**10. Key information about the offer to the public or admission to trading**
+
+Admission to trading is sought to enable WARD to be admitted to trading on platforms for crypto-assets in the EU.
+
+The initial total supply is 1,000,000,000 WARD. The circulating supply at listing will represent approximately 25.03% of the total supply (250,320,000 WARD), with a fully diluted valuation of approximately USD 2,270,000. Token Listing Date for EU: June 1st, 2026. Distribution will occur via direct listing on centralized and decentralized exchanges; no public sale, IDO or IEO has been conducted. An airdrop program is available through the Warden App for eligible users based on activity and social engagement, with vested allocations automatically staked and bonus incentives of up to 500% for users who lock rather than immediately withdraw. ProtoWardo Ltd expects the token to be admitted to trading on leading EU-based crypto-asset platforms that operate in full compliance with MiCAR.
+
+## Part A – Information about the offeror or the person seeking admission to trading
+
+**1. Name**
+
+ProtoWardo Ltd
+
+**2. Legal form**
+
+Limited Company (BVI).
+
+**3. Registered address**
+
+Floor 4 Banco Popular Building, Road Town, VG1110 Tortola, Virgin Islands (British).
+
+**4. Head office**
+
+Floor 4 Banco Popular Building, Road Town, VG1110 Tortola, Virgin Islands (British).
+
+**5. Registration date**
+
+2024-06-20.
+
+**6. Legal Entity Identifier**
+
+984500477F9C991NE141.
+
+**7. Another identifier required pursuant to applicable national law**
+
+BVI Company Number: 2151504.
+
+**8. Contact telephone number**
+
+Contact via official channels.
+
+**9. E-mail address**
+
+Contact via https://www.wardenprotocol.org
+
+**10. Response time (days)**
+
+30.
+
+**11. Parent company**
+
+Not applicable.
+
+**12. Members of the management body**
+
+| Full Name      | Business Address                                                  | Function          |
+| -------------- | ----------------------------------------------------------------- | ----------------- |
+| Josh Goodbody  | Floor 4 Banco Popular Building, Road Town, VG1110 Tortola, BVI    | Managing Director |
+| Luis Vaello    | Floor 4 Banco Popular Building, Road Town, VG1110 Tortola, BVI    | Director          |
+
+**13. Business activity**
+
+ProtoWardo Ltd is the issuer for the WARD token, the main utility token of Warden Protocol. Warden Protocol is built and maintained by Warden Labs Ltd, which develops and operates the Warden Protocol — a decentralized infrastructure platform for AI Agents. Core activities include the development and maintenance of Warden Chain (EVM-compatible Cosmos SDK), operation of the Warden App (an AI-powered crypto interface serving over 15 million users for trading, research, and DeFi operations), development of Warden Studio (toolkit for building and deploying AI Agents), operation of the Warden Agent Hub (Agent marketplace), and research into AI verification technologies including Proof of Inference (SPEX). The team consists of approximately 30 members, predominantly technical, with 15 in engineering and product, 3 in marketing, and 2 in operations, distributed across Europe and working remotely.
+
+**14. Parent company business activity**
+
+Not applicable.
+
+**15. Newly established**
+
+True.
+
+**16. Financial condition for the past three years**
+
+Not applicable — newly established entity.
+
+**17. Financial condition since registration**
+
+Founder funding since registration.
+
+## Part B – Information about the issuer, if different from the offeror or person seeking admission to trading
+
+**1. Issuer different from offeror or person seeking admission to trading**
+
+False.
+
+**2. Name** — Not applicable.
+
+**3. Legal form** — Not applicable.
+
+**4. Registered address** — Not applicable.
+
+**5. Head office** — Not applicable.
+
+**6. Registration date** — Not applicable.
+
+**7. Legal Entity Identifier** — Not applicable.
+
+**8. Another identifier required pursuant to applicable national law** — Not applicable.
+
+**9. Parent company** — Not applicable.
+
+**10. Members of the management body** — Not applicable.
+
+**11. Business activity** — Not applicable.
+
+**12. Parent company business activity** — Not applicable.
+
+## Part C – Information about the operator of the trading platform in cases where it draws up the crypto-asset white paper and information about other persons drawing the crypto-asset white paper pursuant to Article 6(1), second subparagraph, of Regulation (EU) 2023/1114
+
+**1. Name** — Not applicable.
+
+**2. Legal form** — Not applicable.
+
+**3. Registered address** — Not applicable.
+
+**4. Head office** — Not applicable.
+
+**5. Registration date** — Not applicable.
+
+**6. Legal Entity Identifier** — Not applicable.
+
+**7. Another identifier required pursuant to applicable national law** — Not applicable.
+
+**8. Parent company** — Not applicable.
+
+**9. Reason for crypto-asset white paper preparation** — Not applicable.
+
+**10. Members of the management body** — Not applicable.
+
+**11. Operator business activity** — Not applicable.
+
+**12. Parent company business activity** — Not applicable.
+
+**13. Other persons drawing up the white paper under Article 6(1) second subparagraph MiCAR** — Not applicable.
+
+**14. Reason for drawing up the white paper under Article 6(1) second subparagraph MiCAR** — Not applicable.
+
+## Part D – Information about the crypto-asset project
+
+**1. Crypto-asset project name**
+
+Warden Protocol
+
+**2. Crypto-assets name**
+
+Warden Token (WARD)
+
+**3. Abbreviation**
+
+WARD
+
+**4. Crypto-asset project description**
+
+Warden Protocol is a decentralized full-stack framework powering the emerging AI Agent economy. The protocol provides infrastructure enabling developers to create and deploy autonomous AI Agents capable of both off-chain reasoning and on-chain execution.
+
+Core components:
+
+- **Warden Chain**: a specialized EVM blockchain (Cosmos SDK with integrated EVM module) providing Agent identity, reputation, spending logic, and Proof of Inference capabilities.
+- **Warden Studio**: developer toolkit for building and publishing Agents, with SDKs, APIs, and testing environments.
+- **Warden Agent Hub**: marketplace for Agent discovery and monetization, where users browse Agents by category (DeFi, Trading, Yield, Research, Social).
+- **Warden App**: consumer-facing application providing an AI-powered crypto interface serving over 15 million users.
+
+Key innovation — **Proof of Inference (SPEX)**: a mechanism that records agentic activity on-chain, enabling verification of AI model outputs and ensuring transparency in Agent execution.
+
+The protocol addresses critical challenges in Web3: UX complexity, Agent discovery and distribution, cross-chain complexity, and trust/transparency in AI operations.
+
+Strategic partnerships: Messari, Uniswap Labs, Langchain, Venice AI, Privy, Hyperlane.
+
+**5. Details of all persons involved in the implementation of the crypto-asset project**
+
+| Full Name        | Business Address                                                | Function         |
+| ---------------- | --------------------------------------------------------------- | ---------------- |
+| Warden Labs Ltd  | Floor 4, Banco Popular Building, Road Town, VG1110 Tortola, BVI | Development team |
+
+**6. Utility token classification**
+
+True.
+
+**7. Key features of goods/services for utility token projects**
+
+WARD functions as the network's utility token and is used for gas payments, premium and gated Agent access, developer publishing, Verification-as-a-Service (SPEX), staking and governance, and as a universal cross-chain gas-abstraction token (for further details see Sections F and G below).
+
+**8. Plans for the token**
+
+The project is structured as a multi-layer infrastructure designed to enable autonomous AI Agents to operate, transact, and coordinate through blockchain-based mechanisms.
+
+The architecture is composed of: a base blockchain layer (Warden Chain) optimized for Agent identity, spending logic, and Proof of Inference; an Agent infrastructure layer (Warden Studio) providing SDKs, APIs, testing environments, and framework integrations (LangChain, ElizaOS); a marketplace layer (Warden Agent Hub) for discovery, reputation, usage tracking, and developer revenue sharing; and a consumer application layer (Warden App) providing AI-powered swaps, yield optimization, portfolio management, research agents, trading terminal access (Hyperliquid), and prediction markets.
+
+Completed milestones (Q4 2024 – Q4 2025) include: protocol development and testnet deployment; team expansion to 30 members; mainnet launch with 40 active validators; Proof of Prompt (Proof of Inference) live at proofs.wardenprotocol.org; Warden App beta launch (May 26, 2025); 15 million+ user sign-ups; 10 million+ on-chain swaps; Tier 1 partnerships with Langchain, Venice AI, Messari, Uniswap Labs, Hyperlane and Privy; revenue generation initiated (USD 313K during beta); 12 AI Agents deployed including the Messari Research Agent and Uniswap Trading Agent; 15,000+ daily active users and 1 million+ monthly active users.
+
+Planned milestones include:
+
+- **Q1 2026**: token listing event (February 3rd, 2026) on major CEXs and DEXs; Agent Publisher tools release; Warden Studio Alpha; iOS App launch; Kaito Bot integration; multilingual versions (Mandarin, Korean); AI Hyperliquid perp trading.
+- **Q2 2026**: Verification Layer (SPEX) live; Android App launch; Big Brain V1 (domain-specific LLM trained on Agent interactions); Polymarket Agent; Pump.Hub.
+- **Q3–Q4 2026**: multi-Agent coordination capabilities; Autopilot Yield Agents; Big Brain V2; long-term memory for Agents; EVM chain expansion; Warden Connect (external integrations).
+
+**9. Resource allocation**
+
+Resource allocation across the project: Engineering and Product — 15 team members (50%); Marketing — 3 (10%); Operations — 2 (7%); Management and Strategy — 10 (33%). Infrastructure costs include cloud computing, AI model inference, blockchain node operations, security audits, and legal compliance.
+
+**10. Planned use of collected funds or crypto-assets**
+
+Long-term development and research programs; infrastructure maintenance; ecosystem partnerships; operational expenses.
+
+## Part E – Information about the offer to the public of crypto-assets and their admission to trading
+
+**1. Public offering or admission to trading**
+
+ATTR (Admission to trading).
+
+**2. Reasons for public offer or admission to trading**
+
+The admission to trading is sought in order to enable WARD to be listed on leading EU-based crypto-asset platforms that operate in full compliance with MiCAR. The objective is to provide market participants with transparent and regulated access to the token, ensure liquidity within a regulated environment, and facilitate broader adoption and utility of the token across the Warden Protocol ecosystem.
+
+**3. Fundraising target** — Not applicable.
+
+**4. Minimum subscription goals** — Not applicable.
+
+**5. Maximum subscription goal** — Not applicable.
+
+**6. Oversubscription acceptance** — False.
+
+**7. Oversubscription allocation** — Not applicable.
+
+**8. Issue price** — Not applicable.
+
+**9. Official currency or any other crypto-assets determining the issue price**
+
+US Dollar.
+
+**10. Subscription fee** — Not applicable.
+
+**11. Offer price determination method** — Not applicable.
+
+**12. Total number of offered/traded crypto-assets**
+
+The initial total supply is 1,000,000,000 WARD. The circulating supply at listing will represent 25.03% of the total supply (250,320,000 WARD). ProtoWardo Ltd expects the token to be admitted to trading on leading EU-based crypto-asset platforms that operate in full compliance with MiCAR.
+
+**13. Targeted holders**
+
+ALL.
+
+**14. Holder restrictions**
+
+No. Token distribution will be carried out to holders in accordance with the laws and regulations applicable in each EU Member State.
+
+**15. Reimbursement notice**
+
+WARD holders do not hold any right of withdrawal, reimbursement or refund.
+
+**16. Refund mechanism** — Not applicable.
+
+**17. Refund timeline** — Not applicable.
+
+**18. Offer phases** — Not applicable.
+
+**19. Early purchase discount** — Not applicable.
+
+**20. Time-limited offer** — False.
+
+**21. Subscription period beginning** — Not applicable.
+
+**22. Subscription period end** — Not applicable.
+
+**23. Safeguarding arrangements for offered funds/crypto-assets** — Not applicable.
+
+**24. Payment methods for crypto-asset purchase**
+
+WARD can be purchased through the following methods:
+
+- Centralized exchanges
+- Decentralized exchanges
+
+**25. Value transfer methods for reimbursement** — Not applicable.
+
+**26. Right of withdrawal** — Not applicable.
+
+**27. Transfer of purchased crypto-assets**
+
+WARD will be transferred to prospective holders' wallets via compatible blockchain networks, including EVM-compatible chains and the native Warden Chain.
+
+**28. Transfer time schedule**
+
+The transfer of WARD to holders will occur as follows:
+
+- Purchase via trading platform: WARD transfers processed upon purchase confirmation through exchanges. Delivery typically takes between 5 minutes and up to 15 minutes, depending on the particular exchange's internal procedures.
+- Acquisition via decentralized platforms: WARD acquired through the Warden Chain or via DEXs is transferred to the user's on-chain wallet immediately after the transaction is finalized.
+
+**29. Purchaser's technical requirements**
+
+To hold and use WARD, users need: a compatible EVM wallet (MetaMask, Privy, etc.) for Warden Chain transactions; a stable internet connection; and a KYC-verified account on supported exchanges for trading. For Warden App usage: a web browser or mobile application; Privy wallet integration (automatic creation during 10-second onboarding). No specialized hardware is required. The Warden App abstracts complexity including gas management across multiple chains.
+
+**30. Crypto-Asset Service Provider (CASP) name** — Not applicable.
+
+**31. CASP identifier**
+
+984500477F9C991NE141.
+
+**32. Placement form**
+
+NTAV (Not applicable).
+
+**33. Trading platforms name**
+
+Not applicable. ProtoWardo Ltd intends for the token to be admitted to trading on leading EU-based crypto-asset platforms that operate in full compliance with MiCAR.
+
+**34. Trading platforms Market Identifier Code (MIC)** — Not applicable.
+
+**35. Trading platforms access**
+
+Prospective WARD holders must create a trading account on the trading platforms where WARD is listed, by completing the specific onboarding procedure requested by each platform.
+
+**36. Involved costs**
+
+There are no costs involved in relation to the access of investors to the trading platforms.
+
+**37. Offer expenses** — Not applicable.
+
+**38. Conflicts of interest**
+
+There are no potential conflicts of interest of the persons involved in the admission to trading, arising in relation to the admission to trading.
+
+**39. Applicable law**
+
+Law of the British Virgin Islands.
+
+**40. Competent court**
+
+Courts of the British Virgin Islands.
+
+## Part F – Information about the crypto-assets
+
+**1. Crypto-asset type**
+
+Crypto-asset other than asset-referenced tokens or e-money tokens (Utility Token) — native blockchain gas token and ecosystem access token.
+
+**2. Crypto-asset functionality**
+
+WARD is a multi-functional utility token used for staking, reward distribution, governance, and as a prerequisite for performing specific Agent and service-related activities within the ecosystem. In particular, it has the following core functions:
+
+- **Gas Token**: native gas token for Warden Chain transactions (EVM-compatible Cosmos SDK blockchain).
+- **Access Token**: required currency for accessing premium AI Agents in the Warden Agent Hub and premium features in the Warden App.
+- **Governance Token**: enables voting and delegation on protocol proposals.
+- **Staking Token**: can be staked to secure the network and earn inflationary rewards (~5% annually).
+- **Payment Token**: used for Agent publishing fees, Verification-as-a-Service (SPEX), and subscription access to premium features.
+- **Operator Bond**: used as collateral by service operators.
+
+**3. Planned application of functionalities**
+
+The functionalities of WARD become effective from mainnet launch, as the token is required for gas payments, Agent Hub access, governance and staking from day one.
+
+Current functionality (live): network gas payments on Warden Chain mainnet; Agent Hub access and payments; governance voting and delegation; staking for network security.
+
+Planned functionality expansion:
+
+- **Q1 2026**: enhanced Agent publishing tools with WARD-based fee structure; cross-chain gas-abstraction improvements.
+- **Q2 2026**: Verification Layer (SPEX) payment integration; Big Brain model access tiers based on WARD holdings; subscription tier system for Warden App premium features.
+- **Q3–Q4 2026**: multi-Agent orchestration payments; Autopilot Agent activation fees; enhanced governance mechanisms.
+
+**4. Type of white paper**
+
+OTHR (Other crypto-asset token white paper).
+
+**5. The type of submission**
+
+NEWT (New).
+
+**6. Crypto-asset characteristics**
+
+WARD is the native utility token of the Warden Network and functions as a gas, access, staking, and coordination asset within an EVM-compatible Cosmos SDK Layer-1 blockchain secured by Tendermint/CometBFT Proof-of-Stake consensus.
+
+Technical characteristics:
+
+| Property                | Value                                                |
+| ----------------------- | ---------------------------------------------------- |
+| Blockchain              | Warden Chain (Cosmos SDK with EVM module)            |
+| Token Standard          | Native chain token (not ERC-20)                      |
+| Total Initial Supply    | 1,000,000,000 WARD                                   |
+| Decimals                | 6                                                    |
+| Hard Cap                | No (inflationary model)                              |
+| Inflation Rate          | ~5% annually for validator rewards                   |
+| Token Contract          | No smart-contract address (native gas token)         |
+| Blockchain Explorer     | https://explorer.wardenprotocol.org                  |
+| Proofs Dashboard        | https://proofs.wardenprotocol.org                    |
+
+Inflation/deflation mechanism: dynamic issuance — the amount generated depends on network staking percentage; the target staking ratio is 65%; programmatic burns of 3% of all protocol fees are automatically executed; additional non-programmatic (manual) burns may be carried out as determined by governance. At high protocol usage, burns can offset or exceed inflation; at low usage, inflation dominates. Long-term supply trajectory depends on network adoption and usage patterns. All supply changes are transparent and verifiable on-chain.
+
+Interoperability: IBC enabled (Cosmos ecosystem); EVM compatible (Ethereum tooling); cross-chain bridging via Hyperlane.
+
+**7. Commercial name or trading name**
+
+WARD / Warden / Warden Protocol.
+
+**8. Website of the issuer**
+
+https://wardenprotocol.org
+
+**9. Starting date of offer to the public or admission to trading**
+
+2026-01-06.
+
+**10. Publication date**
+
+2026-01-06.
+
+**11. Any other services provided by the issuer**
+
+Warden Labs provides the following services:
+
+- **Warden App**: AI-powered crypto interface offering multi-chain token swaps, yield optimization, portfolio management, AI research agents, trading terminal (Hyperliquid integration), and prediction market access. Live product: https://app.wardenprotocol.org. Analytics dashboard: https://dune.com/wardenprotocol/warden-app-dashboard.
+- **Warden Studio**: developer toolkit for Agent creation including SDKs, APIs, testing environments, deployment tools, and framework integrations (LangChain, ElizaOS).
+- **Warden Agent Hub**: marketplace services for Agent discovery, revenue sharing for developers, and usage tracking and reputation systems.
+- **Infrastructure services**: blockchain node operations, validator support, and cross-chain bridging.
+
+**12. Language or languages of the white paper**
+
+English.
+
+**13. Digital token identifier code used to uniquely identify the crypto-asset or each of the several crypto assets to which the white paper relates, where available**
+
+DTI J7D9BF035.
+
+**14. Functionally fungible group digital token identifier, where available** — Not applicable.
+
+**15. Voluntary data flag** — False.
+
+**16. Personal data flag** — False.
+
+**17. LEI eligibility** — True.
+
+**18. Home Member State**
+
+Estonia.
+
+**19. Host Member States**
+
+Austria; Belgium; Bulgaria; Croatia; Cyprus; Czechia; Denmark; Estonia; Finland; France; Germany; Greece; Hungary; Iceland; Ireland; Italy; Latvia; Liechtenstein; Lithuania; Luxembourg; Malta; Netherlands; Norway; Poland; Portugal; Romania; Slovakia; Slovenia; Spain; Sweden.
+
+## Part G – Information on the rights and obligations attached to the crypto-assets
+
+**1. Purchaser rights and obligations**
+
+The rights attached to the token include the right to use WARD for gas payments on Warden Chain, the right to access AI Agents in the Agent Hub proportional to token holdings, the right to stake tokens and receive inflationary rewards (~5% annually), the right to participate in protocol governance through voting and delegation, the right to transfer tokens freely (subject to exchange and jurisdictional restrictions), and the indirect benefit of fee burns reducing total supply. The token does not grant ownership rights, voting rights over any legal entity, nor any redemption or repayment rights.
+
+Token-holder obligations: comply with applicable laws and regulations in the holder's jurisdiction; maintain secure wallet access and private-key management; self-custody (the holder is responsible for security); and report and pay taxes as required by local law.
+
+**2. Exercise of rights and obligation**
+
+The exercise of rights attached to WARD is limited to on-chain functional interactions permitted by the blockchain network:
+
+- **Network usage (gas)**: hold WARD in an EVM-compatible wallet; connect to Warden Chain network; WARD is automatically used for gas fees.
+- **Service access**: access via https://app.wardenprotocol.org; connect wallet through Privy integration; WARD spent for premium Agent interactions.
+- **Staking**: delegate WARD to validators through the Warden Chain interface or stake directly in the Warden App; rewards distributed automatically per block.
+- **Governance**: vote on proposals through on-chain governance; delegate voting power to other addresses; proposals visible on the governance interface.
+- **Transfer**: standard EVM transfer transactions; exchange deposits/withdrawals; cross-chain via integrated bridges.
+
+**3. Conditions for modifications of rights and obligations**
+
+Token rights and obligations may be modified through: (i) protocol governance — proposals submitted to on-chain governance, token-weighted voting determines outcomes, time-locked implementation for approved changes; (ii) smart-contract upgrades — multi-signature approval required, public visibility of pending changes, community notification period; and (iii) unilateral changes by the issuer — emergency security patches may be implemented by the core team, with all changes publicly documented and the community informed through official channels.
+
+Modification limitations: core token properties (total-supply cap mechanism, decimals) cannot be changed arbitrarily; the burn mechanism (3% of fees) is protocol-enforced; the validator reward rate is subject to network parameters. Token holders accept that protocol evolution may result in changes to functionality over time.
+
+**4. Future public offers**
+
+No additional public token sales are planned. Future token distribution will occur through ecosystem incentives, airdrops, and protocol-defined allocation schedules as outlined in the tokenomics.
+
+**5. Issuer retained crypto-assets**
+
+240,000,000 WARD.
+
+**6. Utility token classification**
+
+True.
+
+**7. Key features of goods/services of utility tokens**
+
+Access to Warden Chain network services, the AI Agent Hub marketplace, premium Warden App features, governance participation, and staking rewards. The token serves as the primary medium of exchange within the Warden Protocol ecosystem.
+
+**8. Utility tokens redemption**
+
+WARD does not include any redemption mechanism and cannot be redeemed for fiat currency, goods or other assets directly from the issuer. Tokens can be sold on secondary markets (exchanges) at prevailing market prices. Service-access rights are ongoing as long as the protocol operates.
+
+**9. Non-trading request** — False.
+
+**10. Crypto-assets purchase or sale modalities**
+
+Tokens can be purchased and sold on supported centralized exchanges through standard exchange order books and on decentralized exchanges. No direct purchase from the issuer is available.
+
+**11. Crypto-assets transfer restrictions**
+
+No technical transfer restrictions are implemented on-chain. Vested tokens for team, investors, and certain allocations are subject to smart-contract-enforced vesting schedules. Exchange transfers are subject to exchange KYC/AML policies.
+
+**12. Supply adjustment protocols** — True.
+
+**13. Supply adjustment mechanisms**
+
+Supply adjustment mechanisms are as follows:
+
+- **Inflationary**: dynamic issuance for validator rewards (~5% annually); rate adjusts based on staking ratio (target 65%); formula: (1 − current_staked_ratio / target_staked_ratio) × inflation_rate_of_change.
+- **Deflationary**: programmatic burns of 3% of all protocol fees automatically burned; non-programmatic burns — manual treasury burns as determined by governance.
+
+Net effect: at high protocol usage, burns can offset or exceed inflation; at low usage, inflation dominates. Long-term supply trajectory depends on network adoption and usage patterns. All supply changes are transparent and verifiable on-chain.
+
+**14. Token value protection schemes** — False.
+
+**15. Token value protection schemes description**
+
+No explicit token value-protection schemes exist. Token value is determined by market forces. The burn mechanism reduces supply over time but is not designed as a price-stabilization mechanism.
+
+**16. Compensation schemes** — False.
+
+**17. Compensation schemes description** — Not applicable.
+
+**18. Applicable law**
+
+British Virgin Islands law governs the issuer entity. Protocol operations are decentralized and not subject to any single jurisdiction. Token holders are subject to the laws of their respective jurisdictions.
+
+**19. Competent court**
+
+Courts of the British Virgin Islands for disputes with the issuer. Protocol-level disputes may be subject to on-chain governance mechanisms. Exchange-related disputes are governed by exchange terms.
+
+## Part H – Information on the underlying technology
+
+**1. Distributed Ledger Technology**
+
+Warden Chain is a custom Layer-1 blockchain built using the Cosmos SDK with an integrated EVM module. The network operates as the coordination layer for the AI Agent economy, providing Agent identity management, on-chain reputation, Proof-of-Inference verification, economic coordination, and governance. State channels and gas-abstraction primitives enable users to interact with Ethereum, Solana, Base, and BNB Chain ecosystems via Hyperlane and IBC. The architecture maintains compatibility with EVM tooling and Cosmos IBC, enabling Agents to transact and coordinate natively across ecosystems.
+
+**2. Protocols and technical standards**
+
+The network follows a hybrid Cosmos SDK + EVM-compatible architecture. Technical standards include:
+
+- Cosmos SDK framework (blockchain consensus and application logic)
+- EVM module (Ethereum Virtual Machine compatibility)
+- IBC Protocol (Inter-Blockchain Communication for Cosmos interoperability)
+- ERC standards compatibility (for EVM interactions)
+- XBRL/iXBRL compliance for this white paper
+
+Protocol versions: Cosmos SDK v53; Tendermint/CometBFT consensus; Apache 2.0 open-source license.
+
+Interoperability protocols: IBC for Cosmos ecosystem communication; Hyperlane for cross-chain messaging; EVM compatibility for Ethereum tooling.
+
+**3. Technology used**
+
+Warden Protocol's architecture represents a purposeful departure from traditional general-purpose chain design. Instead of building another general-purpose chain that happens to support AI workflows, every architectural decision optimizes for one goal: enabling autonomous AI Agents to operate with verifiable identity, programmable spending logic, and on-chain proofs of inference.
+
+The architecture stacks purpose-built layers from blockchain to applications:
+
+- **Blockchain Layer (Warden Chain)**: a Cosmos SDK Layer-1 with an integrated EVM module, optimized for Agent identity, spending logic, and Proof-of-Inference. Consensus is Tendermint/CometBFT (Byzantine Fault Tolerant). The Virtual Machine is EVM-compatible for smart-contract execution. Interoperability is provided through the IBC protocol and Hyperlane integration.
+- **Application Layer (Warden App)**: a backend with modular architecture for high concurrency; a frontend web application with mobile support (iOS and Android planned); Privy wallet integration for seamless onboarding; and AI integration with multiple LLM providers and domain-specific models.
+- **Agent Infrastructure Layer**: Warden Studio (SDKs, APIs, testing environments); Warden Agent Hub (marketplace with reputation and usage tracking); Proof of Inference / SPEX (Statistical Proof of Execution for AI verification); and Big Brain (a protocol-enabled domain-specific language model).
+- **Security Infrastructure**: MPC custodial solutions; multi-signature wallets; HSM/Ledger hardware signing; encrypted secret management.
+
+GitHub repository: https://github.com/wardenprotocol/wardenprotocol. Documentation: https://docs.wardenprotocol.org.
+
+**4. Consensus mechanism**
+
+Consensus mechanism: Tendermint/CometBFT (Byzantine Fault Tolerant Consensus).
+
+Characteristics: type — Proof of Stake (PoS); block time ~5–7 seconds; finality — instant (no probabilistic finality); validator set — 40 active validators at mainnet launch.
+
+Validator requirements: stake WARD tokens (minimum stake varies by network conditions); run validator node software; maintain uptime for rewards.
+
+Staking parameters: target staking ratio of 65% of total supply; dynamic inflation 1–10% based on staking ratio; slashing conditions for validator misbehavior.
+
+Validators are selected based on delegated stake weight. Token holders can delegate to validators and share in rewards proportionally.
+
+**5. Incentive mechanisms and applicable fees**
+
+Incentive mechanisms:
+
+- **Validator rewards**: block rewards from dynamic inflation (~5% annually); transaction-fee sharing; rewards distributed proportionally to stake.
+- **Delegator rewards**: share of validator rewards minus commission; automatic compounding available; validators locked in perpetuity (10% of supply).
+- **Agent developer incentives**: 19% of supply allocated to Agent Incentives & Developers; revenue sharing from Agent Hub usage; publishing rewards for popular Agents.
+- **User incentives**: airdrop program for active users (4.7% of supply); staking bonuses (up to 400% for lock-and-stake); Ecosystem & Community allocation (12% of supply).
+
+Applicable fees: gas fees variable based on transaction complexity; Agent usage fees per-interaction pricing set by Agents; protocol fee burn of 3% of fees permanently burned; publishing fees — one-time WARD cost for Agent deployment.
+
+**6. Use of Distributed Ledger Technology** — True.
+
+**7. DLT functionality description**
+
+Warden Chain serves as the coordination layer for the AI Agent economy, providing:
+
+- **Agent identity management**: cryptographic identifiers for each deployed Agent; on-chain registration and discovery; wallet assignment for Agent operations.
+- **Reputation system**: verifiable on-chain record of Agent performance; usage statistics and success rates; publicly auditable by anyone.
+- **Proof of Inference (SPEX)**: records AI Agent actions on-chain; verifies model execution integrity; ensures transparency in AI decision-making; Statistical Proof of Execution for model verification.
+- **Economic coordination**: token transfers and payments; staking and delegation; fee collection and distribution; burn mechanism execution.
+- **Governance**: on-chain proposal submission; token-weighted voting; time-locked parameter changes.
+- **Cross-chain operations**: IBC for Cosmos ecosystem; EVM compatibility for Ethereum tools; Hyperlane integration for external chains.
+
+Live explorer: https://explorer.wardenprotocol.org. Proof dashboard: https://proofs.wardenprotocol.org.
+
+**8. Audit** — True.
+
+**9. Audit outcome**
+
+Security audits completed:
+
+- **Warden Protocol Audit (July–August 2024)** — Auditor: Informal Systems. Scope: main components of Warden Protocol. Duration: 5 person-weeks. Team: 4 security engineers. Result: findings addressed and remediated. Report available in project documentation.
+- **Cosmos SDK v53 Audit** — standard framework audit completed; no Warden-specific issues identified.
+- **Cosmos EVM Module Audit (July 2025)** — Auditor: Sherlock. Scope: EVM integration module. Result: no critical vulnerabilities found.
+
+Ongoing security measures: open-source code (Apache 2.0) enabling community review; continuous integration testing; bug bounty program planned; regular dependency updates.
+
+Audit links: https://drive.google.com/drive/folders/1niDnlDr6HUjoswmzXgJs7akaOEx7fGX
+
+## Part I – Information on risks
+
+**1. Offer-related risks**
+
+The admission to trading of WARD entails risks related to market volatility, liquidity availability and operational execution. Cryptocurrency markets are highly volatile and the token price may fluctuate significantly with no guarantee of maintaining value. Secondary-market liquidity is not guaranteed; large orders may impact price significantly and exchange delistings could reduce trading options. Centralized exchanges are subject to regulatory actions, exchange failures could result in loss of tokens, and trading halts are possible during market stress. Evolving cryptocurrency regulations globally, potential classification changes, and expanding geographic restrictions may all affect trading. Vesting unlock risk is material: 77% of supply is subject to vesting schedules, large unlocks may create selling pressure, and core-contributor unlocks begin 6 months post-listing. Market-maker activities (engagements with GSR and Portofino for liquidity) may affect price dynamics, and competition risk arises from other tokens competing for exchange attention and from new entrants in the AI/Agent space. Investors should only invest amounts they can afford to lose entirely.
+
+**2. Issuer-related risks**
+
+**Key person risk**: the project depends on founding-team expertise; loss of key personnel could impact development. **Operational risk**: the team is remote and distributed across Europe (~30 members, majority technical); coordination challenges in distributed organization. **Financial risk**: startup nature with limited operating history; revenue dependent on protocol adoption; current runway is approximately 18 months without revenue and 36 months with revenue. **Jurisdictional risk**: the issuer is incorporated in the British Virgin Islands and may face regulatory scrutiny in various jurisdictions; the legal framework may evolve unfavorably. **Concentration risk**: token holdings concentrated among team and early contributors (20% to Core Contributors, 24% to Treasury). **Governance risk**: the management body has significant influence over protocol development; transition to full decentralization is ongoing. **Business model risk**: revenue model not yet proven at scale and depends on sustained user growth and Agent adoption.
+
+**3. Crypto-assets-related risks**
+
+**Market risk**: Crypto-assets are notoriously volatile, with prices subject to significant fluctuations due to market sentiment, regulatory news, technological advancements, and macroeconomic factors.
+
+**Liquidity risk**: Crypto-assets may suffer from low liquidity, making it difficult to buy or sell large amounts without affecting the market price, which could lead to significant losses, especially in fast-moving market conditions.
+
+**Custodial risk**: Risks associated with the theft of crypto-assets from exchanges or wallets, loss of private keys, or failure of custodial services, which can result in the irreversible loss of crypto-assets.
+
+**Smart contract risk**: Smart contracts are code running on a blockchain, executing the programmed functions automatically if the defined conditions are fulfilled. Bugs or vulnerabilities in smart-contract code can expose blockchain users to potential hacks and exploits. Any flaw in the code can lead to unintended consequences, such as the loss of crypto-assets or unauthorized access to sensitive data.
+
+**Regulatory and tax risk**: Changes in the regulatory environment for crypto-assets (such as consumer protection, taxation, and anti-money laundering requirements) could affect the use, value, or legality of crypto-assets in a given jurisdiction.
+
+**Counterparty risk**: In cases where crypto-assets are used in contractual agreements or held on exchanges, there is a risk that the counterparty may fail to fulfill their obligations due to insolvency, compliance issues, or fraud, resulting in loss of crypto-assets.
+
+**Reputational risk**: Association with illicit activities, high-profile thefts, or technological failures can damage the reputation of certain crypto-assets, impacting user trust and market value.
+
+**Inflation risk**: WARD is subject to ~5% annual inflation for validator rewards; non-staking holders face dilution. The net effect depends on the burn rate versus issuance.
+
+**Self-custody risk**: Token holders are responsible for private-key security; lost keys mean lost tokens permanently with no recovery mechanism.
+
+**No investor protections**: WARD is not covered by deposit guarantee schemes or investor compensation schemes; there is no insurance on holdings.
+
+**Cross-chain risk**: Bridge vulnerabilities in multi-chain operations and interoperability issues may arise.
+
+**4. Project implementation-related risks**
+
+**Development risk**: roadmap milestones may be delayed; technical challenges may arise; resource constraints possible. **Adoption risk**: user growth may not continue at the current pace; Agent developer adoption is uncertain; network effects may not materialize. **Competition risk**: multiple projects in the AI × Blockchain space — competitors include Magic Newton, GoKite, Infinit, and others; established players may enter the market. **Partnership risk**: partner commitments may change; Messari, Uniswap Labs, and Langchain partnerships are ongoing; integration dependencies. **Scaling risk**: current infrastructure tested to millions of users; unexpected growth may strain systems; performance degradation possible. **AI technology risk**: AI models evolve rapidly; Big Brain development may face challenges; SPEX verification technology is novel and unproven at scale. **Token utility delivery risk**: promised features may not materialize; utility-token status depends on delivering services; regulatory classification may change.
+
+As the network relies on validator and developer participation, there is operational risk of underperformance or service disruption. To mitigate malicious use or misaligned incentives, the protocol applies a staking-and-slashing mechanism that economically penalizes misconduct.
+
+**5. Technology-related risks**
+
+**Private key management risk and loss of access to crypto-assets**: The security of crypto-assets heavily relies on the management of private keys, which are used to access and control the crypto-assets (e.g. initiate transactions). Poor management practices, loss, or theft of private keys, or respective credentials, can lead to irreversible loss of access to crypto-assets.
+
+**Settlement and transaction finality**: While Tendermint/CometBFT provides instant finality under normal conditions, there remains a theoretical risk that a transaction could be reversed or concurring versions of the ledger could persist due to exceptional circumstances such as forks or consensus errors. Under normal circumstances, once a transaction is confirmed, it cannot be reversed or cancelled. Crypto-assets sent to a wrong address cannot be retrieved, resulting in the loss of the sent crypto-assets.
+
+**Scaling limitations and transaction fees**: As the number of users and transactions grows, the network may face scaling challenges. This could lead to increased transaction fees and slower transaction processing times, affecting usability and costs.
+
+**Economic self-sufficiency and operational parameters**: The network might not reach the critical mass in transaction volume necessary to sustain self-sufficiency and remain economically viable to incentivize block production. In failing to achieve such an inflection point, the network might lose its relevance, become insecure, or result in changes to the protocol's operational parameters, such as the monetary policy, fee structure and consensus rewards, governance model, or technical specifications such as block size or intervals.
+
+**Network attacks and cyber-security risks**: The network can be vulnerable to a variety of cyber-attacks, including 51% (majority-stake) attacks, Sybil attacks, or DDoS attacks. These can disrupt the network's operations and compromise data integrity, affecting its security and reliability.
+
+**Consensus failures or forks**: Faults in the consensus mechanism can lead to forks, where multiple versions of the ledger coexist, or network halts, potentially destabilizing the network and reducing trust among participants.
+
+**Bugs in the blockchain's core code**: Even with thorough testing, there is always a risk that unknown bugs may exist in the protocol, which could be exploited to disrupt network operations or manipulate account balances. Continuous code review, audit trails, and a bug-bounty program are essential to identify and rectify such vulnerabilities promptly.
+
+**Smart contract security risk**: Bugs or vulnerabilities in smart-contract code can expose blockchain networks to potential hacks and exploits. Despite audits by Informal Systems and Sherlock, unknown bugs may exist, and any flaw in the code can lead to unintended consequences such as loss of crypto-assets or unauthorized access to sensitive data.
+
+**Dependency on underlying technology**: The technology relies on underlying infrastructures, such as specific hardware or network connectivity, which may themselves be vulnerable to attacks, outages, or other interferences. The protocol also depends on third-party libraries and upstream open-source dependencies.
+
+**Risk of technological disruption**: Technological advancements or the emergence of new technology could impact the system, or components used in it, by making them insecure or obsolete (e.g. quantum computing breaking encryption paradigms). This could lead to theft or loss of crypto-assets or compromise data integrity on the network.
+
+**Governance risk**: Faulty governance models can lead to ineffective decision-making, slow responses to issues, and potential network forks, undermining stability and integrity. There is also a risk of disproportionate influence by a group of stakeholders, leading to centralized power and decisions that may not align with the broader public's interests.
+
+**Anonymity and privacy risk**: The inherent transparency and immutability of blockchain technology can pose risks to user anonymity and privacy. Since all transactions are recorded on a public ledger, there is potential for sensitive data to be exposed. The possibility for the public to link certain transactions to a specific address might expose it to phishing attacks, fraud, or other malicious activities.
+
+**Data corruption**: Corruption of blockchain data, whether through software bugs, human error, or malicious tampering, can undermine the reliability and accuracy of the system.
+
+**Third-party risks**: Crypto-assets rely on third-party services such as exchanges and wallet providers for trading and storage. These platforms can be susceptible to security breaches, operational failures, and regulatory non-compliance, which can lead to the loss or theft of crypto-assets.
+
+**AI/ML risk**: AI models may produce incorrect outputs; hallucination risk in LLM-based Agents; model updates may change behavior.
+
+**Interoperability risk**: IBC and bridge vulnerabilities; cross-chain transaction failures; Hyperlane integration dependencies.
+
+**6. Mitigation measures**
+
+Risk mitigation measures include:
+
+- **Security**: professional security audits by Informal Systems and Sherlock; open-source code enabling community review; multi-signature and MPC custody for critical assets; hardware security modules for signing operations; regular security assessments and updates.
+- **Technical**: proven technology stack (Cosmos SDK, EVM); comprehensive testing and CI/CD pipelines; gradual rollout with beta testing (15M+ users); redundant infrastructure deployment; circuit breakers and rate limiting.
+- **Operational**: experienced team with backgrounds at Binance, Huobi, Uber, and Google; geographic distribution reduces single point of failure; clear incident-response procedures; insurance coverage for key operational risks where available.
+- **Financial**: 18-month runway without revenue; multiple revenue streams diversifying income; treasury reserves for unforeseen circumstances; conservative token-release schedule.
+- **Governance**: time-locked protocol changes; multi-signature requirements for critical operations; community oversight through open-source development; gradual decentralization roadmap.
+- **Compliance**: legal counsel for regulatory monitoring; geographic restrictions where required; adaptation to evolving regulatory frameworks.
+
+Users should conduct their own due diligence and consult financial and legal advisors before acquiring tokens.
+
+## Part J – Information on the sustainability indicators in relation to adverse impact on the climate and other environment-related adverse impacts
+
+**1. Adverse impacts on climate and other environment-related adverse impacts**
+
+Warden Chain uses a Proof-of-Stake (PoS) consensus mechanism (Tendermint/CometBFT), which is significantly more energy-efficient than Proof-of-Work systems. The validator set comprises 40 active validators running standard server infrastructure (no specialized mining equipment) and the estimated energy consumption is significantly lower than PoW chains. Compared to Proof-of-Work, no mining hardware is required, there is no competitive energy-consumption race, and validator hardware requirements are modest. The project acknowledges the environmental considerations of blockchain technology and has chosen PoS specifically to minimize environmental footprint. Detailed quantitative environmental metrics are not yet fully available as the mainnet launched in late 2025; the project commits to providing updated sustainability data as operational data is collected.
+
+### Mandatory information on principal adverse impacts on the climate and other environment-related adverse impacts of the consensus mechanism
+
+#### General information
+
+| Field                                                  | Value                                  |
+| ------------------------------------------------------ | -------------------------------------- |
+| **Name** (as reported in field A.1)                    | ProtoWardo Ltd                         |
+| **Relevant legal entity identifier** (field A.6)       | 984500477F9C991NE141                   |
+| **Name of the crypto-asset** (field D.2)               | WARD                                   |
+| **Beginning of the period to which the disclosure relates** | 2025-01-01                        |
+| **End of the period to which the disclosure relates**  | 2025-12-31                             |
+
+**Consensus mechanism**
+
+Warden Chain operates as a Cosmos SDK Layer-1 with an integrated EVM module, secured by Tendermint/CometBFT Proof-of-Stake consensus. Validators are required to stake WARD and participate in consensus to secure the network. Slashing applies in case of validator misbehavior or failure to meet network performance requirements, ensuring economic accountability and alignment with protocol objectives. The validator set comprises 40 active validators at mainnet launch, with a target staking ratio of 65% of total supply.
+
+**Incentive mechanisms and applicable fees**
+
+The network applies a Proof-of-Stake incentive model. Validators and delegators receive block rewards from dynamic inflation (~5% annually) distributed proportionally to stake, plus a share of transaction fees. 3% of all protocol fees are programmatically burned. Gas fees are paid in WARD and vary based on transaction complexity. Agent developers and users receive incentives via the Agent Incentives allocation (19% of supply), the Ecosystem & Community allocation (12% of supply), the airdrop program (4.7% of supply) and lock-and-stake bonuses (up to 400%).
+
+#### Mandatory key indicator on energy consumption
+
+**Energy consumption** — total amount of energy used for the validation of transactions and the maintenance of the integrity of the distributed ledger of transactions, expressed per calendar year.
+
+The Proof-of-Stake model minimizes energy use. While quantitative energy data is not yet available, the total amount of energy does not exceed 500,000 kilowatt-hours.
+
+#### Sources and methodologies
+
+**Energy consumption sources and methodologies** — sources and methodologies used in relation to the information reported in the energy consumption field.
+
+Energy consumption is measured at each validator node and a transaction-based methodology is used to determine energy consumption.


### PR DESCRIPTION
## Summary
- Add the WARD Token MiCAR white paper to the developer docs under the `$WARD` section
- Lives at `docs/developer-docs/docs/ward/micar-whitepaper.md`; appears in the autogenerated `ward` sidebar at position 7 (after Supply)
- Source: WARD MiCAR White Paper v1.0 (January 2026). The "not approved by any competent authority" notice is rendered as a Docusaurus `:::warning` admonition; numbered MiCAR fields are preserved as bold labels and tables for readability


## Notes for reviewers
- Source document lists `Decimals: 6` for WARD; existing [`introduction.md`](docs/developer-docs/docs/ward/introduction.md) lists `Decimals: 18`. Preserved the source's value here verbatim — flagging the discrepancy for someone to reconcile in a follow-up if needed.
